### PR TITLE
feat: persist routes with upsert semantics and add route inspection c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.2] – 2026-01-19
+
+### ✨ Routing & Persistence
+
+- Introduced full persistence for computed routes (schema v7–v8)
+- Routes are now **unique per (from, to)** pair and automatically **upserted**
+- Re-running a route with different parameters updates the existing record instead of creating duplicates
+- Added support for storing:
+    - route metadata (options, length, iterations, status)
+    - route polyline (ordered waypoints)
+    - detailed detour decisions with scoring breakdown
+- Computed detour waypoints are deduplicated via fingerprint and stored in the global waypoint catalog
+
+### 🧭 CLI Enhancements
+
+- Refactored `route` command into subcommands:
+    - `route compute <from> <to>`
+    - `route last <from> <to>`
+    - `route show <route_id>`
+- Added inspection commands for persisted routes
+- Improved routing debug output (detours, scoring, geometry)
+
+### 🧪 Tests
+
+- Added integration tests for routing:
+    - direct route without obstacles
+    - single obstacle detour
+    - multiple obstacles
+- Introduced shared collision-free assertion helper for routes
+
+### 🗄️ Database
+
+- Schema upgrades up to **v8**
+- Added `routes`, `route_waypoints`, `route_detours`
+- Enforced uniqueness on `(from_planet_fid, to_planet_fid)`
+- Added `updated_at` to routes for proper cache semantics
+
+### 🧹 Internal
+
+- Routing code refactored and modularized
+- Clippy clean (`-D warnings`)
+- Improved separation between routing logic, persistence, and CLI
+
+---
+
 ## [0.5.1] – 2026-01-19
 
 ### 🚀 Routing Engine (in-memory, v1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sw_galaxy_map"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -1246,7 +1246,6 @@ dependencies = [
  "clap",
  "directories",
  "hex",
- "log",
  "owo-colors",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]
@@ -49,7 +49,6 @@ atty = "0.2.14"
 owo-colors = "4.2.3"
 sha2 = "0.10.9"
 hex = "0.4.3"
-log = "0.4.29"
 
 [profile.release]
 lto = true

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -68,8 +68,11 @@ pub enum Commands {
         cmd: WaypointCmd,
     },
 
-    /// Compute a route (in-memory router v1)
-    Route(RouteArgs),
+    /// Routing commands (router v1)
+    Route {
+        #[command(subcommand)]
+        cmd: RouteCmd,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -209,8 +212,29 @@ pub enum WaypointCmd {
     },
 }
 
+#[derive(Subcommand, Debug)]
+pub enum RouteCmd {
+    /// Compute and persist a route between two planets (name or alias)
+    Compute(RouteComputeArgs),
+
+    /// Show a persisted route by id
+    Show {
+        /// Route id
+        route_id: i64,
+    },
+
+    /// Show the current persisted route for a FROM→TO pair (unique in schema v8)
+    Last {
+        /// Start planet name (or alias)
+        from: String,
+
+        /// Destination planet name (or alias)
+        to: String,
+    },
+}
+
 #[derive(Args, Debug)]
