### PR TITLE
Persist skipped-planets JSON and add multi-leg `route compute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v0.8.1 — 2026-02-10
+
+### Added
+
+- `route compute` now accepts two or more planets to compute multi-leg trips in one command.
+
 ## v0.8.0 — 2026-01-28
 
 ### ⚠️ Breaking change

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,7 +3466,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sw_galaxy_map"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -349,15 +349,14 @@ Same as route polyline:
 
 ### ✅ Persistence workflow (high-level)
 
-When running `route compute <from> <to>`:
-1. Resolve `from/to` to planet fids. 
-2. Compute the route in memory. 
-3. Upsert the route record in `routes` (unique per pair).
-4. Replace the associated polyline in `route_waypoints`. 
-5. Replace the associated decision log in `route_detours`. 
+When running `route compute <from> <to> [<via>...]`:
+1. Resolve the planet sequence to fids.
+2. Compute each leg in memory (FROM→TO, then TO→NEXT, etc.).
+3. Upsert each leg into `routes` (unique per pair).
+4. Replace the associated polylines in `route_waypoints`.
+5. Replace the associated decision logs in `route_detours`.
 6. For each detour waypoint:
    - upsert into `waypoints` if computed (via `fingerprint`)
    - optionally link waypoint ↔ planets in `waypoint_planets`
 
 This ensures that the database always holds the most recent “best known” route for each pair.
-

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -133,6 +133,9 @@ pub enum DbCommands {
         stats_limit: usize,
     },
 
+    /// Emit JSON listing the most recently skipped planets during db update
+    SkippedPlanets,
+
     /// Migrate the local database to the latest schema version
     Migrate {
         /// Show what migrations would be applied without executing them
@@ -260,7 +263,7 @@ pub enum RouteListSort {
 
 #[derive(Subcommand, Debug)]
 pub enum RouteCmd {
-    /// Compute and persist a route between two planets (name or alias)
+    /// Compute and persist a route between two or more planets (name or alias)
     Compute(RouteComputeArgs),
 
     /// Show a persisted route by id
@@ -326,11 +329,9 @@ pub enum RouteCmd {
 
 #[derive(Args, Debug)]
 pub struct RouteComputeArgs {
-    /// Start planet name (or alias)
-    pub from: String,
-
-    /// Destination planet name (or alias)
-    pub to: String,
+    /// Planet names (or aliases), in travel order
+    #[arg(required = true, num_args = 2.., value_name = "PLANET")]
+    pub planets: Vec<String>,
 
     /// Safety radius in parsecs used to model a planet's hyperspace no-fly zone.
     ///

--- a/src/cli/commands/route.rs
+++ b/src/cli/commands/route.rs
@@ -12,6 +12,7 @@ use crate::cli::export::{
     ExplainNote, ExplainObstacle, ExplainRouteMeta, ExplainScore, ExplainWaypoint,
 };
 use crate::db::queries;
+use crate::model::Planet;
 use crate::model::RouteOptionsJson;
 use crate::routing::collision::Obstacle;
 use crate::routing::geometry::Point;
@@ -33,7 +34,7 @@ const DEFAULT_SEVERITY_K: f64 = 0.35;
 pub fn run(con: &mut Connection, cmd: &RouteCmd) -> Result<()> {
     match cmd {
         RouteCmd::Compute(args) => {
-            validate::validate_route_compute(&args.from, &args.to)?;
+            validate::validate_route_planets(&args.planets)?;
         }
         RouteCmd::Show { route_id } => {
             validate::validate_route_id(*route_id, "show")?;
@@ -84,15 +85,89 @@ pub fn run(con: &mut Connection, cmd: &RouteCmd) -> Result<()> {
 }
 
 fn run_compute(con: &mut Connection, args: &RouteComputeArgs) -> Result<()> {
+    let mut total_length = 0.0;
+    let mut total_waypoints = 0usize;
+    let mut total_detours = 0usize;
+    let mut route_ids = Vec::new();
+
+    for (idx, leg) in args.planets.windows(2).enumerate() {
+        let from = &leg[0];
+        let to = &leg[1];
+        let computed = compute_leg(con, args, from, to)?;
+
+        if args.planets.len() > 2 {
+            println!(
+                "Leg {}/{}: {} → {}",
+                idx + 1,
+                args.planets.len() - 1,
+                computed.from_p.planet,
+                computed.to_p.planet
+            );
+        } else {
+            println!(
+                "Route: {} → {}",
+                computed.from_p.planet, computed.to_p.planet
+            );
+        }
+
+        println!("Route ID: {}", computed.route_id);
+        println!("Waypoints: {}", computed.route.waypoints.len());
+        println!("Detours: {}", computed.route.detours.len());
+        println!("Length: {:.3} parsec", computed.route.length);
+        if args.planets.len() > 2 && idx + 1 < args.planets.len() - 1 {
+            println!();
+        }
+
+        total_length += computed.route.length;
+        total_waypoints += computed.route.waypoints.len();
+        total_detours += computed.route.detours.len();
+        route_ids.push(computed.route_id);
+
+        // Debug details (only in debug builds)
+        debug_print_route(&computed.route);
+    }
+
+    if args.planets.len() > 2 {
+        let route_ids_txt = route_ids
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!(
+            "Trip summary: {} legs, {} total waypoints, {} total detours, {:.3} total parsec",
+            args.planets.len() - 1,
+            total_waypoints,
+            total_detours,
+            total_length
+        );
+        println!("Route IDs: {}", route_ids_txt);
+    }
+
+    Ok(())
+}
+
+struct ComputedLeg {
+    from_p: Planet,
+    to_p: Planet,
+    route: crate::routing::router::Route,
+    route_id: i64,
+}
+
+fn compute_leg(
+    con: &mut Connection,
+    args: &RouteComputeArgs,
+    from: &str,
+    to: &str,
+) -> Result<ComputedLeg> {
     // 1) Resolve FROM/TO planets (name or alias)
-    let from_norm = normalize_text(&args.from);
-    let to_norm = normalize_text(&args.to);
+    let from_norm = normalize_text(from);
+    let to_norm = normalize_text(to);
 
     let from_p = queries::find_planet_for_info(con, &from_norm)?
-        .ok_or_else(|| anyhow::anyhow!("Planet not found: {}", args.from))?;
+        .ok_or_else(|| anyhow::anyhow!("Planet not found: {}", from))?;
 
     let to_p = queries::find_planet_for_info(con, &to_norm)?
-        .ok_or_else(|| anyhow::anyhow!("Planet not found: {}", args.to))?;
+        .ok_or_else(|| anyhow::anyhow!("Planet not found: {}", to))?;
 
     let start = Point::new(from_p.x, from_p.y);
     let end = Point::new(to_p.x, to_p.y);
@@ -172,16 +247,12 @@ fn run_compute(con: &mut Connection, args: &RouteComputeArgs) -> Result<()> {
     // 6) Persist route (v7)
     let route_id = queries::persist_route(con, from_p.fid, to_p.fid, opts, &route)?;
 
-    println!("Route: {} → {}", from_p.planet, to_p.planet);
-    println!("Route ID: {}", route_id);
-    println!("Waypoints: {}", route.waypoints.len());
-    println!("Detours: {}", route.detours.len());
-    println!("Length: {:.3} parsec", route.length);
-
-    // Debug details (only in debug builds)
-    debug_print_route(&route);
-
-    Ok(())
+    Ok(ComputedLeg {
+        from_p,
+        to_p,
+        route,
+        route_id,
+    })
 }
 
 fn run_show(con: &Connection, route_id: i64) -> Result<()> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -53,6 +53,11 @@ fn run_one_shot(cli: &args::Cli, cmd: &args::Commands) -> Result<()> {
                 crate::db::db_update::run(&mut con, *prune, *dry_run, *stats, *stats_limit)
             }
 
+            args::DbCommands::SkippedPlanets => {
+                let mut con = open_db_migrating(cli.db.clone())?;
+                crate::db::db_skipped_planets::run(&mut con)
+            }
+
             args::DbCommands::Migrate { dry_run } => {
                 // IMPORTANT: do not auto-migrate before running migrate
                 let mut con = open_db_raw(cli.db.clone())?;

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -55,6 +55,25 @@ pub fn validate_route_compute(from: &str, to: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn validate_route_planets(planets: &[String]) -> anyhow::Result<()> {
+    if planets.len() < 2 {
+        anyhow::bail!("Route compute requires at least two planets.");
+    }
+    for (idx, planet) in planets.iter().enumerate() {
+        if planet.trim().is_empty() {
+            anyhow::bail!("Planet {} cannot be empty.", idx + 1);
+        }
+    }
+    for window in planets.windows(2) {
+        let from = window[0].trim();
+        let to = window[1].trim();
+        if from.eq_ignore_ascii_case(to) {
+            anyhow::bail!("Adjacent planets must be different ({} → {}).", from, to);
+        }
+    }
+    Ok(())
+}
+
 pub fn validate_limit(limit: i64, ctx: &str) -> anyhow::Result<()> {
     if limit <= 0 {
         anyhow::bail!("Invalid limit for {ctx}: {limit} (must be > 0)");

--- a/src/db/db_skipped_planets.rs
+++ b/src/db/db_skipped_planets.rs
@@ -1,0 +1,26 @@
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::db::db_update::META_SKIPPED_PLANETS_JSON;
+
+pub fn run(con: &mut Connection) -> Result<()> {
+    let skipped_json: Option<String> = con
+        .query_row(
+            "SELECT value FROM meta WHERE key = ?1",
+            [META_SKIPPED_PLANETS_JSON],
+            |r| r.get(0),
+        )
+        .optional()
+        .context("Failed to read skipped planets metadata")?;
+
+    match skipped_json {
+        Some(json) => {
+            println!("{json}");
+        }
+        None => {
+            println!("[]");
+        }
+    }
+
+    Ok(())
+}

--- a/src/db/db_update.rs
+++ b/src/db/db_update.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
 
@@ -9,6 +10,7 @@ use crate::db::provision::{
 use crate::provision::arcgis;
 use crate::ui;
 use crate::utils::normalize::normalize_text;
+use crate::utils::time::now_utc_iso;
 
 // ----------------------------
 // Stats collection (optional)
@@ -27,6 +29,18 @@ struct ChangeEvent {
     kind: ChangeKind,
     planet: Option<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkippedPlanetRow {
+    pub fid: Option<i64>,
+    pub planet: Option<String>,
+    pub x: Option<f64>,
+    pub y: Option<f64>,
+    pub reasons: Vec<String>,
+}
+
+pub const META_SKIPPED_PLANETS_JSON: &str = "skipped_planets_json";
+pub const META_SKIPPED_PLANETS_UPDATED_AT: &str = "skipped_planets_updated_at";
 
 fn compute_arcgis_hash(a: &Value) -> String {
     // Must match the one used in provision (keep in sync)
@@ -300,6 +314,7 @@ pub fn run(
     let mut skipped_missing_planet: i64 = 0;
     let mut skipped_missing_x: i64 = 0;
     let mut skipped_missing_y: i64 = 0;
+    let mut skipped_rows: Vec<SkippedPlanetRow> = Vec::new();
 
     // Helper to capture best-effort planet name
     let planet_name = |a: &Value| -> Option<String> {
@@ -315,6 +330,13 @@ pub fn run(
             Some(v) => v,
             None => {
                 skipped += 1;
+                skipped_rows.push(SkippedPlanetRow {
+                    fid: None,
+                    planet: planet_name(a),
+                    x: get_f(a, "X"),
+                    y: get_f(a, "Y"),
+                    reasons: vec!["missing_fid".to_string()],
+                });
                 continue;
             }
         };
@@ -342,6 +364,24 @@ pub fn run(
             if !y_ok {
                 skipped_missing_y += 1;
             }
+
+            let mut reasons = Vec::new();
+            if !planet_ok {
+                reasons.push("missing_planet".to_string());
+            }
+            if !x_ok {
+                reasons.push("missing_x".to_string());
+            }
+            if !y_ok {
+                reasons.push("missing_y".to_string());
+            }
+            skipped_rows.push(SkippedPlanetRow {
+                fid: Some(fid),
+                planet: planet_name(a),
+                x: get_f(a, "X"),
+                y: get_f(a, "Y"),
+                reasons,
+            });
 
             continue;
         }
@@ -446,6 +486,11 @@ pub fn run(
         meta_upsert_public(&tx, "last_update_utc", &crate::utils::time::now_utc_iso())?;
         meta_upsert_public(&tx, "update_mode", "incremental")?;
         meta_upsert_public(&tx, "prune_used", if prune { "1" } else { "0" })?;
+
+        if let Ok(skipped_json) = serde_json::to_string_pretty(&skipped_rows) {
+            meta_upsert_public(&tx, META_SKIPPED_PLANETS_JSON, &skipped_json)?;
+            meta_upsert_public(&tx, META_SKIPPED_PLANETS_UPDATED_AT, &now_utc_iso())?;
+        }
 
         tx.commit().context("Failed to commit db update")?;
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,6 @@
 pub mod core;
 pub mod db_init;
+pub mod db_skipped_planets;
 pub mod db_status;
 pub mod db_update;
 pub mod migrate;

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -181,13 +181,18 @@ impl NavicomputerApp {
             }
 
             "route" => {
-                // route compute <from> <to>, route show <id>, route explain <id>...
+                // route compute <from> <to> [<via>...], route show <id>, route explain <id>...
                 if tokens.len() >= 2 {
                     match tokens[1].as_str() {
                         "compute" => {
-                            let from = tokens.get(2).map(|s| s.as_str()).unwrap_or("");
-                            let to = tokens.get(3).map(|s| s.as_str()).unwrap_or("");
-                            validate::validate_route_compute(from, to)?;
+                            let mut planets = Vec::new();
+                            for token in tokens.iter().skip(2) {
+                                if token.starts_with('-') {
+                                    break;
+                                }
+                                planets.push(token.clone());
+                            }
+                            validate::validate_route_planets(&planets)?;
                         }
                         "show" => {
                             let id = tokens
@@ -822,7 +827,7 @@ impl eframe::App for NavicomputerApp {
                         let resp = ui.add(
                             egui::TextEdit::singleline(&mut self.command)
                                 .id(cmd_id)
-                                .hint_text(r#"e.g. route compute "Corellia" "Tatooine""#)
+                                .hint_text(r#"e.g. route compute "Corellia" "Tatooine" "Hoth""#)
                                 .desired_width(800.0)
                                 .interactive(true)
                                 .frame(false),


### PR DESCRIPTION
### Motivation

- Surface details about rows skipped during database updates as machine-readable JSON so users and tools can inspect invalid entries.  
- Improve routing UX by allowing `route compute` to accept two or more planets and provide per-leg output plus a trip summary.  
- Update CLI/GUI validation and hints to reflect multi-leg routing and make the new DB introspection command accessible.

### Description

- Added a new DB command `db skipped-planets` with implementation in `src/db/db_skipped_planets.rs` and dispatcher wiring in `src/cli/mod.rs` and `src/cli/args.rs` to print the persisted JSON (or `[]` when absent).  
- Collected skipped-row details during `db update` by introducing `SkippedPlanetRow` (serde `Serialize`/`Deserialize`) and persisting a pretty JSON snapshot under meta keys `skipped_planets_json` and `skipped_planets_updated_at` in `src/db/db_update.rs`.  
- Extended routing to support multi-leg trips by changing `RouteComputeArgs` to accept `Vec<String>` planets, adding `validate_route_planets`, refactoring the compute flow into a `compute_leg` helper that returns `ComputedLeg`, and aggregating per-leg output plus a trip summary in `src/cli/commands/route.rs`.  
- Updated GUI command hint and interactive validation to handle multi-leg input, registered the new DB module in `src/db/mod.rs`, and applied workspace formatting; bumped package version in `Cargo.toml`/`Cargo.lock` accordingly.

### Testing

- Ran `cargo fmt --all` and it completed successfully.  
- Ran `cargo clippy --all-features --all-targets -- -D warnings` and it completed successfully with no warnings.  
- Committed the `Cargo.lock` update produced by the tooling run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837325800c8325a35aa7a34d2eecd4)