### PR TITLE
feat(route): add explainable routing, detour telemetry and JSON expor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.6.0] – 2026-01-20
+
+### ✨ New Features
+
+- Introduced **explainable routing** with the new `route explain <id>` command
+- Added **detour telemetry** (`tries_used`, `tries_exhausted`) to make routing decisions provable
+- Implemented **JSON export** for route explanations via `route explain --json`
+- Added support for **file output** with `--file <path>` when exporting JSON
+- Unified and centralized **CLI color policy** across `route show` and `route explain`
+- Enhanced CLI output with **context-aware coloring** (start/end, obstacles, detours, scores)
+- Added explanatory footer notes to clarify routing invariants and units
+
+### 🧠 Improvements
+
+- Refactored routing engine to propagate decision telemetry from runtime to persistence
+- Improved detour scoring diagnostics with dominant penalty identification
+- Hardened route explanation against legacy routes (partial telemetry)
+- Improved robustness of DB loading for extended detour metadata
+
+### 🛠 Internal / Refactoring
+
+- Added shared `cli::color` helpers to avoid duplicated color logic
+- Cleaned up complex CLI output code paths to avoid temporary borrow issues
+- Improved route explanation structure for future machine consumption (JSON schema-ready)
+
+### ⚠️ Backward Compatibility
+
+- Existing routes computed before v0.6.0 remain readable and explainable
+  (telemetry fields may be reported as `n/a`)
+
+---
+
 ## [0.5.3] – 2026-01-19
 
 ### ✨ Routing & Persistence

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sw_galaxy_map"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2024"
 
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -223,6 +223,21 @@ pub enum RouteCmd {
         route_id: i64,
     },
 
