### PR TITLE
Add multi-leg support to `route compute` and bump to v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v0.8.1 — 2026-02-10
+
+### Added
+
+- `route compute` now accepts two or more planets to compute multi-leg trips in one command.
+
 ## v0.8.0 — 2026-01-28
 
 ### ⚠️ Breaking change

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -349,15 +349,14 @@ Same as route polyline:
 
 ### ✅ Persistence workflow (high-level)
 
-When running `route compute <from> <to>`:
-1. Resolve `from/to` to planet fids. 
-2. Compute the route in memory. 
-3. Upsert the route record in `routes` (unique per pair).
-4. Replace the associated polyline in `route_waypoints`. 
-5. Replace the associated decision log in `route_detours`. 
+When running `route compute <from> <to> [<via>...]`:
+1. Resolve the planet sequence to fids.
+2. Compute each leg in memory (FROM→TO, then TO→NEXT, etc.).
+3. Upsert each leg into `routes` (unique per pair).
+4. Replace the associated polylines in `route_waypoints`.
+5. Replace the associated decision logs in `route_detours`.
 6. For each detour waypoint:
    - upsert into `waypoints` if computed (via `fingerprint`)
    - optionally link waypoint ↔ planets in `waypoint_planets`
 
 This ensures that the database always holds the most recent “best known” route for each pair.
