### PR TITLE
feat(db): add incremental db update with dry-run, prune and stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v0.4.0 – Incremental database updates
+
+### Added
+
+- New `db update` command with fully incremental update logic.
+- Hash-based comparison (`arcgis_hash`) to detect changed planets.
+- Soft-delete support via `deleted` column on `planets`.
+- Optional `--prune` flag to permanently remove deleted planets.
+- `--dry-run` mode to preview changes without writing to disk.
+- `--stats` flag to display update statistics and top changed FIDs.
+- Extended `db status` with ArcGIS layer metadata and edit timestamps.
+- Automatic FTS5 rebuild after updates (when enabled).
+
+### Improved
+
+- More robust handling of invalid ArcGIS rows.
+- Clearer CLI output with colored messages and counters.
+- Consistent metadata tracking for update mode and pruning.
+
+### Internal
+
+- Schema version bump.
+- Incremental update logic isolated and transaction-safe.
+- Shared normalization and hash computation reused across init/update.
+
+---
+
 ## [0.3.0] – 2026-01-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +218,35 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "directories"
@@ -326,6 +364,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +432,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1113,6 +1167,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,19 +1238,21 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sw_galaxy_map"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "atty",
  "chrono",
  "clap",
  "directories",
+ "hex",
  "owo-colors",
  "regex",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "unicode-normalization",
 ]
 
@@ -1360,6 +1427,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1482,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]
@@ -47,6 +47,8 @@ directories = "6.0.0"
 chrono = "0.4.43"
 atty = "0.2.14"
 owo-colors = "4.2.3"