-pub struct RouteArgs {
+pub struct RouteComputeArgs {
     /// Start planet name (or alias)
     pub from: String,
 

--- a/src/cli/commands/route.rs
+++ b/src/cli/commands/route.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rusqlite::Connection;
 
 use crate::cli::args::{RouteCmd, RouteComputeArgs};
@@ -7,7 +7,7 @@ use crate::normalize::normalize_text;
 use crate::routing::collision::Obstacle;
 use crate::routing::geometry::Point;
 use crate::routing::route_debug::debug_print_route;
-use crate::routing::router::{compute_route, RouteOptions};
+use crate::routing::router::{RouteOptions, compute_route};
 
 pub fn run(con: &mut Connection, cmd: &RouteCmd) -> Result<()> {
     match cmd {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -56,9 +56,9 @@ pub fn run() -> Result<()> {
             commands::waypoints::run_waypoint(&con, &cmd)
         }
 
-        args::Commands::Route(args) => {
-            let con = open_db_for_commands(cli.db)?;
-            commands::route::run(&con, &args)
+        args::Commands::Route { cmd } => {
+            let mut con = open_db_for_commands(cli.db)?;
+            commands::route::run(&mut con, &cmd)
         }
     }
 }

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -1,8 +1,10 @@
 use crate::db::has_table;
 use crate::model::{AliasRow, NearHit, Planet, Waypoint, WaypointPlanetLink};
+use crate::model::{RouteDetourRow, RouteLoaded, RouteRow, RouteWaypointRow};
+use crate::routing::router::{DetourDecision, Route as ComputedRoute, RouteOptions};
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, Row, params};
-// adatta: crate::models::Planet ecc.
+use sha2::{Digest, Sha256};
 
 const PLANET_SELECT_CANON: &str = r#"
   p.FID         AS fid,
@@ -589,4 +591,456 @@ pub fn list_planets_in_bbox(
         out.push(row?);
     }
     Ok(out)
+}
+
+fn round4(v: f64) -> f64 {
+    (v * 10_000.0).round() / 10_000.0
+}
+
+fn detour_fingerprint(from_fid: i64, to_fid: i64, d: &DetourDecision) -> String {
+    // fingerprint deterministico (con rounding), sufficiente per deduplica dei computed-waypoints
+    let s = format!(
+        "detour|from={}|to={}|ob={}|it={}|seg={}|x={:.4}|y={:.4}",
+        from_fid,
+        to_fid,
+        d.obstacle_id,
+        d.iteration,
+        d.segment_index,
+        round4(d.waypoint.x),
+        round4(d.waypoint.y)
+    );
+
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    hex::encode(h.finalize())
+}
+
+pub fn insert_route(
+    con: &Connection,
+    from_planet_fid: i64,
+    to_planet_fid: i64,
+    algo_version: &str,
+    options_json: &str,
+    length: f64,
+    iterations: usize,
+) -> Result<i64> {
+    con.execute(
+        r#"
+        INSERT INTO routes(from_planet_fid, to_planet_fid, algo_version, options_json, length, iterations, status)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'ok')
+        "#,
+        params![
+            from_planet_fid,
+            to_planet_fid,
+            algo_version,
+            options_json,
+            length,
+            iterations as i64
+        ],
+    )?;
+
+    Ok(con.last_insert_rowid())
+}
+
+pub fn insert_route_waypoint(
+    con: &Connection,
+    route_id: i64,
+    seq: usize,
+    x: f64,
+    y: f64,
+    waypoint_id: Option<i64>,
+) -> Result<()> {
+    con.execute(
+        r#"
+        INSERT INTO route_waypoints(route_id, seq, x, y, waypoint_id)
+        VALUES (?1, ?2, ?3, ?4, ?5)
+        "#,
+        params![route_id, seq as i64, x, y, waypoint_id],
+    )?;
+    Ok(())
+}
+
+pub fn insert_route_detour(
+    con: &Connection,
+    route_id: i64,
+    idx: usize,
+    d: &DetourDecision,
+    waypoint_id: Option<i64>,
+) -> Result<()> {
+    let total = d.score.total();
+
+    con.execute(
+        r#"
+        INSERT INTO route_detours(
+          route_id, idx,
+          iteration, segment_index,
+          obstacle_id, obstacle_x, obstacle_y, obstacle_radius,
+          closest_t, closest_qx, closest_qy, closest_dist,
+          offset_used,
+          wp_x, wp_y, waypoint_id,
+          score_base, score_turn, score_back, score_proximity, score_total
+        ) VALUES (
+          ?1, ?2,
+          ?3, ?4,
+          ?5, ?6, ?7, ?8,
+          ?9, ?10, ?11, ?12,
+          ?13,
+          ?14, ?15, ?16,
+          ?17, ?18, ?19, ?20, ?21
+        )
+        "#,
+        params![
+            route_id,
+            idx as i64,
+            d.iteration as i64,
+            d.segment_index as i64,
+            d.obstacle_id,
+            d.obstacle_center.x,
+            d.obstacle_center.y,
+            d.obstacle_radius,
+            d.closest_t,
+            d.closest_q.x,
+            d.closest_q.y,
+            d.closest_dist,
+            d.offset_used,
+            d.waypoint.x,
+            d.waypoint.y,
+            waypoint_id,
+            d.score.base,
+            d.score.turn,
+            d.score.back,
+            d.score.proximity,
+            total
+        ],
+    )?;
+
+    Ok(())
+}
+
+/// Persist a computed route and its detours.
+/// - Creates a routes row
+/// - Upserts detour waypoints into catalog (waypoints) using fingerprint
+/// - Stores polyline (route_waypoints) and detour details (route_detours)
+pub fn persist_route(
+    con: &mut Connection,
+    from_planet_fid: i64,
+    to_planet_fid: i64,
+    opts: RouteOptions,
+    route: &ComputedRoute,
+) -> Result<i64> {
+    let tx = con
+        .transaction()
+        .context("Failed to start route persistence transaction")?;
+
+    let options_json = serde_json::to_string(&serde_json::json!({
+        "clearance": opts.clearance,
+        "max_iters": opts.max_iters,
+        "max_offset_tries": opts.max_offset_tries,
+        "offset_growth": opts.offset_growth,
+        "turn_weight": opts.turn_weight,
+        "back_weight": opts.back_weight,
+        "proximity_weight": opts.proximity_weight,
+        "proximity_margin": opts.proximity_margin,
+    }))?;
+
+    let route_id = upsert_route_id(
+        &tx,
+        from_planet_fid,
+        to_planet_fid,
+        "router_v1",
+        &options_json,
+        route.length,
+        route.iterations,
+    )?;
+
+    // IMPORTANT: replace existing polyline/detours for this from->to
+    delete_route_children(&tx, route_id)?;
+
+    // 1) Detours: upsert computed waypoint + store detour row.
+    // Build a small lookup (rounded) to attach waypoint_id to the polyline too.
+    use std::collections::HashMap;
+    let mut detour_wp_ids: HashMap<String, i64> = HashMap::new();
+
+    for (idx, d) in route.detours.iter().enumerate() {
+        let fp = detour_fingerprint(from_planet_fid, to_planet_fid, d);
+
+        let wp_name = format!("Detour {}", fp.get(0..8).unwrap_or("detour"));
+        let wp_norm = crate::normalize::normalize_text(&wp_name);
+
+        let (wp_id, _created) = upsert_computed_waypoint(
+            &tx,
+            &wp_name,
+            &wp_norm,
+            d.waypoint.x,
+            d.waypoint.y,
+            "computed",
+            Some("Computed detour waypoint"),
+            &fp,
+        )?;
+
+        // Optional but useful: link computed waypoint to the obstacle planet as "avoid"
+        // (obstacle_id is a planet fid in your current model)
+        // distance = dist between waypoint and obstacle center
+        let dist_to_ob = crate::routing::geometry::dist(d.waypoint, d.obstacle_center);
+        // Ignore errors if already linked (depending on your UNIQUE/PK constraints you may want INSERT OR REPLACE)
+        let _ = link_waypoint_to_planet(&tx, wp_id, d.obstacle_id, "avoid", Some(dist_to_ob));
+
+        insert_route_detour(&tx, route_id, idx, d, Some(wp_id))?;
+
+        let key = format!("{:.4},{:.4}", round4(d.waypoint.x), round4(d.waypoint.y));
+        detour_wp_ids.insert(key, wp_id);
+    }
+
+    // 2) Route polyline
+    for (seq, p) in route.waypoints.iter().enumerate() {
+        let key = format!("{:.4},{:.4}", round4(p.x), round4(p.y));
+        let waypoint_id = detour_wp_ids.get(&key).copied();
+        insert_route_waypoint(&tx, route_id, seq, p.x, p.y, waypoint_id)?;
+    }
+
+    tx.commit()
+        .context("Failed to commit route persistence transaction")?;
+    Ok(route_id)
+}
+
+pub fn upsert_route_id(
+    con: &Connection,
+    from_planet_fid: i64,
+    to_planet_fid: i64,
+    algo_version: &str,
+    options_json: &str,
+    length: f64,
+    iterations: usize,
+) -> Result<i64> {
+    con.execute(
+        r#"
+        INSERT INTO routes(
+          from_planet_fid, to_planet_fid, algo_version, options_json,
+          length, iterations, status, error, created_at, updated_at
+        )
+        VALUES (
+          ?1, ?2, ?3, ?4,
+          ?5, ?6, 'ok', NULL,
+          strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+          strftime('%Y-%m-%dT%H:%M:%fZ','now')
+        )
+        ON CONFLICT(from_planet_fid, to_planet_fid) DO UPDATE SET
+          algo_version = excluded.algo_version,
+          options_json = excluded.options_json,
+          length       = excluded.length,
+          iterations   = excluded.iterations,
+          status       = 'ok',
+          error        = NULL,
+          updated_at   = excluded.updated_at
+        "#,
+        params![
+            from_planet_fid,
+            to_planet_fid,
+            algo_version,
+            options_json,
+            length,
+            iterations as i64
+        ],
+    )?;
+
+    let id: i64 = con.query_row(
+        r#"
+        SELECT id
+        FROM routes
+        WHERE from_planet_fid = ?1 AND to_planet_fid = ?2
+        "#,
+        params![from_planet_fid, to_planet_fid],
+        |r| r.get(0),
+    )?;
+
+    Ok(id)
+}
+
+fn delete_route_children(con: &Connection, route_id: i64) -> Result<()> {
+    con.execute(
+        "DELETE FROM route_waypoints WHERE route_id = ?1",
+        [route_id],
+    )?;
+    con.execute("DELETE FROM route_detours WHERE route_id = ?1", [route_id])?;
+    Ok(())
+}
+
+fn route_from_row(r: &Row<'_>) -> rusqlite::Result<RouteRow> {
+    Ok(RouteRow {
+        id: r.get("id")?,
+        from_planet_fid: r.get("from_planet_fid")?,
+        to_planet_fid: r.get("to_planet_fid")?,
+        algo_version: r.get("algo_version")?,
+        options_json: r.get("options_json")?,
+        length: r.get("length")?,
+        iterations: r.get("iterations")?,
+        status: r.get("status")?,
+        error: r.get("error")?,
+        created_at: r.get("created_at")?,
+        updated_at: r.get("updated_at")?,
+    })
+}
+
+fn route_waypoint_from_row(r: &Row<'_>) -> rusqlite::Result<RouteWaypointRow> {
+    Ok(RouteWaypointRow {
+        seq: r.get("seq")?,
+        x: r.get("x")?,
+        y: r.get("y")?,
+        waypoint_id: r.get("waypoint_id")?,
+    })
+}
+
+fn route_detour_from_row(r: &Row<'_>) -> rusqlite::Result<RouteDetourRow> {
+    Ok(RouteDetourRow {
+        idx: r.get("idx")?,
+        iteration: r.get("iteration")?,
+        segment_index: r.get("segment_index")?,
+
+        obstacle_id: r.get("obstacle_id")?,
+        obstacle_x: r.get("obstacle_x")?,
+        obstacle_y: r.get("obstacle_y")?,
+        obstacle_radius: r.get("obstacle_radius")?,
+
+        closest_t: r.get("closest_t")?,
+        closest_qx: r.get("closest_qx")?,
+        closest_qy: r.get("closest_qy")?,
+        closest_dist: r.get("closest_dist")?,
+
+        offset_used: r.get("offset_used")?,
+
+        wp_x: r.get("wp_x")?,
+        wp_y: r.get("wp_y")?,
+        waypoint_id: r.get("waypoint_id")?,
+
+        score_base: r.get("score_base")?,
+        score_turn: r.get("score_turn")?,
+        score_back: r.get("score_back")?,
+        score_proximity: r.get("score_proximity")?,
+        score_total: r.get("score_total")?,
+    })
+}
+
+pub fn get_route_by_from_to(
+    con: &Connection,
+    from_planet_fid: i64,
+    to_planet_fid: i64,
+) -> Result<Option<RouteRow>> {
+    let mut stmt = con.prepare(
+        r#"
+        SELECT
+          id,
+          from_planet_fid,
+          to_planet_fid,
+          algo_version,
+          options_json,
+          length,
+          iterations,
+          status,
+          error,
+          created_at,
+          updated_at
+        FROM routes
+        WHERE from_planet_fid = ?1 AND to_planet_fid = ?2
+        LIMIT 1
+        "#,
+    )?;
+
+    let row = stmt
+        .query_row(params![from_planet_fid, to_planet_fid], route_from_row)
+        .optional()?;
+
+    Ok(row)
+}
+
+pub fn load_route(con: &Connection, route_id: i64) -> Result<Option<RouteLoaded>> {
+    // 1) Route header
+    let mut stmt_route = con.prepare(
+        r#"
+        SELECT
+          id,
+          from_planet_fid,
+          to_planet_fid,
+          algo_version,
+          options_json,
+          length,
+          iterations,
+          status,
+          error,
+          created_at,
+          updated_at
+        FROM routes
+        WHERE id = ?1
+        LIMIT 1
+        "#,
+    )?;
+
+    let route = stmt_route
+        .query_row([route_id], route_from_row)
+        .optional()?;
+
+    let Some(route) = route else {
+        return Ok(None);
+    };
+
+    // 2) Polyline
+    let mut stmt_wp = con.prepare(
+        r#"
+        SELECT
+          seq,
+          x,
+          y,
+          waypoint_id
+        FROM route_waypoints
+        WHERE route_id = ?1
+        ORDER BY seq ASC
+        "#,
+    )?;
+
+    let mut waypoints: Vec<RouteWaypointRow> = Vec::new();
+    let rows = stmt_wp.query_map([route_id], route_waypoint_from_row)?;
+    for r in rows {
+        waypoints.push(r?);
+    }
+
+    // 3) Detours
+    let mut stmt_det = con.prepare(
+        r#"
+        SELECT
+          idx,
+          iteration,
+          segment_index,
+          obstacle_id,
+          obstacle_x,
+          obstacle_y,
+          obstacle_radius,
+          closest_t,
+          closest_qx,
+          closest_qy,
+          closest_dist,
+          offset_used,
+          wp_x,
+          wp_y,
+          waypoint_id,
+          score_base,
+          score_turn,
+          score_back,
+          score_proximity,
+          score_total
+        FROM route_detours
+        WHERE route_id = ?1
+        ORDER BY idx ASC
+        "#,
+    )?;
+
+    let mut detours: Vec<RouteDetourRow> = Vec::new();
+    let rows = stmt_det.query_map([route_id], route_detour_from_row)?;
+    for r in rows {
+        detours.push(r?);
+    }
+
+    Ok(Some(RouteLoaded {
+        route,
+        waypoints,
+        detours,
+    }))
 }

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -615,33 +615,6 @@ fn detour_fingerprint(from_fid: i64, to_fid: i64, d: &DetourDecision) -> String 
     hex::encode(h.finalize())
 }
 