+    /// Explain a persisted route detours (why/what/how) by id
+    Explain {
+        /// Route id
+        route_id: i64,
+
+        /// Export explanation as JSON (stdout)
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        json: bool,
+
+        /// Write JSON to file (absolute or relative path). Requires --json.
+        #[arg(long, requires = "json")]
+        file: Option<std::path::PathBuf>,
+
+    },
+
     /// Show the current persisted route for a FROM→TO pair (unique in schema v8)
     Last {
         /// Start planet name (or alias)

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -235,7 +235,6 @@ pub enum RouteCmd {
         /// Write JSON to file (absolute or relative path). Requires --json.
         #[arg(long, requires = "json")]
         file: Option<std::path::PathBuf>,
-
     },
 
     /// Show the current persisted route for a FROM→TO pair (unique in schema v8)

--- a/src/cli/color.rs
+++ b/src/cli/color.rs
@@ -1,0 +1,234 @@
+use owo_colors::OwoColorize;
+
+use crate::ui::Style;
+
+/// Color helper with a single policy shared across commands.
+///
+/// Notes:
+/// - All functions return `String` to avoid borrow-to-temporary issues (E0716).
+/// - Colors are applied only if `style.color == true`.
+pub struct Colors {
+    pub enabled: bool,
+}
+
+impl Colors {
+    pub fn new(style: &Style) -> Self {
+        Self {
+            enabled: style.color,
+        }
+    }
+
+    #[inline]
+    pub fn ok(&self, s: impl AsRef<str>) -> String {
+        let s = s.as_ref();
+        if self.enabled {
+            s.green().to_string()
+        } else {
+            s.to_string()
+        }
+    }
+
+    #[inline]
+    pub fn err(&self, s: impl AsRef<str>) -> String {
+        let s = s.as_ref();
+        if self.enabled {
+            s.red().to_string()
+        } else {
+            s.to_string()
+        }
+    }
+
+    #[inline]
+    pub fn warn(&self, s: impl AsRef<str>) -> String {
+        let s = s.as_ref();
+        if self.enabled {
+            s.yellow().to_string()
+        } else {
+            s.to_string()
+        }
+    }
+
+    #[inline]
+    pub fn info(&self, s: impl AsRef<str>) -> String {
+        let s = s.as_ref();
+        if self.enabled {
+            s.cyan().to_string()
+        } else {
+            s.to_string()
+        }
+    }
+
+    #[inline]
+    pub fn dim(&self, s: impl AsRef<str>) -> String {
+        let s = s.as_ref();
+        if self.enabled {
+            s.bright_black().to_string()
+        } else {
+            s.to_string()
+        }
+    }
+
+    // Domain-specific helpers (policy)
+    #[inline]
+    pub fn from_name(&self, s: impl AsRef<str>) -> String {
+        // from = red
+        self.err(s)
+    }
+
+    #[inline]
+    pub fn to_name(&self, s: impl AsRef<str>) -> String {
+        // to = green
+        self.ok(s)
+    }
+
+    #[inline]
+    pub fn label_start(&self, s: impl AsRef<str>) -> String {
+        // start label = red
+        self.err(s)
+    }
+
+    #[inline]
+    pub fn label_end(&self, s: impl AsRef<str>) -> String {
+        // end label = green
+        self.ok(s)
+    }
+
+    #[inline]
+    pub fn label_detour(&self, s: impl AsRef<str>) -> String {
+        // detour label = yellow
+        self.warn(s)
+    }
+
+    #[inline]
+    pub fn obstacle(&self, s: impl AsRef<str>) -> String {
+        // obstacle = red
+        self.err(s)
+    }
+
+    #[inline]
+    pub fn waypoint(&self, s: impl AsRef<str>) -> String {
+        // inserted waypoint = yellow
+        self.warn(s)
+    }
+
+    #[inline]
+    pub fn violated(&self, s: impl AsRef<str>) -> String {
+        // inserted waypoint = yellow
+        self.err(s)
+    }
+
+    #[inline]
+    pub fn tries(&self, exhausted: bool, s: impl AsRef<str>) -> String {
+        // exhausted tries = red, otherwise green
+        let s = s.as_ref();
+        if !self.enabled {
+            return s.to_string();
+        }
+        if exhausted {
+            s.red().to_string()
+        } else {
+            s.green().to_string()
+        }
+    }
+
+    /// Color a "total score" given a penalty ratio (penalties/base).
+    /// Policy:
+    /// - <= 1%: green
+    /// - <= 5%: yellow
+    /// - else: red
+    pub fn score_total_by_ratio(&self, penalty_ratio: f64, total_txt: impl AsRef<str>) -> String {
+        let s = total_txt.as_ref();
+        if !self.enabled {
+            return s.to_string();
+        }
+
+        if penalty_ratio <= 0.01 {
+            s.green().to_string()
+        } else if penalty_ratio <= 0.05 {
+            s.yellow().to_string()
+        } else {
+            s.red().to_string()
+        }
+    }
+
+    /// Color a scalar magnitude (dominant penalty value).
+    /// Policy:
+    /// - <= 0.05: green
+    /// - <= 1.0: yellow
+    /// - else: red
+    pub fn magnitude(&self, v: f64, txt: impl AsRef<str>) -> String {
+        let s = txt.as_ref();
+        if !self.enabled {
+            return s.to_string();
+        }
+
+        if v <= 0.05 {
+            s.green().to_string()
+        } else if v <= 1.0 {
+            s.yellow().to_string()
+        } else {
+            s.red().to_string()
+        }
+    }
+
+    pub fn driver_line(&self, line: impl AsRef<str>) -> String {
+        let line = line.as_ref();
+        if !self.enabled {
+            return line.to_string();
+        }
+        if line.starts_with("constraint:") || line.starts_with("limit:") {
+            line.red().to_string()
+        } else if line.starts_with("cost:") {
+            line.yellow().to_string()
+        } else {
+            line.to_string()
+        }
+    }
+
+    /// Color a value based on absolute thresholds.
+    /// Policy:
+    /// - value <= good  -> green
+    /// - value >= bad   -> red
+    /// - otherwise      -> yellow
+    #[inline]
+    pub fn by_thresholds(
+        &self,
+        value: f64,
+        good: Option<f64>,
+        bad: Option<f64>,
+        txt: impl AsRef<str>,
+    ) -> String {
+        let s = txt.as_ref();
+        if !self.enabled {
+            return s.to_string();
+        }
+
+        match (good, bad) {
+            (Some(g), Some(b)) => {
+                if value <= g {
+                    s.green().to_string()
+                } else if value >= b {
+                    s.red().to_string()
+                } else {
+                    s.yellow().to_string()
+                }
+            }
+            _ => s.to_string(),
+        }
+    }
+
+    #[inline]
+    pub fn dom_penalty(&self, v: f64, txt: impl AsRef<str>) -> String {
+        let dom_val_plain = format!("{:.3}", v);
+        let dom_val_out: String;
+        if v <= 0.05 {
+            dom_val_out = self.ok(dom_val_plain);
+        } else if v <= 1.0 {
+            dom_val_out = self.warn(dom_val_plain);
+        } else {
+            dom_val_out = self.err(dom_val_plain);
+        }
+
+        format!("{} ({})", self.warn(txt), dom_val_out)
+    }
+}

--- a/src/cli/commands/route.rs
+++ b/src/cli/commands/route.rs
@@ -1,18 +1,35 @@
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
+use owo_colors::OwoColorize;
 use rusqlite::Connection;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
 
 use crate::cli::args::{RouteCmd, RouteComputeArgs};
+use crate::cli::color::Colors;
+use crate::cli::export::{
+    ExplainClosest, ExplainDetour, ExplainDominantPenalty, ExplainEndpoint, ExplainExport,
+    ExplainNote, ExplainObstacle, ExplainRouteMeta, ExplainScore, ExplainWaypoint,
+};
 use crate::db::queries;
+use crate::model::RouteOptionsJson;
 use crate::normalize::normalize_text;
 use crate::routing::collision::Obstacle;
 use crate::routing::geometry::Point;
 use crate::routing::route_debug::debug_print_route;
-use crate::routing::router::{RouteOptions, compute_route};
+use crate::routing::router::{compute_route, RouteOptions};
+
+use crate::ui::Style;
 
 pub fn run(con: &mut Connection, cmd: &RouteCmd) -> Result<()> {
     match cmd {
         RouteCmd::Compute(args) => run_compute(con, args),
         RouteCmd::Show { route_id } => run_show(con, *route_id),
+        RouteCmd::Explain {
+            route_id,
+            json,
+            file,
+        } => run_explain(con, *route_id, *json, file.as_deref()),
         RouteCmd::Last { from, to } => run_last(con, from, to),
     }
 }
@@ -44,20 +61,48 @@ fn run_compute(con: &mut Connection, args: &RouteComputeArgs) -> Result<()> {
     let min_y = start.y.min(end.y) - args.bbox_margin;
     let max_y = start.y.max(end.y) + args.bbox_margin;
 
-    let raw = queries::list_planets_in_bbox(con, min_x, max_x, min_y, max_y, args.max_obstacles)?;
+    // Prefer DB-annotated obstacles (waypoint_planets.role), but fall back to the legacy
+    // behavior if none are configured yet.
+    let mut obstacles: Vec<Obstacle> = Vec::new();
 
-    // 3) Convert to obstacles, excluding endpoints (optional but recommended)
-    let mut obstacles: Vec<Obstacle> = Vec::with_capacity(raw.len());
+    let raw_db = queries::list_routing_obstacles_in_bbox(
+        con,
+        min_x,
+        max_x,
+        min_y,
+        max_y,
+        args.max_obstacles,
+        args.safety,
+    )?;
 
-    for (fid, _name, x, y) in raw {
-        if fid == from_p.fid || fid == to_p.fid {
-            continue;
+    if !raw_db.is_empty() {
+        obstacles.reserve(raw_db.len());
+        for ob in raw_db {
+            if ob.fid == from_p.fid || ob.fid == to_p.fid {
+                continue;
+            }
+            obstacles.push(Obstacle {
+                id: ob.fid,
+                name: ob.planet.clone(),
+                center: Point::new(ob.x, ob.y),
+                radius: ob.radius,
+            });
         }
-        obstacles.push(Obstacle {
-            id: fid,
-            center: Point::new(x, y),
-            radius: args.safety, // safety circle model
-        });
+    } else {
+        let raw =
+            queries::list_planets_in_bbox(con, min_x, max_x, min_y, max_y, args.max_obstacles)?;
+        obstacles.reserve(raw.len());
+        for (fid, name, x, y) in raw {
+            if fid == from_p.fid || fid == to_p.fid {
+                continue;
+            }
+            obstacles.push(Obstacle {
+                id: fid,
+                name: name.clone(),
+                center: Point::new(x, y),
+                radius: args.safety, // safety circle model
+            });
+        }
     }
 
     // 4) Build routing options
@@ -94,16 +139,32 @@ fn run_show(con: &Connection, route_id: i64) -> Result<()> {
     let loaded = queries::load_route(con, route_id)?
         .ok_or_else(|| anyhow::anyhow!("Route not found: id={}", route_id))?;
 
+    let style = Style::default();
+    let c = Colors::new(&style);
+
+    // ---- Header -------------------------------------------------------------
+    let status_txt = loaded.route.status.as_str();
+    let status = if status_txt == "ok" {
+        c.ok(status_txt)
+    } else {
+        c.err(status_txt)
+    };
+
+    let from_name = c.from_name(&loaded.route.from_planet_name);
+    let to_name = c.to_name(&loaded.route.to_planet_name);
+
     println!(
         "Route #{} (FROM {} [{}] TO {} [{}]) status={}",
         loaded.route.id,
-        loaded.route.from_planet_name,
+        from_name,
         loaded.route.from_planet_fid,
-        loaded.route.to_planet_name,
+        to_name,
         loaded.route.to_planet_fid,
-        loaded.route.status
+        status
     );
-    if let Some(len) = loaded.route.length {
+
+    let route_len = loaded.route.length;
+    if let Some(len) = route_len {
         println!("Length: {:.3} parsec", len);
     }
     if let Some(it) = loaded.route.iterations {
@@ -115,48 +176,473 @@ fn run_show(con: &Connection, route_id: i64) -> Result<()> {
         println!("Created: {}", loaded.route.created_at);
     }
 
+    // ---- Waypoints ----------------------------------------------------------
     let last_seq = loaded.waypoints.len().saturating_sub(1);
+
     println!("Waypoints: {}", loaded.waypoints.len());
     for w in &loaded.waypoints {
-        let label = if w.seq as usize == 0 {
-            "Start".to_string()
-        } else if w.seq as usize == last_seq {
-            "End".to_string()
+        let is_start = w.seq as usize == 0;
+        let is_end = w.seq as usize == last_seq;
+
+        let (label, is_detour) = if is_start {
+            ("Start".to_string(), false)
+        } else if is_end {
+            ("End".to_string(), false)
         } else {
-            match (
+            let det = w.waypoint_kind.as_deref() == Some("computed")
+                || w.waypoint_name
+                    .as_deref()
+                    .is_some_and(|n| n.starts_with("Detour"));
+
+            let lbl = match (
                 w.waypoint_id,
                 w.waypoint_name.as_deref(),
                 w.waypoint_kind.as_deref(),
             ) {
-                (Some(_id), Some(name), Some(kind)) => {
-                    format!("{} (kind={})", name, kind)
-                }
-                (Some(id), Some(name), None) => {
-                    format!("{} (id={})", name, id)
-                }
-                (Some(id), None, _) => {
-                    format!("wp_id={}", id)
-                }
+                (Some(_id), Some(name), Some(kind)) => format!("{} (kind={})", name, kind),
+                (Some(id), Some(name), None) => format!("{} (id={})", name, id),
+                (Some(id), None, _) => format!("wp_id={}", id),
                 (None, _, _) => "intermediate".to_string(),
-            }
+            };
+
+            (lbl, det)
         };
 
-        println!("  {:>3}: ({:>10.3}, {:>10.3}) {}", w.seq, w.x, w.y, label);
+        let colored_label = if is_start {
+            c.label_start(label)
+        } else if is_end {
+            c.label_end(label)
+        } else if is_detour {
+            c.label_detour(label)
+        } else {
+            label
+        };
+
+        println!(
+            "  {:>3}: ({:>10.3}, {:>10.3}) {}",
+            w.seq, w.x, w.y, colored_label
+        );
     }
 
+    // ---- Detours ------------------------------------------------------------
+    // Score coloring thresholds (relative to route length, if available)
+    let (good, bad) = match route_len {
+        Some(len) => (Some(len * 1.05), Some(len * 1.15)),
+        None => (None, None),
+    };
+
     println!("Detours: {}", loaded.detours.len());
-    for d in &loaded.detours {
+    for (i, d) in loaded.detours.iter().enumerate() {
+        if style.color {
+            let obstacle_plain = format!("{} [{}]", d.obstacle_name, d.obstacle_id);
+            let obstacle = c.obstacle(obstacle_plain);
+
+            let wp_plain = format!("({:.3},{:.3})", d.wp_x, d.wp_y);
+            let wp = c.waypoint(wp_plain);
+
+            let score_raw = d.score_total;
+            let score_txt = format!("{:.3}", score_raw);
+
+            let score_out = c.by_thresholds(score_raw, good, bad, &score_txt);
+
+            println!(
+                "  det#{:<2} it={} seg={} obstacle={} wp={} score={}",
+                i, d.iteration, d.segment_index, obstacle, wp, score_out
+            );
+        } else {
+            println!(
+                "  det#{:<2} it={} seg={} obstacle={} [{}] wp=({:.3},{:.3}) score={:.3}",
+                i,
+                d.iteration,
+                d.segment_index,
+                d.obstacle_name,
+                d.obstacle_id,
+                d.wp_x,
+                d.wp_y,
+                d.score_total,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn analyze_detour_drivers(
+    d: &crate::model::RouteDetourRow,
+    opts: Option<&RouteOptionsJson>,
+) -> Vec<String> {
+    let mut out = Vec::new();
+
+    // 1) Constraint driver: breach amount (always meaningful)
+    let clearance = opts.map(|o| o.clearance).unwrap_or(0.0);
+    let required = d.obstacle_radius + clearance;
+    let breach = required - d.closest_dist;
+    if breach > 0.0 {
+        out.push(format!(
+            "constraint: safety breach {:.3} (closest {:.3} < required {:.3})",
+            breach, d.closest_dist, required
+        ));
+    } else {
+        out.push(format!(
+            "constraint: no breach at logging time (margin {:.3})",
+            -breach
+        ));
+    }
+
+    // 2) Limit driver: offset tries saturation (heuristic)
+    // We can’t see the number of tries directly, but we *can* infer “offset got large”
+    // relative to required clearance and the configured growth/tries.
+    if let Some(o) = opts {
+        // theoretical max offset scale: required * growth^(tries-1)
+        // base offset in router is usually (radius + clearance), which matches `required`.
+        let tries = o.max_offset_tries.max(1) as i32;
+        let theo_max = required * o.offset_growth.powi((tries - 1).max(0));
+
+        // If we are very close to the theoretical max, we flag “limited by tries/growth”.
+        // Threshold 0.90 is conservative; adjust as you like.
+        if theo_max.is_finite() && theo_max > 0.0 && d.offset_used >= theo_max * 0.90 {
+            out.push(format!(
+                "limit: offset near theoretical max (offset_used {:.3} ≈ max {:.3}); likely limited by max_offset_tries={} and offset_growth={:.3}",
+                d.offset_used, theo_max, o.max_offset_tries, o.offset_growth
+            ));
+        }
+    }
+
+    // 3) Cost driver: dominant penalty component (real signal, you persist these)
+    let mut comps = [
+        ("turn_weight", d.score_turn),
+        ("back_weight", d.score_back),
+        ("proximity_weight", d.score_proximity),
+    ];
+    comps.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    let (name, val) = comps[0];
+
+    // Only claim it if it is actually non-trivial.
+    if val.abs() > 1e-9 {
+        out.push(format!(
+            "cost: dominant penalty component is {} ({:.3})",
+            name, val
+        ));
+    }
+
+    // 4) Another useful signal: “detour is mostly base length” vs “penalty heavy”
+    let penalties = d.score_turn + d.score_back + d.score_proximity;
+    if penalties > d.score_base * 0.25 {
+        out.push(format!(
+            "cost: penalties are significant ({:.3}) vs base ({:.3})",
+            penalties, d.score_base
+        ));
+    } else {
+        out.push(format!(
+            "cost: route length dominates (base {:.3}, penalties {:.3})",
+            d.score_base, penalties
+        ));
+    }
+
+    out
+}
+
+fn run_explain(con: &Connection, route_id: i64, json: bool, file: Option<&Path>) -> Result<()> {
+    let loaded = queries::load_route(con, route_id)?
+        .ok_or_else(|| anyhow::anyhow!("Route not found: id={}", route_id))?;
+
+    // Parse options_json (best-effort: explain still works even if parsing fails)
+    let opts: Option<RouteOptionsJson> = serde_json::from_str(&loaded.route.options_json).ok();
+    let clearance = opts.as_ref().map(|o| o.clearance).unwrap_or(0.0);
+
+    if json {
+        // Build export payload
+        let mut detours_out = Vec::with_capacity(loaded.detours.len());
+
+        for d in &loaded.detours {
+            let required = d.obstacle_radius + clearance;
+            let violated_by = required - d.closest_dist;
+
+            // dominant penalty
+            let mut comps = [
+                ("turn".to_string(), d.score_turn),
+                ("back".to_string(), d.score_back),
+                ("proximity".to_string(), d.score_proximity),
+            ];
+            comps.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            let dom = ExplainDominantPenalty {
+                component: comps[0].0.clone(),
+                value: comps[0].1,
+            };
+
+            // drivers (usa la tua funzione già esistente)
+            let drivers = analyze_detour_drivers(d, opts.as_ref());
+
+            // tries_* (adatta ai tuoi tipi: spesso `tries_exhausted` è i64 0/1)
+            let tries_exhausted = d.tries_exhausted == 1;
+
+            detours_out.push(ExplainDetour {
+                idx: d.idx,
+                iteration: d.iteration as usize,
+                segment_index: d.segment_index as usize,
+
+                obstacle: ExplainObstacle {
+                    id: d.obstacle_id,
+                    name: d.obstacle_name.clone(),
+                    x: d.obstacle_x,
+                    y: d.obstacle_y,
+                    radius: d.obstacle_radius,
+                },
+                closest: ExplainClosest {
+                    t: d.closest_t,
+                    qx: d.closest_qx,
+                    qy: d.closest_qy,
+                    dist: d.closest_dist,
+                    required,
+                    violated_by,
+                },
+
+                offset_used: d.offset_used,
+                waypoint: ExplainWaypoint {
+                    x: d.wp_x,
+                    y: d.wp_y,
+                    computed_waypoint_id: d.waypoint_id,
+                },
+
+                score: ExplainScore {
+                    base: d.score_base,
+                    turn: d.score_turn,
+                    back: d.score_back,
+                    proximity: d.score_proximity,
+                    total: d.score_total,
+                },
+
+                tries_used: d.tries_used, // Option<i64>
+                tries_exhausted,          // bool
+
+                dominant_penalty: dom,
+                decision_drivers: drivers,
+            });
+        }
+
+        let export = ExplainExport {
+                route: ExplainRouteMeta {
+                    id: loaded.route.id,
+                    from: ExplainEndpoint {
+                        fid: loaded.route.from_planet_fid,
+                        name: loaded.route.from_planet_name.clone(),
+                    },
+                    to: ExplainEndpoint {
+                        fid: loaded.route.to_planet_fid,
+                        name: loaded.route.to_planet_name.clone(),
+                    },
+                    status: loaded.route.status.clone(),
+                    length_parsec: loaded.route.length,
+                    iterations: loaded.route.iterations,
+                    created_at: loaded.route.created_at.clone(),
+                    updated_at: loaded.route.updated_at.clone(),
+                },
+                options: opts.clone(),
+                detours: detours_out,
+                note: ExplainNote {
+                    text: "The above detour explanation reflects the state at the time of route computation. Subsequent changes to route parameters or obstacle data will not be reflected here.".to_string(),
+                    units: "parsec".to_string(),
+                },
+            };
+
+        // JSON only, no colors, stdout
+        let s = serde_json::to_string_pretty(&export)?;
+
+        if let Some(path) = file {
+            if let Some(parent) = path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    fs::create_dir_all(parent)?;
+                }
+            }
+
+            let mut f = fs::File::create(path)?;
+            f.write_all(s.as_bytes())?;
+            f.write_all(b"\n")?;
+
+            // stdout remains clean for scripting; optional confirmation on stderr
+            eprintln!("JSON written to {}", path.display());
+        } else {
+            println!("{}", s);
+        }
+
+        return Ok(());
+    }
+
+    let style = Style::default();
+    let c = Colors::new(&style);
+
+    let status_txt = loaded.route.status.as_str();
+    let status = if status_txt == "ok" {
+        c.ok(status_txt)
+    } else {
+        c.err(status_txt)
+    };
+
+    let from_name = c.from_name(&loaded.route.from_planet_name);
+    let to_name = c.to_name(&loaded.route.to_planet_name);
+
+    println!(
+        "Route #{} — {} [{}] → {} [{}] — status={}",
+        loaded.route.id,
+        from_name,
+        loaded.route.from_planet_fid,
+        to_name,
+        loaded.route.to_planet_fid,
+        status
+    );
+
+    if let Some(len) = loaded.route.length {
+        println!("Length: {:.3} parsec", len);
+    }
+    if let Some(it) = loaded.route.iterations {
+        println!("Iterations: {}", it);
+    }
+
+    if let Some(ref o) = opts {
+        println!("Router params:");
+        println!("  clearance={:.3}", o.clearance);
         println!(
-            "  det#{:<3} it={} seg={} obstacle={} [{}] wp=({:.3},{:.3}) score={:.3}",
-            d.idx,
-            d.iteration,
-            d.segment_index,
-            d.obstacle_name,
-            d.obstacle_id,
-            d.wp_x,
-            d.wp_y,
-            d.score_total
+            "  limits: max_iters={}  max_offset_tries={}  offset_growth={:.3}",
+            o.max_iters, o.max_offset_tries, o.offset_growth
         );
+        println!(
+            "  weights: turn={:.3}  back={:.3}  proximity={:.3}  proximity_margin={:.3}",
+            o.turn_weight, o.back_weight, o.proximity_weight, o.proximity_margin
+        );
+    }
+
+    println!();
+    println!("Detours: {}", loaded.detours.len());
+    if loaded.detours.is_empty() {
+        println!("(no detours)");
+        return Ok(());
+    }
+
+    for (i, d) in loaded.detours.iter().enumerate() {
+        println!("  det#{}:", i);
+
+        // context (neutro)
+        println!("    context: it={} seg={}", d.iteration, d.segment_index);
+
+        let exhausted = d.tries_exhausted == 1;
+        // tries line: green if not exhausted, red if exhausted
+        let tries_line = match d.tries_used {
+            Some(tu) => {
+                if exhausted {
+                    format!("tries_used={} (EXHAUSTED max_offset_tries)", tu)
+                } else {
+                    format!("tries_used={} (found before exhaustion)", tu)
+                }
+            }
+            None => "tries_used=n/a (telemetry not available for this route)".to_string(),
+        };
+        println!("    offset search: {}", c.tries(exhausted, tries_line));
+
+        // obstacle: always red in color mode
+        let obstacle_plain = format!(
+            "{} [{}] center=({:.3},{:.3}) radius={:.3}",
+            d.obstacle_name, d.obstacle_id, d.obstacle_x, d.obstacle_y, d.obstacle_radius
+        );
+        println!("    obstacle: {}", c.obstacle(obstacle_plain));
+
+        // why: highlight "violated by" in red when positive
+        let clearance = opts.as_ref().map(|o| o.clearance).unwrap_or(0.0);
+        let required = d.obstacle_radius + clearance;
+        let violated_by = required - d.closest_dist;
+
+        let why_plain = if violated_by > 0.0 {
+            format!(
+                "closest_dist={:.3} < required={:.3} (violated by {:.3})  (Q=({:.3},{:.3}), t={:.3})",
+                d.closest_dist, required, violated_by, d.closest_qx, d.closest_qy, d.closest_t
+            )
+        } else {
+            format!(
+                "closest_dist={:.3} >= required={:.3} (margin {:.3})  (Q=({:.3},{:.3}), t={:.3})",
+                d.closest_dist, required, -violated_by, d.closest_qx, d.closest_qy, d.closest_t
+            )
+        };
+
+        let why_out = if style.color && violated_by > 0.0 {
+            // Color only the "violated by X" part red by rebuilding two segments
+            // (keeps it simple and avoids substring indexing headaches)
+            let head = format!(
+                "closest_dist={:.3} < required={:.3} (",
+                d.closest_dist, required
+            );
+            let viol = format!("violated by {:.3}", violated_by);
+            let tail = format!(
+                ")  (Q=({:.3},{:.3}), t={:.3})",
+                d.closest_qx, d.closest_qy, d.closest_t
+            );
+
+            format!("{}{}{}", head, c.violated(viol), tail)
+        } else if style.color && violated_by <= 0.0 {
+            // margin case: green because it's safe (rare for detours, but possible)
+            why_plain.green().to_string()
+        } else {
+            why_plain
+        };
+        println!("    why: {}", why_out);
+
+        // action: waypoint in yellow, offset in default (or yellow)
+        let wp_plain = format!("({:.3},{:.3})", d.wp_x, d.wp_y);
+        let wp_out = c.waypoint(wp_plain);
+
+        let action_plain = match d.waypoint_id {
+            Some(id) => format!(
+                "waypoint={} offset_used={:.3} (computed_waypoint_id={})",
+                wp_out, d.offset_used, id
+            ),
+            None => format!("waypoint={} offset_used={:.3}", wp_out, d.offset_used),
+        };
+        println!("    action: {}", action_plain);
+
+        // score: color total based on penalty magnitude vs base
+        let penalties = d.score_turn + d.score_back + d.score_proximity;
+        let ratio = if d.score_base.abs() > 1e-12 {
+            penalties / d.score_base
+        } else {
+            0.0
+        };
+
+        let total_out = c.score_total_by_ratio(ratio, format!("{:.3}", d.score_total));
+
+        println!(
+            "    score: base={:.3}  turn={:.3}  back={:.3}  proximity={:.3}  total={}",
+            d.score_base, d.score_turn, d.score_back, d.score_proximity, total_out
+        );
+
+        // dominant penalty: name yellow, value colored by magnitude
+        let mut comps = [
+            ("turn", d.score_turn),
+            ("back", d.score_back),
+            ("proximity", d.score_proximity),
+        ];
+        comps.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        let (dom_name, dom_val) = comps[0];
+
+        println!("    dominant_penalty: {}", c.dom_penalty(dom_val, dom_name));
+
+        // decision drivers: color prefixes
+        println!("    decision_drivers:");
+        for line in analyze_detour_drivers(d, opts.as_ref()) {
+            println!("      - {}", c.driver_line(line));
+        }
+    }
+
+    if !loaded.detours.is_empty() {
+        let sep = "------------------------------------------------------------------------------------------";
+        println!("{}", c.dim(sep));
+
+        let note = c.warn("NOTE:");
+        println!(
+            "{} The above detour explanation reflects the state at the time of route computation.",
+            note
+        );
+        println!(
+            "      Subsequent changes to route parameters or obstacle data will not be reflected here."
+        );
+        println!("      All the distances are explained in parsec units.");
     }
 
     Ok(())

--- a/src/cli/commands/route.rs
+++ b/src/cli/commands/route.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use owo_colors::OwoColorize;
 use rusqlite::Connection;
 use std::fs;
@@ -17,7 +17,7 @@ use crate::normalize::normalize_text;
 use crate::routing::collision::Obstacle;
 use crate::routing::geometry::Point;
 use crate::routing::route_debug::debug_print_route;
-use crate::routing::router::{compute_route, RouteOptions};
+use crate::routing::router::{RouteOptions, compute_route};
 
 use crate::ui::Style;
 
@@ -449,10 +449,10 @@ fn run_explain(con: &Connection, route_id: i64, json: bool, file: Option<&Path>)
         let s = serde_json::to_string_pretty(&export)?;
 
         if let Some(path) = file {
-            if let Some(parent) = path.parent() {
-                if !parent.as_os_str().is_empty() {
-                    fs::create_dir_all(parent)?;
-                }
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                fs::create_dir_all(parent)?;
             }
 
             let mut f = fs::File::create(path)?;

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -1,0 +1,96 @@
+use crate::model::RouteOptionsJson;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct ExplainExport {
+    pub route: ExplainRouteMeta,
+    pub options: Option<RouteOptionsJson>,
+    pub detours: Vec<ExplainDetour>,
+    pub note: ExplainNote,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExplainRouteMeta {
+    pub id: i64,
+    pub from: ExplainEndpoint,
+    pub to: ExplainEndpoint,
+    pub status: String,
+    pub length_parsec: Option<f64>,
+    pub iterations: Option<i64>,
+    pub created_at: String,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExplainEndpoint {
+    pub fid: i64,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExplainDetour {
+    pub idx: i64,
+    pub iteration: usize,
+    pub segment_index: usize,
+
+    pub obstacle: ExplainObstacle,
+    pub closest: ExplainClosest,
+
+    pub offset_used: f64,
+    pub waypoint: ExplainWaypoint,
+
+    pub score: ExplainScore,
+
+    pub tries_used: Option<i64>,
+    pub tries_exhausted: bool,
+
+    pub dominant_penalty: ExplainDominantPenalty,
+    pub decision_drivers: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExplainObstacle {
+    pub id: i64,
+    pub name: String,
+    pub x: f64,
+    pub y: f64,
+    pub radius: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExplainClosest {
+    pub t: f64,
+    pub qx: f64,
+    pub qy: f64,
+    pub dist: f64,
+    pub required: f64,
+    pub violated_by: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExplainWaypoint {
+    pub x: f64,
+    pub y: f64,
+    pub computed_waypoint_id: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExplainScore {
+    pub base: f64,
+    pub turn: f64,
+    pub back: f64,
+    pub proximity: f64,
+    pub total: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExplainDominantPenalty {
+    pub component: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExplainNote {
+    pub text: String,
+    pub units: String,
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,7 @@
 pub mod args;
+pub mod color;
 pub mod commands;
+pub mod export;
 
 use crate::db::db_status::resolve_db_path;
 use crate::ui::warning;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
-use rusqlite::{Result as SqlResult, Row};
-
 use crate::utils::wiki::fandom_planet_url;
+use rusqlite::{Result as SqlResult, Row};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub struct Planet {
@@ -164,6 +164,9 @@ pub struct RouteDetourRow {
     pub score_back: f64,
     pub score_proximity: f64,
     pub score_total: f64,
+
+    pub tries_used: Option<i64>,
+    pub tries_exhausted: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -171,4 +174,29 @@ pub struct RouteLoaded {
     pub route: RouteRow,
     pub waypoints: Vec<RouteWaypointRow>,
     pub detours: Vec<RouteDetourRow>,
+}
+
+/// A lightweight view of an obstacle used by the routing engine.
+///
+/// We use a named struct rather than a large tuple to keep the API readable and
+/// to avoid triggering `clippy::type_complexity` when `-D warnings` is enabled.
+#[derive(Debug, Clone)]
+pub struct RoutingObstacleRow {
+    pub fid: i64,
+    pub planet: String,
+    pub x: f64,
+    pub y: f64,
+    pub radius: f64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RouteOptionsJson {
+    pub clearance: f64,
+    pub max_iters: usize,
+    pub max_offset_tries: usize,
+    pub offset_growth: f64,
+    pub turn_weight: f64,
+    pub back_weight: f64,
+    pub proximity_weight: f64,
+    pub proximity_margin: f64,
 }

--- a/src/routing/collision.rs
+++ b/src/routing/collision.rs
@@ -3,6 +3,7 @@ use crate::routing::geometry::*;
 #[derive(Debug, Clone)]
 pub struct Obstacle {
     pub id: i64,
+    pub name: String,
     pub center: Point,
     pub radius: f64,
 }

--- a/tests/routing_endpoint_collision.rs
+++ b/tests/routing_endpoint_collision.rs
@@ -13,6 +13,7 @@ fn route_allows_destination_endpoint_collision() {
     // Obstacle exactly at destination. With endpoint-safe logic, this must not prevent routing.
     let obstacles = vec![Obstacle {
         id: 99,
+        name: "Tepasi".to_string(),
         center: end,
         radius: 2.0,
     }];

--- a/tests/routing_multiple_obstacles.rs
+++ b/tests/routing_multiple_obstacles.rs
@@ -13,11 +13,13 @@ fn route_with_multiple_obstacles_is_safe() {
     let obstacles = vec![
         Obstacle {
             id: 1,
+            name: "Prakith".to_string(),
             center: Point::new(4.0, 0.0),
             radius: 0.6,
         },
         Obstacle {
             id: 2,
+            name: "Keeara Major".to_string(),
             center: Point::new(8.0, 0.0),
             radius: 0.6,
         },

--- a/tests/routing_single_obstacle.rs
+++ b/tests/routing_single_obstacle.rs
@@ -12,6 +12,7 @@ fn route_with_single_obstacle_creates_detour() {
 
     let obstacles = vec![Obstacle {
         id: 1,
+        name: "Prakith".to_string(),
         center: Point::new(5.0, 0.0),
         radius: 0.6,
     }];


### PR DESCRIPTION
…t (v0.6.0)

- add route explain command with detailed detour diagnostics
- persist tries_used / tries_exhausted for provable routing limits
- add --json and --file options for explain export
- unify CLI color policy across route show and explain
- improve scoring breakdown and dominant penalty reporting