-

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -260,7 +260,7 @@ pub enum RouteListSort {
 
 #[derive(Subcommand, Debug)]
 pub enum RouteCmd {
-    /// Compute and persist a route between two planets (name or alias)
+    /// Compute and persist a route between two or more planets (name or alias)
     Compute(RouteComputeArgs),
 
     /// Show a persisted route by id
@@ -326,11 +326,9 @@ pub enum RouteCmd {
 
 #[derive(Args, Debug)]
 pub struct RouteComputeArgs {
-    /// Start planet name (or alias)
-    pub from: String,
-
-    /// Destination planet name (or alias)
-    pub to: String,
+    /// Planet names (or aliases), in travel order
+    #[arg(required = true, num_args = 2.., value_name = "PLANET")]
+    pub planets: Vec<String>,
 
     /// Safety radius in parsecs used to model a planet's hyperspace no-fly zone.
     ///

--- a/src/cli/commands/route.rs
+++ b/src/cli/commands/route.rs
@@ -12,6 +12,7 @@ use crate::cli::export::{
     ExplainNote, ExplainObstacle, ExplainRouteMeta, ExplainScore, ExplainWaypoint,
 };
 use crate::db::queries;
+use crate::model::Planet;
 use crate::model::RouteOptionsJson;
 use crate::routing::collision::Obstacle;
 use crate::routing::geometry::Point;
@@ -33,7 +34,7 @@ const DEFAULT_SEVERITY_K: f64 = 0.35;
 pub fn run(con: &mut Connection, cmd: &RouteCmd) -> Result<()> {
     match cmd {
         RouteCmd::Compute(args) => {
-            validate::validate_route_compute(&args.from, &args.to)?;
+            validate::validate_route_planets(&args.planets)?;
         }
         RouteCmd::Show { route_id } => {
             validate::validate_route_id(*route_id, "show")?;
@@ -84,15 +85,86 @@ pub fn run(con: &mut Connection, cmd: &RouteCmd) -> Result<()> {
 }
 
 fn run_compute(con: &mut Connection, args: &RouteComputeArgs) -> Result<()> {
+    let mut total_length = 0.0;
+    let mut total_waypoints = 0usize;
+    let mut total_detours = 0usize;
+    let mut route_ids = Vec::new();
+
+    for (idx, leg) in args.planets.windows(2).enumerate() {
+        let from = &leg[0];
+        let to = &leg[1];
+        let computed = compute_leg(con, args, from, to)?;
+
+        if args.planets.len() > 2 {
+            println!(
+                "Leg {}/{}: {} → {}",
+                idx + 1,
+                args.planets.len() - 1,
+                computed.from_p.planet,
+                computed.to_p.planet
+            );
+        } else {
+            println!("Route: {} → {}", computed.from_p.planet, computed.to_p.planet);
+        }
+
+        println!("Route ID: {}", computed.route_id);
+        println!("Waypoints: {}", computed.route.waypoints.len());
+        println!("Detours: {}", computed.route.detours.len());
+        println!("Length: {:.3} parsec", computed.route.length);
+        if args.planets.len() > 2 && idx + 1 < args.planets.len() - 1 {
+            println!();
+        }
+
+        total_length += computed.route.length;
+        total_waypoints += computed.route.waypoints.len();
+        total_detours += computed.route.detours.len();
+        route_ids.push(computed.route_id);
+
+        // Debug details (only in debug builds)
+        debug_print_route(&computed.route);
+    }
+
+    if args.planets.len() > 2 {
+        let route_ids_txt = route_ids
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!(
+            "Trip summary: {} legs, {} total waypoints, {} total detours, {:.3} total parsec",
+            args.planets.len() - 1,
+            total_waypoints,
+            total_detours,
+            total_length
+        );
+        println!("Route IDs: {}", route_ids_txt);
+    }
+
+    Ok(())
+}
+
+struct ComputedLeg {
+    from_p: Planet,
+    to_p: Planet,
+    route: crate::routing::router::Route,
+    route_id: i64,
+}
+
+fn compute_leg(
+    con: &mut Connection,
+    args: &RouteComputeArgs,
+    from: &str,
+    to: &str,
+) -> Result<ComputedLeg> {
     // 1) Resolve FROM/TO planets (name or alias)
-    let from_norm = normalize_text(&args.from);
-    let to_norm = normalize_text(&args.to);
+    let from_norm = normalize_text(from);
+    let to_norm = normalize_text(to);
 
     let from_p = queries::find_planet_for_info(con, &from_norm)?
-        .ok_or_else(|| anyhow::anyhow!("Planet not found: {}", args.from))?;
+        .ok_or_else(|| anyhow::anyhow!("Planet not found: {}", from))?;
 
     let to_p = queries::find_planet_for_info(con, &to_norm)?
-        .ok_or_else(|| anyhow::anyhow!("Planet not found: {}", args.to))?;
+        .ok_or_else(|| anyhow::anyhow!("Planet not found: {}", to))?;
 
     let start = Point::new(from_p.x, from_p.y);
     let end = Point::new(to_p.x, to_p.y);
@@ -172,16 +244,12 @@ fn run_compute(con: &mut Connection, args: &RouteComputeArgs) -> Result<()> {
     // 6) Persist route (v7)
     let route_id = queries::persist_route(con, from_p.fid, to_p.fid, opts, &route)?;
 
-    println!("Route: {} → {}", from_p.planet, to_p.planet);
-    println!("Route ID: {}", route_id);
-    println!("Waypoints: {}", route.waypoints.len());
-    println!("Detours: {}", route.detours.len());
-    println!("Length: {:.3} parsec", route.length);
-
-    // Debug details (only in debug builds)
-    debug_print_route(&route);
-
-    Ok(())
+    Ok(ComputedLeg {
+        from_p,
+        to_p,
+        route,
+        route_id,
+    })
 }
 
 fn run_show(con: &Connection, route_id: i64) -> Result<()> {

--- a/src/cli/commands/route.rs
+++ b/src/cli/commands/route.rs
@@ -104,7 +104,10 @@ fn run_compute(con: &mut Connection, args: &RouteComputeArgs) -> Result<()> {
                 computed.to_p.planet
             );
         } else {
-            println!("Route: {} → {}", computed.from_p.planet, computed.to_p.planet);
+            println!(
+                "Route: {} → {}",
+                computed.from_p.planet, computed.to_p.planet
+            );
         }
 
         println!("Route ID: {}", computed.route_id);

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -55,6 +55,25 @@ pub fn validate_route_compute(from: &str, to: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn validate_route_planets(planets: &[String]) -> anyhow::Result<()> {
+    if planets.len() < 2 {
+        anyhow::bail!("Route compute requires at least two planets.");
+    }
+    for (idx, planet) in planets.iter().enumerate() {
+        if planet.trim().is_empty() {
+            anyhow::bail!("Planet {} cannot be empty.", idx + 1);
+        }
+    }
+    for window in planets.windows(2) {
+        let from = window[0].trim();
+        let to = window[1].trim();
+        if from.eq_ignore_ascii_case(to) {
+            anyhow::bail!("Adjacent planets must be different ({} → {}).", from, to);
+        }
+    }
+    Ok(())
+}
+
 pub fn validate_limit(limit: i64, ctx: &str) -> anyhow::Result<()> {
     if limit <= 0 {
         anyhow::bail!("Invalid limit for {ctx}: {limit} (must be > 0)");

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -181,13 +181,18 @@ impl NavicomputerApp {
             }
 
             "route" => {
-                // route compute <from> <to>, route show <id>, route explain <id>...
+                // route compute <from> <to> [<via>...], route show <id>, route explain <id>...
                 if tokens.len() >= 2 {
                     match tokens[1].as_str() {
                         "compute" => {
-                            let from = tokens.get(2).map(|s| s.as_str()).unwrap_or("");
-                            let to = tokens.get(3).map(|s| s.as_str()).unwrap_or("");
-                            validate::validate_route_compute(from, to)?;
+                            let mut planets = Vec::new();
+                            for token in tokens.iter().skip(2) {
+                                if token.starts_with('-') {
+                                    break;
+                                }
+                                planets.push(token.clone());
+                            }
+                            validate::validate_route_planets(&planets)?;
                         }
                         "show" => {
                             let id = tokens
@@ -822,7 +827,7 @@ impl eframe::App for NavicomputerApp {
                         let resp = ui.add(
                             egui::TextEdit::singleline(&mut self.command)
                                 .id(cmd_id)
-                                .hint_text(r#"e.g. route compute "Corellia" "Tatooine""#)
+                                .hint_text(r#"e.g. route compute "Corellia" "Tatooine" "Hoth""#)
                                 .desired_width(800.0)
                                 .interactive(true)
                                 .frame(false),


### PR DESCRIPTION
### Motivation
- Allow users to compute multi-leg trips with a single command by specifying two or more planets in travel order.
- Keep existing per-leg routing and persistence semantics (routes are unique per origin/destination) while providing per-leg output and an overall trip summary.
- Update the GUI input hint, CLI validation, and documentation to reflect the new multi-leg workflow and release a patch version.

### Description
- Change CLI signature by replacing `from`/`to` with `planets: Vec<String>` on `RouteComputeArgs` (Clap `num_args = 2..`) to accept N≥2 planets.
- Add `validate_route_planets` and wire it into CLI and GUI token validation to ensure at least two non-empty, non-equal adjacent planets.
- Implement multi-leg computation by iterating `args.planets.windows(2)` in `run_compute`, extracting `compute_leg` to resolve planets, fetch obstacles, run `compute_route`, and persist each leg; print per-leg stats and a trip summary with aggregated totals and route IDs.
- Update GUI hint text and parsing to accept multiple planets, adjust `README.md` and `CHANGELOG.md` to document the new behavior, and bump `Cargo.toml` version to `0.8.1`.

### Testing
- No automated tests were executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837325800c8325a35aa7a34d2eecd4)