+sha2 = "0.10.9"
+hex = "0.4.3"
 
 [profile.release]
 lto = true

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -71,4 +71,19 @@ pub enum DbCommands {
 
     /// Show local database status (path, meta, counts)
     Status,
+    Update {
+        /// Permanently remove planets marked as deleted
+        #[arg(long)]
+        prune: bool,
+
+        /// Perform a dry run without modifying the database
+        #[arg(long)]
+        dry_run: bool,
+
+        #[arg(long)]
+        stats: bool,
+
+        #[arg(long, default_value_t = 10)]
+        stats_limit: usize,
+    },
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -130,7 +130,7 @@ fn search_planets_like(
             SELECT p.FID, p.Planet
             FROM planet_search s
             JOIN planets p ON p.FID = s.planet_fid
-            WHERE s.search_norm LIKE ?1
+            WHERE p.deleted = 0 AND s.search_norm LIKE ?1
             ORDER BY p.Planet COLLATE NOCASE
             LIMIT ?2
             "#,
@@ -163,7 +163,7 @@ fn search_planets_fts(
             SELECT p.FID, p.Planet
             FROM planets_fts f
             JOIN planets p ON p.FID = f.planet_fid
-            WHERE planets_fts MATCH ?1
+            WHERE p.deleted = 0 AND planets_fts MATCH ?1
             ORDER BY bm25(planets_fts)
             LIMIT ?2
             "#,

--- a/src/provision/arcgis.rs
+++ b/src/provision/arcgis.rs
@@ -7,11 +7,31 @@ const LAYER_URL: &str =
 
 #[derive(Debug, Deserialize)]
 pub struct LayerInfo {
-    #[serde(rename = "serviceItemId", default)]
+    #[serde(rename = "serviceItemId")]
     pub service_item_id: String,
 
-    #[serde(rename = "maxRecordCount", default)]
+    #[serde(rename = "maxRecordCount")]
     pub max_record_count: i64,
+
+    // Optional fields (safe if missing)
+    #[serde(rename = "currentVersion")]
+    pub current_version: Option<f64>,
+
+    #[serde(rename = "editingInfo")]
+    pub editing_info: Option<EditingInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EditingInfo {
+    #[serde(rename = "lastEditDate")]
+    pub last_edit_date: Option<i64>,
+
+    // Optional: keep for future use
+    #[serde(rename = "schemaLastEditDate")]
+    pub schema_last_edit_date: Option<i64>,
+
+    #[serde(rename = "dataLastEditDate")]
+    pub data_last_edit_date: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/provision/db_update.rs
+++ b/src/provision/db_update.rs
@@ -1,0 +1,620 @@
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use serde_json::Value;
+use std::collections::HashSet;
+
+use crate::normalize::normalize_text;
+use crate::provision::arcgis;
+use crate::provision::build_sqlite::{
+    meta_upsert_public, rebuild_planet_search_public, rebuild_planets_fts_if_enabled,
+};
+use crate::ui;
+
+// ----------------------------
+// Stats collection (optional)
+// ----------------------------
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChangeKind {
+    Inserted,
+    Updated,
+    Revived,
+    MarkedDeleted,
+}
+
+#[derive(Debug, Clone)]
+struct ChangeEvent {
+    fid: i64,
+    kind: ChangeKind,
+    planet: Option<String>,
+}
+
+fn compute_arcgis_hash(a: &Value) -> String {
+    // Must match the one used in build_sqlite.rs (keep in sync)
+    let keys = [
+        "FID",
+        "Planet",
+        "Region",
+        "Sector",
+        "System",
+        "Grid",
+        "X",
+        "Y",
+        "Canon",
+        "Legends",
+        "zm",
+        "name0",
+        "name1",
+        "name2",
+        "lat",
+        "long",
+        "ref",
+        "status",
+        "CRegion",
+        "CRegion_li",
+    ];
+
+    let mut s = String::new();
+    for k in keys {
+        s.push_str(k);
+        s.push('=');
+
+        match a.get(k) {
+            None | Some(Value::Null) => {}
+            Some(Value::String(v)) => s.push_str(v.trim()),
+            Some(Value::Number(n)) => s.push_str(&n.to_string()),
+            Some(Value::Bool(b)) => s.push_str(if *b { "1" } else { "0" }),
+            Some(other) => s.push_str(&other.to_string()),
+        }
+
+        s.push('\n');
+    }
+
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    hex::encode(h.finalize())
+}
+
+fn get_i(a: &Value, k: &str) -> Option<i64> {
+    a.get(k).and_then(|v| v.as_i64())
+}
+fn get_f(a: &Value, k: &str) -> Option<f64> {
+    a.get(k).and_then(|v| v.as_f64())
+}
+fn get_s(a: &Value, k: &str) -> Option<String> {
+    a.get(k)
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+}
+
+fn upsert_planet(tx: &Transaction<'_>, a: &Value) -> Result<()> {
+    let fid = get_i(a, "FID").context("Missing FID")?;
+    let planet = get_s(a, "Planet").unwrap_or_default();
+    let x = get_f(a, "X").context("Missing X")?;
+    let y = get_f(a, "Y").context("Missing Y")?;
+
+    if planet.is_empty() {
+        // Skip invalid rows (policy consistent with init)
+        return Ok(());
+    }
+
+    let planet_norm = normalize_text(&planet);
+    let arcgis_hash = compute_arcgis_hash(a);
+
+    // DELETE + INSERT strategy (ensures aliases cascade cleanly)
+    tx.execute("DELETE FROM planets WHERE FID = ?1", params![fid])?;
+
+    tx.execute(
+        r#"
+        INSERT INTO planets(
+            FID, Planet, planet_norm, Region, Sector, System, Grid,
+            X, Y,
+            arcgis_hash, deleted,
+            Canon, Legends, zm,
+            name0, name1, name2,
+            lat, long, ref, status, CRegion, CRegion_li
+        ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7,
+            ?8, ?9,
+            ?10, 0,
+            ?11, ?12, ?13,
+            ?14, ?15, ?16,
+            ?17, ?18, ?19, ?20, ?21, ?22
+        )
+        "#,
+        params![
+            fid,
+            planet,
+            planet_norm,
+            get_s(a, "Region"),
+            get_s(a, "Sector"),
+            get_s(a, "System"),
+            get_s(a, "Grid"),
+            x,
+            y,
+            arcgis_hash,
+            get_i(a, "Canon"),
+            get_i(a, "Legends"),
+            get_i(a, "zm"),
+            get_s(a, "name0"),
+            get_s(a, "name1"),
+            get_s(a, "name2"),
+            get_f(a, "lat"),
+            get_f(a, "long"),
+            get_s(a, "ref"),
+            get_s(a, "status"),
+            get_s(a, "CRegion"),
+            get_s(a, "CRegion_li"),
+        ],
+    )?;
+
+    // Insert aliases from name0/name1/name2
+    let mut stmt_alias = tx.prepare_cached(
+        r#"
+        INSERT OR IGNORE INTO planet_aliases(planet_fid, alias, alias_norm, source)
+        VALUES (?1, ?2, ?3, ?4)
+        "#,
+    )?;
+
+    for (src, key) in [("name0", "name0"), ("name1", "name1"), ("name2", "name2")] {
+        if let Some(val) = a.get(key).and_then(|v| v.as_str()) {
+            let val = val.trim();
+            if !val.is_empty() {
+                stmt_alias.execute(params![fid, val, normalize_text(val), src])?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn db_get_hash_and_deleted(tx: &Transaction<'_>, fid: i64) -> Result<Option<(String, i64)>> {
+    tx.query_row(
+        "SELECT arcgis_hash, deleted FROM planets WHERE FID = ?1",
+        [fid],
+        |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn mark_deleted_missing(tx: &Transaction<'_>, keep_fids: &HashSet<i64>) -> Result<i64> {
+    // Mark planets not in remote feed as deleted=1
+    // For SQLite, best approach: create temp table and join.
+    tx.execute_batch(
+        "DROP TABLE IF EXISTS __keep_fids; CREATE TEMP TABLE __keep_fids(fid INTEGER PRIMARY KEY);",
+    )?;
+
+    {
+        let mut ins = tx.prepare("INSERT OR IGNORE INTO __keep_fids(fid) VALUES (?1)")?;
+        for fid in keep_fids {
+            ins.execute([fid])?;
+        }
+    }
+
+    let changed = tx.execute(
+        r#"
+        UPDATE planets
+        SET deleted = 1
+        WHERE deleted = 0
+          AND FID NOT IN (SELECT fid FROM __keep_fids)
+        "#,
+        [],
+    )? as i64;
+
+    tx.execute_batch("DROP TABLE IF EXISTS __keep_fids;")?;
+    Ok(changed)
+}
+
+fn prune_deleted(tx: &Transaction<'_>) -> Result<i64> {
+    // FK cascades will remove aliases/search automatically (where linked).
+    let n = tx.execute("DELETE FROM planets WHERE deleted = 1", [])? as i64;
+    Ok(n)
+}
+
+pub fn run(
+    con: &mut Connection,
+    prune: bool,
+    dry_run: bool,
+    stats: bool,
+    stats_limit: usize,
+) -> Result<()> {
+    ui::info("Fetching data from remote service...");
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .context("Failed to build HTTP client")?;
+
+    let layer = arcgis::fetch_layer_info(&client).context("Failed to fetch ArcGIS layer info")?;
+
+    let page_size = layer.max_record_count.min(2000);
+    let features = arcgis::fetch_all_features(&client, page_size)
+        .context("Failed to download features from ArcGIS")?;
+
+    ui::info(format!(
+        "Downloaded {} features. Comparing with local database...",
+        features.len()
+    ));
+
+    if dry_run {
+        ui::warning("DRY-RUN mode enabled: no changes will be written");
+        if prune {
+            ui::warning("Prune requested in dry-run: this will be reported as 'would prune'");
+        }
+    }
+
+    // Start transaction: gives consistent view and allows temp tables.
+    // In dry-run we will NOT commit -> changes (if any) won't persist.
+    let tx = con
+        .transaction()
+        .context("Failed to start update transaction")?;
+
+    // Write meta only in real mode
+    if !dry_run {
+        meta_upsert_public(&tx, "source_serviceItemId", &layer.service_item_id)?;
+
+        meta_upsert_public(
+            &tx,
+            "source_maxRecordCount",
+            &layer.max_record_count.to_string(),
+        )?;
+
+        if let Some(v) = layer.current_version {
+            meta_upsert_public(&tx, "source_currentVersion", &v.to_string())?;
+        }
+
+        if let Some(ms) = layer.editing_info.as_ref().and_then(|e| e.last_edit_date) {
+            meta_upsert_public(&tx, "source_lastEditDate", &ms.to_string())?;
+        }
+
+        if let Some(ms) = layer
+            .editing_info
+            .as_ref()
+            .and_then(|e| e.schema_last_edit_date)
+        {
+            meta_upsert_public(&tx, "source_schemaLastEditDate", &ms.to_string())?;
+        }
+
+        if let Some(ms) = layer
+            .editing_info
+            .as_ref()
+            .and_then(|e| e.data_last_edit_date)
+        {
+            meta_upsert_public(&tx, "source_dataLastEditDate", &ms.to_string())?;
+        }
+    }
+
+    let mut events: Vec<ChangeEvent> = Vec::new();
+
+    // Keep set of FIDs present in remote feed
+    let mut keep = HashSet::<i64>::with_capacity(features.len());
+
+    // Counters
+    let mut inserted: i64 = 0;
+    let mut updated: i64 = 0;
+    let mut unchanged: i64 = 0;
+    let mut revived: i64 = 0;
+
+    let mut skipped: i64 = 0;
+    let mut skipped_missing_planet: i64 = 0;
+    let mut skipped_missing_x: i64 = 0;
+    let mut skipped_missing_y: i64 = 0;
+
+    // Helper to capture best-effort planet name
+    let planet_name = |a: &Value| -> Option<String> {
+        a.get("Planet")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    };
+
+    // 1) Per-feature compare (and apply only if !dry_run)
+    for a in &features {
+        let fid = match get_i(a, "FID") {
+            Some(v) => v,
+            None => {
+                skipped += 1;
+                continue;
+            }
+        };
+        keep.insert(fid);
+
+        // Skip invalid rows (Planet empty or X/Y missing) consistent with init
+        let planet_ok = a
+            .get("Planet")
+            .and_then(|v| v.as_str())
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+
+        let x_ok = get_f(a, "X").is_some();
+        let y_ok = get_f(a, "Y").is_some();
+
+        if !planet_ok || !x_ok || !y_ok {
+            skipped += 1;
+
+            if !planet_ok {
+                skipped_missing_planet += 1;
+            }
+            if !x_ok {
+                skipped_missing_x += 1;
+            }
+            if !y_ok {
+                skipped_missing_y += 1;
+            }
+
+            continue;
+        }
+
+        let new_hash = compute_arcgis_hash(a);
+
+        match db_get_hash_and_deleted(&tx, fid)? {
+            None => {
+                inserted += 1;
+                if stats && (events.len() < stats_limit * 50) {
+                    events.push(ChangeEvent {
+                        fid,
+                        kind: ChangeKind::Inserted,
+                        planet: planet_name(a),
+                    });
+                }
+                if !dry_run {
+                    upsert_planet(&tx, a)?;
+                }
+            }
+            Some((old_hash, old_deleted)) => {
+                if old_deleted == 1 {
+                    revived += 1;
+                    if stats && (events.len() < stats_limit * 50) {
+                        events.push(ChangeEvent {
+                            fid,
+                            kind: ChangeKind::Revived,
+                            planet: planet_name(a),
+                        });
+                    }
+                    if !dry_run {
+                        // revive by forcing rewrite
+                        upsert_planet(&tx, a)?;
+                    }
+                } else if old_hash != new_hash {
+                    updated += 1;
+                    if stats && (events.len() < stats_limit * 50) {
+                        events.push(ChangeEvent {
+                            fid,
+                            kind: ChangeKind::Updated,
+                            planet: planet_name(a),
+                        });
+                    }
+                    if !dry_run {
+                        upsert_planet(&tx, a)?;
+                    }
+                } else {
+                    unchanged += 1;
+                }
+            }
+        }
+    }
+
+    // 2) Soft-delete missing (real) OR compute count (dry-run)
+    // If stats enabled, capture a preview of top missing (FID, Planet) before actually updating.
+    let mut deleted_preview: Vec<(i64, String)> = Vec::new();
+    if stats {
+        deleted_preview = select_missing_active_planets(&tx, &keep, stats_limit)
+            .context("Failed to compute missing planets preview for --stats")?;
+    }
+
+    let marked_deleted: i64 = if dry_run {
+        count_missing_active_planets(&tx, &keep)?
+    } else {
+        mark_deleted_missing(&tx, &keep)?
+    };
+
+    if stats {
+        for (fid, planet) in deleted_preview {
+            events.push(ChangeEvent {
+                fid,
+                kind: ChangeKind::MarkedDeleted,
+                planet: Some(planet),
+            });
+        }
+    }
+
+    // 3) Prune (real) OR compute would-prune (dry-run)
+    let pruned: i64 = if prune {
+        if dry_run {
+            // would prune: already deleted + would-be-marked-deleted
+            let already_deleted: i64 = tx
+                .query_row("SELECT COUNT(*) FROM planets WHERE deleted = 1", [], |r| {
+                    r.get(0)
+                })
+                .context("Failed to count already deleted planets")?;
+            already_deleted + marked_deleted
+        } else {
+            ui::warning("Prune enabled: permanently removing deleted planets");
+            prune_deleted(&tx)?
+        }
+    } else {
+        0
+    };
+
+    if !dry_run {
+        // Rebuild derived tables
+        rebuild_planet_search_public(&tx)?;
+        rebuild_planets_fts_if_enabled(&tx)?;
+
+        // Update meta
+        meta_upsert_public(
+            &tx,
+            "last_update_utc",
+            &crate::provision::time::now_utc_iso(),
+        )?;
+        meta_upsert_public(&tx, "update_mode", "incremental")?;
+        meta_upsert_public(&tx, "prune_used", if prune { "1" } else { "0" })?;
+
+        tx.commit().context("Failed to commit db update")?;
+
+        ui::success("Update completed");
+    } else {
+        // No commit: transaction rolls back automatically on drop
+        ui::success("Dry-run completed (no changes written)");
+    }
+
+    ui::info(format!("inserted: {}", inserted));
+    ui::info(format!("updated: {}", updated));
+    ui::info(format!("revived: {}", revived));
+    ui::info(format!("unchanged: {}", unchanged));
+    ui::info(format!("marked deleted: {}", marked_deleted));
+
+    if prune {
+        if dry_run {
+            ui::info(format!("would prune: {}", pruned));
+        } else {
+            ui::info(format!("pruned: {}", pruned));
+        }
+    }
+
+    if skipped > 0 {
+        ui::warning(format!("skipped invalid rows: {}", skipped));
+        ui::info(format!("  missing Planet: {}", skipped_missing_planet));
+        ui::info(format!("  missing X: {}", skipped_missing_x));
+        ui::info(format!("  missing Y: {}", skipped_missing_y));
+    }
+
+    // ----------------------------
+    // Print --stats section
+    // ----------------------------
+    if stats {
+        fn kind_label(k: ChangeKind) -> &'static str {
+            match k {
+                ChangeKind::Inserted => "inserted",
+                ChangeKind::Updated => "updated",
+                ChangeKind::Revived => "revived",
+                ChangeKind::MarkedDeleted => "marked deleted",
+            }
+        }
+
+        println!();
+        ui::info("Stats:");
+
+        // Top N per category (sorted by FID)
+        for k in [
+            ChangeKind::Inserted,
+            ChangeKind::Updated,
+            ChangeKind::Revived,
+            ChangeKind::MarkedDeleted,
+        ] {
+            let mut v: Vec<&ChangeEvent> = events.iter().filter(|e| e.kind == k).collect();
+            v.sort_by_key(|e| e.fid);
+
+            ui::info(format!("  Top {} {}:", stats_limit, kind_label(k)));
+            if v.is_empty() {
+                ui::info("    (none)");
+            } else {
+                for e in v.into_iter().take(stats_limit) {
+                    if let Some(p) = &e.planet {
+                        ui::info(format!("    FID={} | {}", e.fid, p));
+                    } else {
+                        ui::info(format!("    FID={}", e.fid));
+                    }
+                }
+            }
+        }
+
+        // First N changed FIDs overall
+        let mut changed: Vec<&ChangeEvent> = events.iter().collect();
+        changed.sort_by_key(|e| e.fid);
+
+        ui::info(format!("  First {} changed FIDs:", stats_limit));
+        if changed.is_empty() {
+            ui::info("    (none)");
+        } else {
+            for e in changed.into_iter().take(stats_limit) {
+                let planet = e
+                    .planet
+                    .as_ref()
+                    .map(|p| format!(" | {}", p))
+                    .unwrap_or_default();
+                ui::info(format!(
+                    "    FID={} | {}{}",
+                    e.fid,
+                    kind_label(e.kind),
+                    planet
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns top N missing active planets (deleted=0 and not in keep_fids), ordered by FID.
+/// Used for --stats preview (both dry-run and real).
+fn select_missing_active_planets(
+    tx: &Transaction<'_>,
+    keep_fids: &HashSet<i64>,
+    limit: usize,
+) -> Result<Vec<(i64, String)>> {
+    tx.execute_batch(
+        "DROP TABLE IF EXISTS __keep_fids; CREATE TEMP TABLE __keep_fids(fid INTEGER PRIMARY KEY);",
+    )?;
+
+    {
+        let mut ins = tx.prepare("INSERT OR IGNORE INTO __keep_fids(fid) VALUES (?1)")?;
+        for fid in keep_fids {
+            ins.execute([fid])?;
+        }
+    }
+
+    let mut stmt = tx.prepare(
+        r#"
+        SELECT FID, Planet
+        FROM planets
+        WHERE deleted = 0
+          AND FID NOT IN (SELECT fid FROM __keep_fids)
+        ORDER BY FID
+        LIMIT ?1
+        "#,
+    )?;
+
+    let rows = stmt.query_map([limit as i64], |r| {
+        Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+    })?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+
+    tx.execute_batch("DROP TABLE IF EXISTS __keep_fids;")?;
+    Ok(out)
+}
+
+/// Dry-run helper: counts how many active (deleted=0) planets would be marked deleted
+/// given the keep_fids set, WITHOUT performing UPDATEs.
+fn count_missing_active_planets(tx: &Transaction<'_>, keep_fids: &HashSet<i64>) -> Result<i64> {
+    // Use the same temp-table strategy as mark_deleted_missing(), but do a SELECT COUNT(*)
+    tx.execute_batch(
+        "DROP TABLE IF EXISTS __keep_fids; CREATE TEMP TABLE __keep_fids(fid INTEGER PRIMARY KEY);",
+    )?;
+
+    {
+        let mut ins = tx.prepare("INSERT OR IGNORE INTO __keep_fids(fid) VALUES (?1)")?;
+        for fid in keep_fids {
+            ins.execute([fid])?;
+        }
+    }
+
+    let n: i64 = tx.query_row(
+        r#"
+        SELECT COUNT(*)
+        FROM planets
+        WHERE deleted = 0
+          AND FID NOT IN (SELECT fid FROM __keep_fids)
+        "#,
+        [],
+        |r| r.get(0),
+    )?;
+
+    tx.execute_batch("DROP TABLE IF EXISTS __keep_fids;")?;
+    Ok(n)
+}

--- a/src/provision/migrate.rs
+++ b/src/provision/migrate.rs
@@ -1,0 +1,96 @@
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OptionalExtension};
+
+const SCHEMA_VERSION: i64 = 4;
+
+fn column_exists(con: &Connection, table: &str, col: &str) -> Result<bool> {
+    let sql = format!("PRAGMA table_info({})", table);
+    let mut stmt = con.prepare(&sql)?;
+    let mut rows = stmt.query([])?;
+
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?; // PRAGMA table_info: 1 = name
+        if name.eq_ignore_ascii_case(col) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn meta_get_i64(con: &Connection, key: &str) -> Result<Option<i64>> {
+    let s: Option<String> = con
+        .query_row("SELECT value FROM meta WHERE key = ?1", [key], |r| {
+            r.get::<_, String>(0)
+        })
+        .optional()?;
+
+    match s {
+        None => Ok(None),
+        Some(v) => {
+            let n = v.parse::<i64>().with_context(|| {
+                format!(
+                    "Invalid integer value in meta table for key '{}': '{}'",
+                    key, v
+                )
+            })?;
+            Ok(Some(n))
+        }
+    }
+}
+
+fn meta_upsert(con: &Connection, key: &str, value: &str) -> Result<()> {
+    con.execute(
+        r#"
+        INSERT INTO meta(key, value) VALUES (?1, ?2)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        "#,
+        (key, value),
+    )?;
+    Ok(())
+}
+
+/// Run schema migrations up to SCHEMA_VERSION.
+/// Idempotent and safe to call on every startup/open.
+pub fn run(con: &mut Connection) -> Result<()> {
+    // meta table should exist for your DBs; still, keep a nice error if not.
+    con.query_row("SELECT 1 FROM meta LIMIT 1", [], |r| r.get::<_, i32>(0))
+        .context("Database schema is missing required table: meta")?;
+
+    let current = meta_get_i64(con, "schema_version")?.unwrap_or(0);
+
+    if current >= SCHEMA_VERSION {
+        return Ok(());
+    }
+
+    // One transaction for migration
+    let tx = con
+        .transaction()
+        .context("Failed to start migration transaction")?;
+
+    // v0.4.0 additions
+    if !column_exists(&tx, "planets", "deleted")? {
+        tx.execute_batch(
+            r#"
+            ALTER TABLE planets
+            ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0 CHECK (deleted IN (0,1));
+            "#,
+        )
+        .context("Failed to add planets.deleted")?;
+    }
+
+    if !column_exists(&tx, "planets", "arcgis_hash")? {
+        tx.execute_batch(
+            r#"
+            ALTER TABLE planets
+            ADD COLUMN arcgis_hash TEXT NOT NULL DEFAULT '';
+            "#,
+        )
+        .context("Failed to add planets.arcgis_hash")?;
+    }
+
+    meta_upsert(&tx, "schema_version", &SCHEMA_VERSION.to_string())
+        .context("Failed to update meta.schema_version")?;
+
+    tx.commit().context("Failed to commit migration")?;
+    Ok(())
+}

--- a/src/provision/mod.rs
+++ b/src/provision/mod.rs
@@ -1,6 +1,8 @@
 pub mod arcgis;
 pub mod build_sqlite;
-pub mod paths;
-
 pub mod db_init;
 pub mod db_status;
+pub mod db_update;
+pub mod migrate;
+pub mod paths;
+pub mod time;

--- a/src/provision/time.rs
+++ b/src/provision/time.rs
@@ -1,0 +1,3 @@
+pub fn now_utc_iso() -> String {
+    chrono::Utc::now().to_rfc3339()
+}


### PR DESCRIPTION
Introduces the db update command with incremental logic based on ArcGIS hash comparison. Supports dry-run execution, optional pruning of deleted planets, and detailed update statistics.

Includes:
- soft-delete support via deleted flag
- hash-based change detection
- rebuild of search and FTS tables
- extended db status metadata
- stats reporting for updated FIDs

This release establishes a safe and auditable update pipeline.