### PR TITLE
feat(route): add clear and prune commands for routing data maintenanc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.6.1] – 2026-01-20
+
+### ✨ New Commands
+
+- Added `route clear` command to delete all persisted routing data:
+    - `routes`
+    - `route_waypoints`
+    - `route_detours`
+- Added interactive confirmation for destructive operations, with optional `--yes` flag for non-interactive usage
+- Added `route prune` command to remove orphan rows in routing tables
+  (`route_waypoints` and `route_detours` not linked to any route)
+
+### 🎨 UX Improvements
+
+- Introduced colorized output for `route clear` and `route prune`, consistent with the unified CLI color policy:
+    - destructive actions highlighted in red
+    - successful operations in green
+    - zero-effect operations dimmed
+    - partial cleanups highlighted in yellow
+- Improved user feedback for aborted destructive operations
+
+### 🛠 Internal / Refactoring
+
+- Reused centralized `confirm_destructive()` helper to avoid duplicated confirmation logic
+- Ensured routing cleanup commands never affect galaxy/domain data
+  (`waypoints`, `waypoint_planets`, `planets` remain untouched)
+- Improved robustness of maintenance commands against disabled foreign key constraints
+
+### ⚠️ Notes
+
+- `route prune` is a safe housekeeping operation and does not require confirmation
+- Both commands are backward-compatible and do not affect existing route computation logic
+
+---
+
 ## [0.6.0] – 2026-01-20
 
 ### ✨ New Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sw_galaxy_map"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -245,6 +245,16 @@ pub enum RouteCmd {
         /// Destination planet name (or alias)
         to: String,
     },
+
+    /// Clear all persisted routes (routes, waypoints, detours)
+    Clear {
+        /// Skip interactive confirmation prompt (destructive)
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        yes: bool,
+    },
+
+    /// Prune orphan rows in route_waypoints / route_detours not linked to any route
+    Prune,
 }
 
 #[derive(Args, Debug)]


### PR DESCRIPTION
…e (v0.6.1)

- add route clear with interactive confirmation and --yes flag
- add route prune to remove orphan route_waypoints and route_detours
- colorize maintenance command output using unified CLI color policy
- reuse confirm_destructive helper for destructive actions