### PR TITLE
feat(route): add route list command with filters, sorting and JSON ex…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.6.2] – 2026-01-20
+
+### ✨ New Features
+
+- Added `route list` command to list persisted routes
+- Introduced advanced filtering options for `route list`:
+    - `--status <status>`
+    - `--from <planet_fid>`
+    - `--to <planet_fid>`
+- Added configurable sorting for route listing via `--sort`:
+    - `updated` (default)
+    - `id`
+    - `length`
+- Added JSON export support for route listing:
+    - `route list --json`
+    - `route list --json --file <path>`
+
+### 🎨 UX Improvements
+
+- Colorized `route list` output using the unified CLI color policy
+- Clear visual distinction between:
+    - successful routes
+    - routes with detours
+    - zero-count values (dimmed)
+- Consistent behavior between stdout JSON export and file-based export
+
+### 🛠 Internal / Refactoring
+
+- Introduced `RouteListOptions` struct to group list parameters and satisfy Clippy constraints
+- Refactored dynamic SQL generation for route listing with:
+    - safe, optional `WHERE` clauses
+    - whitelisted `ORDER BY` clauses
+- Fixed SQL parameter binding mismatch in dynamically generated queries
+- Improved robustness of file output handling (parent directory creation)
+
+### 🐛 Bug Fixes
+
+- Fixed incorrect SQL parameter count when using filtered `route list`
+- Fixed path parent handling when exporting JSON to file
+
+### ⚠️ Notes
+
+- `route list` is backward-compatible with existing databases
+- JSON export produces clean machine-readable output with no extra text on stdout
+
+---
+
 ## [0.6.1] – 2026-01-20
 
 ### ✨ New Commands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sw_galaxy_map"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, Args, Parser, Subcommand};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -212,6 +212,13 @@ pub enum WaypointCmd {
     },
 }
 
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum RouteListSort {
+    Updated,
+    Id,
+    Length,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum RouteCmd {
     /// Compute and persist a route between two planets (name or alias)
@@ -255,6 +262,34 @@ pub enum RouteCmd {
 
     /// Prune orphan rows in route_waypoints / route_detours not linked to any route
     Prune,
+
+    // ...
+    List {
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        json: bool,
+
+        #[arg(long, requires = "json")]
+        file: Option<std::path::PathBuf>,
+
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+
+        /// Filter by status (e.g. ok, failed)
+        #[arg(long)]
+        status: Option<String>,
+
+        /// Filter by FROM planet fid
+        #[arg(long)]
+        from: Option<i64>,
+
+        /// Filter by TO planet fid
+        #[arg(long)]
+        to: Option<i64>,
+
+        /// Sort field (updated|id|length). Default: updated
+        #[arg(long, value_enum, default_value_t = RouteListSort::Updated)]
+        sort: RouteListSort,
+    },
 }
 
 #[derive(Args, Debug)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -200,3 +200,22 @@ pub struct RouteOptionsJson {
     pub proximity_weight: f64,
     pub proximity_margin: f64,
 }
+
+#[derive(Debug, Clone)]
+pub struct RouteListRow {
+    pub id: i64,
+    pub from_planet_fid: i64,
+    pub from_planet_name: String,
+    pub to_planet_fid: i64,
+    pub to_planet_name: String,
+
+    pub status: String,
+    pub length: Option<f64>,
+    pub iterations: Option<i64>,
+
+    pub created_at: String,
+    pub updated_at: Option<String>,
+
+    pub waypoints_count: i64,
+    pub detours_count: i64,
+}


### PR DESCRIPTION
…port (v0.6.2)

- add route list command with status/from/to filters
- add configurable sorting (updated, id, length)
- add JSON export with optional file output
- refactor list options into RouteListOptions to satisfy clippy
- fix SQL parameter binding in dynamic WHERE clauses