-pub fn insert_route(
-    con: &Connection,
-    from_planet_fid: i64,
-    to_planet_fid: i64,
-    algo_version: &str,
-    options_json: &str,
-    length: f64,
-    iterations: usize,
-) -> Result<i64> {
-    con.execute(
-        r#"
-        INSERT INTO routes(from_planet_fid, to_planet_fid, algo_version, options_json, length, iterations, status)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'ok')
-        "#,
-        params![
-            from_planet_fid,
-            to_planet_fid,
-            algo_version,
-            options_json,
-            length,
-            iterations as i64
-        ],
-    )?;
-
-    Ok(con.last_insert_rowid())
-}
-
 pub fn insert_route_waypoint(
     con: &Connection,
     route_id: i64,

--- a/src/model.rs
+++ b/src/model.rs
@@ -104,3 +104,63 @@ impl Planet {
         fandom_planet_url(&self.planet)
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct RouteRow {
+    pub id: i64,
+    pub from_planet_fid: i64,
+    pub to_planet_fid: i64,
+    pub algo_version: String,
+    pub options_json: String,
+    pub length: Option<f64>,
+    pub iterations: Option<i64>,
+    pub status: String,
+    pub error: Option<String>,
+    pub created_at: String,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RouteWaypointRow {
+    pub seq: i64,
+    pub x: f64,
+    pub y: f64,
+    pub waypoint_id: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RouteDetourRow {
+    pub idx: i64,
+
+    pub iteration: i64,
+    pub segment_index: i64,
+
+    pub obstacle_id: i64,
+    pub obstacle_x: f64,
+    pub obstacle_y: f64,
+    pub obstacle_radius: f64,
+
+    pub closest_t: f64,
+    pub closest_qx: f64,
+    pub closest_qy: f64,
+    pub closest_dist: f64,
+
+    pub offset_used: f64,
+
+    pub wp_x: f64,
+    pub wp_y: f64,
+    pub waypoint_id: Option<i64>,
+
+    pub score_base: f64,
+    pub score_turn: f64,
+    pub score_back: f64,
+    pub score_proximity: f64,
+    pub score_total: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct RouteLoaded {
+    pub route: RouteRow,
+    pub waypoints: Vec<RouteWaypointRow>,
+    pub detours: Vec<RouteDetourRow>,
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -105,6 +105,7 @@ impl Planet {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct RouteRow {
     pub id: i64,
@@ -128,6 +129,7 @@ pub struct RouteWaypointRow {
     pub waypoint_id: Option<i64>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct RouteDetourRow {
     pub idx: i64,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,19 @@
+use sw_galaxy_map::routing::collision::Obstacle;
+use sw_galaxy_map::routing::collision::first_collision_on_segment;
+use sw_galaxy_map::routing::router::Route;
+
+pub fn assert_collision_free(route: &Route, obstacles: &[Obstacle]) {
+    for seg in route.waypoints.windows(2) {
+        let a = seg[0];
+        let b = seg[1];
+
+        let hit = first_collision_on_segment(a, b, obstacles);
+        assert!(
+            hit.is_none(),
+            "Collision left in route: {:?} on segment A={:?} B={:?}",
+            hit,
+            a,
+            b
+        );
+    }
+}

--- a/tests/routing_direct.rs
+++ b/tests/routing_direct.rs
@@ -1,5 +1,4 @@
 use sw_galaxy_map::routing::geometry::Point;
-use sw_galaxy_map::routing::route_debug::debug_print_route;
 use sw_galaxy_map::routing::router::{RouteOptions, compute_route};
 
 #[test]
@@ -9,7 +8,6 @@ fn direct_route_without_obstacles() {
 
     let route =
         compute_route(start, end, &[], RouteOptions::default()).expect("route computation failed");
-    debug_print_route(&route);
 
     assert_eq!(route.waypoints.len(), 2);
     assert_eq!(route.waypoints[0], start);

--- a/tests/routing_endpoint_collision.rs
+++ b/tests/routing_endpoint_collision.rs
@@ -1,0 +1,42 @@
+mod common;
+
+use crate::common::assert_collision_free;
+use sw_galaxy_map::routing::collision::{Obstacle, first_collision_on_segment};
+use sw_galaxy_map::routing::geometry::Point;
+use sw_galaxy_map::routing::router::{RouteOptions, compute_route};
+
+#[test]
+fn route_allows_destination_endpoint_collision() {
+    let start = Point::new(0.0, 0.0);
+    let end = Point::new(10.0, 0.0);
+
+    // Obstacle exactly at destination. With endpoint-safe logic, this must not prevent routing.
+    let obstacles = vec![Obstacle {
+        id: 99,
+        center: end,
+        radius: 2.0,
+    }];
+
+    let route = compute_route(start, end, &obstacles, RouteOptions::default())
+        .expect("route computation failed");
+
+    // Must succeed and preserve endpoints
+    assert_eq!(route.waypoints.first().copied(), Some(start));
+    assert_eq!(route.waypoints.last().copied(), Some(end));
+
+    assert_collision_free(&route, &obstacles);
+
+    // No "interior" collisions should remain
+    for seg in route.waypoints.windows(2) {
+        let a = seg[0];
+        let b = seg[1];
+        let hit = first_collision_on_segment(a, b, &obstacles);
+        assert!(
+            hit.is_none(),
+            "Unexpected interior collision: {:?} on segment A={:?} B={:?}",
+            hit,
+            a,
+            b
+        );
+    }
+}

--- a/tests/routing_multiple_obstacles.rs
+++ b/tests/routing_multiple_obstacles.rs
@@ -1,6 +1,8 @@
+mod common;
+
+use crate::common::assert_collision_free;
 use sw_galaxy_map::routing::collision::Obstacle;
 use sw_galaxy_map::routing::geometry::Point;
-use sw_galaxy_map::routing::route_debug::debug_print_route;
 use sw_galaxy_map::routing::router::{RouteOptions, compute_route};
 
 #[test]
@@ -28,10 +30,11 @@ fn route_with_multiple_obstacles_is_safe() {
     };
 
     let route = compute_route(start, end, &obstacles, opts).expect("route computation failed");
-    debug_print_route(&route);
 
     assert!(route.waypoints.len() >= 3);
     assert!(route.iterations > 0);
+
+    assert_collision_free(&route, &obstacles);
 
     // Basic monotonicity: start and end preserved
     assert_eq!(route.waypoints.first().copied(), Some(start));

--- a/tests/routing_single_obstacle.rs
+++ b/tests/routing_single_obstacle.rs
@@ -1,6 +1,8 @@
+mod common;
+
+use crate::common::assert_collision_free;
 use sw_galaxy_map::routing::collision::Obstacle;
 use sw_galaxy_map::routing::geometry::Point;
-use sw_galaxy_map::routing::route_debug::debug_print_route;
 use sw_galaxy_map::routing::router::{RouteOptions, compute_route};
 
 #[test]
@@ -20,10 +22,11 @@ fn route_with_single_obstacle_creates_detour() {
     };
 
     let route = compute_route(start, end, &obstacles, opts).expect("route computation failed");
-    debug_print_route(&route);
 
     // start -> W -> end
     assert!(route.waypoints.len() >= 3);
+
+    assert_collision_free(&route, &obstacles);
 
     // sanity: no waypoint equals the obstacle center
     for w in &route.waypoints {


### PR DESCRIPTION
…ommands

- add routes persistence schema (v7–v8) with unique from/to constraint
- implement upsert + replace strategy for routes, waypoints, and detours
- store detailed detour decisions and scoring
- refactor CLI route command into compute/last/show
- add integration tests for routing and collision safety