### PR TITLE
Persist skipped planets to planets_unknown table (schema v11)

### DIFF
--- a/src/db/db_skipped_planets.rs
+++ b/src/db/db_skipped_planets.rs
@@ -1,26 +1,47 @@
 use anyhow::{Context, Result};
-use rusqlite::{Connection, OptionalExtension};
+use rusqlite::Connection;
+use serde::Serialize;
+use serde_json;
 
-use crate::db::db_update::META_SKIPPED_PLANETS_JSON;
+#[derive(Debug, Serialize)]
+struct SkippedPlanetRow {
+    fid: Option<i64>,
+    planet: Option<String>,
+    x: Option<f64>,
+    y: Option<f64>,
+    reason: String,
+}
 
 pub fn run(con: &mut Connection) -> Result<()> {
-    let skipped_json: Option<String> = con
-        .query_row(
-            "SELECT value FROM meta WHERE key = ?1",
-            [META_SKIPPED_PLANETS_JSON],
-            |r| r.get(0),
+    let mut stmt = con
+        .prepare(
+            r#"
+            SELECT fid, planet, x, y, reason
+            FROM planets_unknown
+            ORDER BY fid
+            "#,
         )
-        .optional()
-        .context("Failed to read skipped planets metadata")?;
+        .context("Failed to query skipped planets table")?;
 
-    match skipped_json {
-        Some(json) => {
-            println!("{json}");
-        }
-        None => {
-            println!("[]");
-        }
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(SkippedPlanetRow {
+                fid: r.get(0)?,
+                planet: r.get(1)?,
+                x: r.get(2)?,
+                y: r.get(3)?,
+                reason: r.get(4)?,
+            })
+        })
+        .context("Failed to read skipped planets rows")?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
     }
+
+    let json = serde_json::to_string_pretty(&out).context("Failed to encode skipped planets JSON")?;
+    println!("{json}");
 
     Ok(())
 }

--- a/src/db/db_skipped_planets.rs
+++ b/src/db/db_skipped_planets.rs
@@ -40,7 +40,8 @@ pub fn run(con: &mut Connection) -> Result<()> {
         out.push(row?);
     }
 
-    let json = serde_json::to_string_pretty(&out).context("Failed to encode skipped planets JSON")?;
+    let json =
+        serde_json::to_string_pretty(&out).context("Failed to encode skipped planets JSON")?;
     println!("{json}");
 
     Ok(())

--- a/src/db/db_update.rs
+++ b/src/db/db_update.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, Transaction, params};
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
 
@@ -10,7 +9,6 @@ use crate::db::provision::{
 use crate::provision::arcgis;
 use crate::ui;
 use crate::utils::normalize::normalize_text;
-use crate::utils::time::now_utc_iso;
 
 // ----------------------------
 // Stats collection (optional)
@@ -30,17 +28,14 @@ struct ChangeEvent {
     planet: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct SkippedPlanetRow {
     pub fid: Option<i64>,
     pub planet: Option<String>,
     pub x: Option<f64>,
     pub y: Option<f64>,
-    pub reasons: Vec<String>,
+    pub reason: String,
 }
-
-pub const META_SKIPPED_PLANETS_JSON: &str = "skipped_planets_json";
-pub const META_SKIPPED_PLANETS_UPDATED_AT: &str = "skipped_planets_updated_at";
 
 fn compute_arcgis_hash(a: &Value) -> String {
     // Must match the one used in provision (keep in sync)
@@ -335,7 +330,7 @@ pub fn run(
                     planet: planet_name(a),
                     x: get_f(a, "X"),
                     y: get_f(a, "Y"),
-                    reasons: vec!["missing_fid".to_string()],
+                    reason: "missing_fid".to_string(),
                 });
                 continue;
             }
@@ -380,7 +375,7 @@ pub fn run(
                 planet: planet_name(a),
                 x: get_f(a, "X"),
                 y: get_f(a, "Y"),
-                reasons,
+                reason: reasons.join(","),
             });
 
             continue;
