### PR TITLE
refactor(db): consolidate queries and fix planet info mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.4.1] – 2026-01-16
+
+### Changed
+
+- Refactored the database layer to consolidate all planet-related queries into `db/queries.rs`.
+- Removed duplicated and legacy planet lookup logic from the former `db.rs` (now `db/core.rs`).
+- Switched `Planet` row mapping to column-name based access (`row.get("...")`) for improved robustness.
+- Standardized SQL queries using canonical column aliases shared across direct and alias-based lookups.
+- Reorganized the `db` module structure (`db/mod.rs`, `db/core.rs`, `db/queries.rs`) for better maintainability.
+
+### Added
+
+- Added a derived Star Wars Fandom information URL for planets, exposed via `Planet::info_planet_url()`.
+- Included the Fandom URL in the output of the `info` command.
+
+### Fixed
+
+- Fixed invalid column name errors caused by inconsistent SQL aliases (`ref` vs `reference`).
+- Resolved compilation issues related to mixed `anyhow::Result` / `rusqlite::Result` usage in query closures.
+- Fixed all Clippy warnings, ensuring a clean `cargo clippy -- -D warnings` run.
+
+### Internal
+
+- Improved separation of concerns between DB connection/setup logic and query logic.
+- Reduced the risk of future SQL drift by enforcing a single source of truth for planet queries.
+
+---
+
 ## v0.4.0 – Incremental database updates
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sw_galaxy_map"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
+use crate::db::queries::search_planets;
+use crate::normalize::normalize_text;
 use crate::ui::warning;
-use crate::{db, normalize::normalize_text};
 
 pub fn run(con: &Connection, query: String, limit: i64) -> Result<()> {
     let qn = normalize_text(&query);
-    let rows = db::search_planets(con, &qn, limit)?;
+    let rows = search_planets(con, &qn, limit)?;
 
     if rows.is_empty() {
         warning(format!("No results found for: {query}"));

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -1,0 +1,20 @@
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+
+pub fn open_db(path: &str) -> Result<Connection> {
+    let con = Connection::open(path).with_context(|| format!("Unable to open database: {path}"))?;
+    Ok(con)
+}
+
+pub fn has_table(con: &Connection, table: &str) -> Result<bool> {
+    let n: i64 = con.query_row(
+        r#"
+        SELECT COUNT(*)
+        FROM sqlite_master
+        WHERE type = 'table' AND name = ?1
+        "#,
+        [table],
+        |r| r.get(0),
+    )?;
+    Ok(n > 0)
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,0 +1,4 @@
+pub mod core;
+pub mod queries;
+
+pub use core::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub(crate) mod model;
 pub(crate) mod normalize;
 pub(crate) mod provision;
 pub mod ui;
+pub(crate) mod utils;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
-use rusqlite::Row;
+use rusqlite::{Result as SqlResult, Row};
+
+use crate::utils::wiki::fandom_planet_url;
 
 #[derive(Debug)]
 pub struct Planet {
@@ -42,29 +43,33 @@ pub struct NearHit {
 }
 
 impl Planet {
-    pub fn from_row(r: &Row<'_>) -> Result<Self> {
+    pub fn from_row(r: &Row<'_>) -> SqlResult<Self> {
         Ok(Self {
-            fid: r.get(0)?,
-            planet: r.get(1)?,
-            planet_norm: r.get(2)?,
-            region: r.get(3)?,
-            sector: r.get(4)?,
-            system: r.get(5)?,
-            grid: r.get(6)?,
-            x: r.get(7)?,
-            y: r.get(8)?,
-            canon: r.get(9)?,
-            legends: r.get(10)?,
-            zm: r.get(11)?,
-            name0: r.get(12)?,
-            name1: r.get(13)?,
-            name2: r.get(14)?,
-            lat: r.get(15)?,
-            long: r.get(16)?,
-            reference: r.get(17)?,
-            status: r.get(18)?,
-            c_region: r.get(19)?,
-            c_region_li: r.get(20)?,
+            fid: r.get("fid")?,
+            planet: r.get("planet")?,
+            planet_norm: r.get("planet_norm")?,
+            region: r.get("region")?,
+            sector: r.get("sector")?,
+            system: r.get("system")?,
+            grid: r.get("grid")?,
+            x: r.get("x")?,
+            y: r.get("y")?,
+            canon: r.get("canon")?,
+            legends: r.get("legends")?,
+            zm: r.get("zm")?,
+            name0: r.get("name0")?,
+            name1: r.get("name1")?,
+            name2: r.get("name2")?,
+            lat: r.get("lat")?,
+            long: r.get("long")?,
+            reference: r.get("reference")?,
+            status: r.get("status")?,
+            c_region: r.get("c_region")?,
+            c_region_li: r.get("c_region_li")?,
         })
+    }
+
+    pub fn info_planet_url(&self) -> String {
+        fandom_planet_url(&self.planet)
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod wiki;

--- a/src/utils/wiki.rs
+++ b/src/utils/wiki.rs
@@ -1,0 +1,15 @@
+pub fn fandom_planet_url(name: &str) -> String {
+    let normalized = name
+        .split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(f) => f.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("_");
+
+    format!("https://starwars.fandom.com/wiki/{}", normalized)
+}


### PR DESCRIPTION
- move all planet lookup logic to db/queries.rs
- remove duplicated legacy queries from db/core
- switch Planet row mapping to by-name access
- add derived fandom info URL via model method
- fix SQL aliases (reference) and clippy warnings