@@ -487,9 +482,15 @@ pub fn run(
         meta_upsert_public(&tx, "update_mode", "incremental")?;
         meta_upsert_public(&tx, "prune_used", if prune { "1" } else { "0" })?;
 
-        if let Ok(skipped_json) = serde_json::to_string_pretty(&skipped_rows) {
-            meta_upsert_public(&tx, META_SKIPPED_PLANETS_JSON, &skipped_json)?;
-            meta_upsert_public(&tx, META_SKIPPED_PLANETS_UPDATED_AT, &now_utc_iso())?;
+        tx.execute("DELETE FROM planets_unknown", [])?;
+        let mut stmt = tx.prepare_cached(
+            r#"
+            INSERT INTO planets_unknown(fid, planet, x, y, reason)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+        )?;
+        for row in &skipped_rows {
+            stmt.execute(params![row.fid, row.planet, row.x, row.y, row.reason])?;
         }
 
         tx.commit().context("Failed to commit db update")?;

--- a/src/db/db_update.rs
+++ b/src/db/db_update.rs
@@ -492,6 +492,7 @@ pub fn run(
         for row in &skipped_rows {
             stmt.execute(params![row.fid, row.planet, row.x, row.y, row.reason])?;
         }
+        drop(stmt);
 
         tx.commit().context("Failed to commit db update")?;
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, Transaction};
 
 const START_SCHEMA_VERSION: i64 = 3;
-const LATEST_SCHEMA_VERSION: i64 = 10;
+const LATEST_SCHEMA_VERSION: i64 = 11;
 
 struct MigrationStep {
     from: i64,
@@ -55,6 +55,12 @@ fn migration_steps() -> &'static [MigrationStep] {
             to: 10,
             label: "routes status index",
             apply: m_to_v10,
+        },
+        MigrationStep {
+            from: 10,
+            to: 11,
+            label: "planets unknown table",
+            apply: m_to_v11,
         },
     ]
 }
@@ -361,6 +367,23 @@ fn m_to_v10(tx: &Transaction<'_>) -> Result<()> {
         "#,
     )
     .context("Failed to migrate schema to v10 (creation idx_routes_status index)")?;
+
+    Ok(())
+}
+
+fn m_to_v11(tx: &Transaction<'_>) -> Result<()> {
+    tx.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS planets_unknown (
+          fid    INTEGER,
+          planet TEXT,
+          x      REAL,
+          y      REAL,
+          reason TEXT
+        );
+        "#,
+    )
+    .context("Failed to migrate schema to v11 (create planets_unknown table)")?;
 
     Ok(())
 }

--- a/src/db/provision.rs
+++ b/src/db/provision.rs
@@ -90,6 +90,19 @@ pub fn create_schema(con: &Connection, enable_fts: bool) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_planets_xy          ON planets(X, Y);
 
         -- =========================
+        -- PLANETS UNKNOWN
+        -- =========================
+        DROP TABLE IF EXISTS planets_unknown;
+
+        CREATE TABLE planets_unknown (
+            fid    INTEGER,
+            planet TEXT,
+            x      REAL,
+            y      REAL,
+            reason TEXT
+        );
+
+        -- =========================
         -- WAYPOINTS (catalog)
         -- =========================
         DROP TABLE IF EXISTS waypoints;
@@ -371,7 +384,7 @@ pub fn insert_all(
     meta_upsert(&tx, "dataset_version", &meta.dataset_version)?;
     meta_upsert(&tx, "importer_version", &meta.importer_version)?;
     meta_upsert(&tx, "fts_enabled", if enable_fts { "1" } else { "0" })?;
-    meta_upsert(&tx, "schema_version", "4")?;
+    meta_upsert(&tx, "schema_version", "11")?;
 
     {
         let mut stmt = tx.prepare(


### PR DESCRIPTION
### Motivation
- Keep skipped-row data in a first-class table instead of embedding JSON in `meta` so it can be queried and emitted reliably by CLI commands.
- Ensure new and existing databases get the `planets_unknown` table via schema migrations and fresh provisioning.

### Description
- Add schema migration step `v10 → v11` that creates `planets_unknown(fid, planet, x, y, reason)` and bump `LATEST_SCHEMA_VERSION` to `11` in `src/db/migrate.rs`.
- Initialize `planets_unknown` in fresh DBs by creating the table in `src/db/provision.rs` and update initial `schema_version` to `11`.
- During `db update` (`src/db/db_update.rs`) collect skipped rows into a consolidated `reason` string and on successful update clear and repopulate `planets_unknown` instead of writing pretty JSON into `meta`.
- Change the `db skipped_planets` command (`src/db/db_skipped_planets.rs`) to `SELECT` from `planets_unknown` and print pretty JSON output.

### Testing
- No automated tests were run for this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983aa8829a48325b6cb6240ae0f1b60)