### PR TITLE
Add `--unknown`/`--fid` support to `near` (search around planets_unknown)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -51,12 +51,21 @@ pub enum Commands {
     ///
     /// Notes:
     /// - If you provide `--planet`, the planet coordinates are used as the center.
+    /// - If you provide `--unknown`, the coordinates are read from `planets_unknown`.
     /// - Otherwise you must provide both `--x` and `--y`.
     /// - For negative coordinates, use the `=` form (e.g. `--y=-190`) to avoid CLI parsing ambiguity.
     Near {
         /// Radius (parsecs)
         #[arg(long)]
         r: f64,
+
+        /// Center the search around an unknown planet (in planets_unknown)
+        #[arg(long, action = ArgAction::SetTrue)]
+        unknown: bool,
+
+        /// Unknown planet FID (requires --unknown)
+        #[arg(long)]
+        fid: Option<i64>,
 
         /// Center the search around a planet (by name)
         #[arg(long)]

--- a/src/cli/commands/near.rs
+++ b/src/cli/commands/near.rs
@@ -1,4 +1,6 @@
-use crate::db::queries::{find_planet_for_info, near_planets, near_planets_excluding_fid};
+use crate::db::queries::{
+    find_planet_for_info, get_unknown_planet_by_fid, near_planets, near_planets_excluding_fid,
+};
 use crate::ui::{info, warning};
 use crate::utils::normalize::normalize_text;
 use anyhow::Result;
@@ -20,15 +22,46 @@ fn print_negative_hint() {
     println!("Tip: for negative coordinates use --x=-190 / --y=-190 (with '=')\n");
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     con: &Connection,
     r: f64,
+    unknown: bool,
+    fid: Option<i64>,
     planet: Option<String>,
     x: Option<f64>,
     y: Option<f64>,
     limit: i64,
 ) -> Result<()> {
-    let rows = if let Some(planet_name) = planet {
+    let rows = if unknown {
+        let fid = fid.ok_or_else(|| anyhow::anyhow!("--fid is required with --unknown"))?;
+        let unknown_planet = get_unknown_planet_by_fid(con, fid)?
+            .ok_or_else(|| anyhow::anyhow!("No unknown planet found for fid {}", fid))?;
+        let x = unknown_planet.x.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown planet fid {} has no X coordinate (reason: {}).",
+                fid,
+                unknown_planet.reason.as_deref().unwrap_or("missing_x")
+            )
+        })?;
+        let y = unknown_planet.y.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown planet fid {} has no Y coordinate (reason: {}).",
+                fid,
+                unknown_planet.reason.as_deref().unwrap_or("missing_y")
+            )
+        })?;
+        let name = unknown_planet
+            .planet
+            .unwrap_or_else(|| format!("(unknown fid {fid})"));
+
+        println!("Center: {} (X={:.3}, Y={:.3})", name, x, y);
+        println!("Radius: {:.3} parsecs", r);
+        println!("Limit: {}", limit);
+        println!();
+
+        near_planets(con, x, y, r, limit)?
+    } else if let Some(planet_name) = planet {
         let pn = normalize_text(&planet_name);
         let p = match find_planet_for_info(con, &pn)? {
             Some(p) => p,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -78,14 +78,16 @@ fn run_one_shot(cli: &args::Cli, cmd: &args::Commands) -> Result<()> {
 
         args::Commands::Near {
             r,
+            unknown,
+            fid,
             planet,
             x,
             y,
             limit,
         } => {
-            validate::validate_near(planet, x, y)?;
+            validate::validate_near(*unknown, fid, planet, x, y)?;
             let con = open_db_migrating(cli.db.clone())?;
-            commands::near::run(&con, *r, planet.clone(), *x, *y, *limit)
+            commands::near::run(&con, *r, *unknown, *fid, planet.clone(), *x, *y, *limit)
         }
 
         args::Commands::Waypoint { cmd } => {

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -4,7 +4,27 @@ use anyhow::{Result, bail};
 pub const TIP_NEGATIVE_COORDS: &str =
     "Note: for negative coordinates, use the '=' form, e.g.:\n  near --r 50 --x=7100 --y=-190";
 
-pub fn validate_near(planet: &Option<String>, x: &Option<f64>, y: &Option<f64>) -> Result<()> {
+pub fn validate_near(
+    unknown: bool,
+    fid: &Option<i64>,
+    planet: &Option<String>,
+    x: &Option<f64>,
+    y: &Option<f64>,
+) -> Result<()> {
+    if unknown {
+        if fid.is_none() {
+            bail!("--fid is required when using --unknown.");
+        }
+        if planet.is_some() || x.is_some() || y.is_some() {
+            bail!("--unknown cannot be combined with --planet, --x, or --y.");
+        }
+        return Ok(());
+    }
+
+    if fid.is_some() {
+        bail!("--fid can only be used with --unknown.");
+    }
+
     if planet.is_some() {
         return Ok(());
     }

--- a/src/db/db_skipped_planets.rs
+++ b/src/db/db_skipped_planets.rs
@@ -1,26 +1,48 @@
 use anyhow::{Context, Result};
-use rusqlite::{Connection, OptionalExtension};
+use rusqlite::Connection;
+use serde::Serialize;
+use serde_json;
 
-use crate::db::db_update::META_SKIPPED_PLANETS_JSON;
+#[derive(Debug, Serialize)]
+struct SkippedPlanetRow {
+    fid: Option<i64>,
+    planet: Option<String>,
+    x: Option<f64>,
+    y: Option<f64>,
+    reason: String,
+}
 
 pub fn run(con: &mut Connection) -> Result<()> {
-    let skipped_json: Option<String> = con
-        .query_row(
-            "SELECT value FROM meta WHERE key = ?1",
-            [META_SKIPPED_PLANETS_JSON],
-            |r| r.get(0),
+    let mut stmt = con
+        .prepare(
+            r#"
+            SELECT fid, planet, x, y, reason
+            FROM planets_unknown
+            ORDER BY fid
+            "#,
         )
-        .optional()
-        .context("Failed to read skipped planets metadata")?;
+        .context("Failed to query skipped planets table")?;
 
-    match skipped_json {
-        Some(json) => {
-            println!("{json}");
-        }
-        None => {
-            println!("[]");
-        }
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(SkippedPlanetRow {
+                fid: r.get(0)?,
+                planet: r.get(1)?,
+                x: r.get(2)?,
+                y: r.get(3)?,
+                reason: r.get(4)?,
+            })
+        })
+        .context("Failed to read skipped planets rows")?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
     }
+
+    let json =
+        serde_json::to_string_pretty(&out).context("Failed to encode skipped planets JSON")?;
+    println!("{json}");
 
     Ok(())
 }

--- a/src/db/db_update.rs
+++ b/src/db/db_update.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, Transaction, params};
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
 
@@ -10,7 +9,6 @@ use crate::db::provision::{
 use crate::provision::arcgis;
 use crate::ui;
 use crate::utils::normalize::normalize_text;
-use crate::utils::time::now_utc_iso;
 
 // ----------------------------
 // Stats collection (optional)
@@ -30,17 +28,14 @@ struct ChangeEvent {
     planet: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct SkippedPlanetRow {
     pub fid: Option<i64>,
     pub planet: Option<String>,
     pub x: Option<f64>,
     pub y: Option<f64>,
-    pub reasons: Vec<String>,
+    pub reason: String,
 }
-
-pub const META_SKIPPED_PLANETS_JSON: &str = "skipped_planets_json";
-pub const META_SKIPPED_PLANETS_UPDATED_AT: &str = "skipped_planets_updated_at";
 
 fn compute_arcgis_hash(a: &Value) -> String {
     // Must match the one used in provision (keep in sync)
@@ -335,7 +330,7 @@ pub fn run(
                     planet: planet_name(a),
                     x: get_f(a, "X"),
                     y: get_f(a, "Y"),
-                    reasons: vec!["missing_fid".to_string()],
+                    reason: "missing_fid".to_string(),
                 });
                 continue;
             }
@@ -380,7 +375,7 @@ pub fn run(
                 planet: planet_name(a),
                 x: get_f(a, "X"),
                 y: get_f(a, "Y"),
-                reasons,
+                reason: reasons.join(","),
             });
 
             continue;
@@ -487,10 +482,17 @@ pub fn run(
         meta_upsert_public(&tx, "update_mode", "incremental")?;
         meta_upsert_public(&tx, "prune_used", if prune { "1" } else { "0" })?;
 
-        if let Ok(skipped_json) = serde_json::to_string_pretty(&skipped_rows) {
-            meta_upsert_public(&tx, META_SKIPPED_PLANETS_JSON, &skipped_json)?;
-            meta_upsert_public(&tx, META_SKIPPED_PLANETS_UPDATED_AT, &now_utc_iso())?;
+        tx.execute("DELETE FROM planets_unknown", [])?;
+        let mut stmt = tx.prepare_cached(
+            r#"
+            INSERT INTO planets_unknown(fid, planet, x, y, reason)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+        )?;
+        for row in &skipped_rows {
+            stmt.execute(params![row.fid, row.planet, row.x, row.y, row.reason])?;
         }
+        drop(stmt);
 
         tx.commit().context("Failed to commit db update")?;
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, Transaction};
 
 const START_SCHEMA_VERSION: i64 = 3;
-const LATEST_SCHEMA_VERSION: i64 = 10;
+const LATEST_SCHEMA_VERSION: i64 = 11;
 
 struct MigrationStep {
     from: i64,
@@ -55,6 +55,12 @@ fn migration_steps() -> &'static [MigrationStep] {
             to: 10,
             label: "routes status index",
             apply: m_to_v10,
+        },
+        MigrationStep {
+            from: 10,
+            to: 11,
+            label: "planets unknown table",
+            apply: m_to_v11,
         },
     ]
 }
@@ -361,6 +367,23 @@ fn m_to_v10(tx: &Transaction<'_>) -> Result<()> {
         "#,
     )
     .context("Failed to migrate schema to v10 (creation idx_routes_status index)")?;
+
+    Ok(())
+}
+
+fn m_to_v11(tx: &Transaction<'_>) -> Result<()> {
+    tx.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS planets_unknown (
+          fid    INTEGER,
+          planet TEXT,
+          x      REAL,
+          y      REAL,
+          reason TEXT
+        );
+        "#,
+    )
+    .context("Failed to migrate schema to v11 (create planets_unknown table)")?;
 
     Ok(())
 }

--- a/src/db/provision.rs
+++ b/src/db/provision.rs
@@ -90,6 +90,19 @@ pub fn create_schema(con: &Connection, enable_fts: bool) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_planets_xy          ON planets(X, Y);
 
         -- =========================
+        -- PLANETS UNKNOWN
+        -- =========================
+        DROP TABLE IF EXISTS planets_unknown;
+
+        CREATE TABLE planets_unknown (
+            fid    INTEGER,
+            planet TEXT,
+            x      REAL,
+            y      REAL,
+            reason TEXT
+        );
+
+        -- =========================
         -- WAYPOINTS (catalog)
         -- =========================
         DROP TABLE IF EXISTS waypoints;
@@ -371,7 +384,7 @@ pub fn insert_all(
     meta_upsert(&tx, "dataset_version", &meta.dataset_version)?;
     meta_upsert(&tx, "importer_version", &meta.importer_version)?;
     meta_upsert(&tx, "fts_enabled", if enable_fts { "1" } else { "0" })?;
-    meta_upsert(&tx, "schema_version", "4")?;
+    meta_upsert(&tx, "schema_version", "11")?;
 
     {
         let mut stmt = tx.prepare(

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -1,7 +1,7 @@
 use crate::db::has_table;
 use crate::model::{
-    AliasRow, NearHit, Planet, PlanetSearchRow, RouteListRow, RoutingObstacleRow, Waypoint,
-    WaypointLinkRow, WaypointListRow, WaypointPlanetLink, WaypointRouteRow,
+    AliasRow, NearHit, Planet, PlanetSearchRow, RouteListRow, RoutingObstacleRow, UnknownPlanet,
+    Waypoint, WaypointLinkRow, WaypointListRow, WaypointPlanetLink, WaypointRouteRow,
 };
 pub(crate) use crate::model::{RouteDetourRow, RouteLoaded, RouteRow, RouteWaypointRow};
 use crate::routing::router::{DetourDecision, Route as ComputedRoute, RouteOptions};
@@ -109,6 +109,28 @@ pub fn find_planet_for_info(con: &Connection, key_norm: &str) -> Result<Option<P
         return Ok(Some(p));
     }
     find_planet_by_alias_norm(con, key_norm)
+}
+
+pub fn get_unknown_planet_by_fid(con: &Connection, fid: i64) -> Result<Option<UnknownPlanet>> {
+    con.query_row(
+        r#"
+        SELECT planet, x, y, reason
+        FROM planets_unknown
+        WHERE fid = ?1
+        LIMIT 1
+        "#,
+        [fid],
+        |r| {
+            Ok(UnknownPlanet {
+                planet: r.get(0)?,
+                x: r.get(1)?,
+                y: r.get(2)?,
+                reason: r.get(3)?,
+            })
+        },
+    )
+    .optional()
+    .context("Failed to query planets_unknown")
 }
 
 pub fn get_aliases(con: &Connection, fid: i64) -> Result<Vec<AliasRow>> {

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -109,6 +109,8 @@ impl NavicomputerApp {
                 let mut planet: Option<String> = None;
                 let mut x: Option<f64> = None;
                 let mut y: Option<f64> = None;
+                let mut unknown = false;
+                let mut fid: Option<i64> = None;
 
                 let mut i = 1usize;
                 while i < tokens.len() {
@@ -120,6 +122,23 @@ impl NavicomputerApp {
                     }
                     if let Some(v) = t.strip_prefix("--planet=") {
                         planet = Some(v.to_string());
+                        i += 1;
+                        continue;
+                    }
+
+                    if t == "--unknown" {
+                        unknown = true;
+                        i += 1;
+                        continue;
+                    }
+
+                    if t == "--fid" && i + 1 < tokens.len() {
+                        fid = tokens[i + 1].parse::<i64>().ok();
+                        i += 2;
+                        continue;
+                    }
+                    if let Some(v) = t.strip_prefix("--fid=") {
+                        fid = v.parse::<i64>().ok();
                         i += 1;
                         continue;
                     }
@@ -149,7 +168,7 @@ impl NavicomputerApp {
                     i += 1;
                 }
 
-                validate::validate_near(&planet, &x, &y)?;
+                validate::validate_near(unknown, &fid, &planet, &x, &y)?;
             }
 
             "search" => {

--- a/src/model.rs
+++ b/src/model.rs
@@ -43,6 +43,14 @@ pub struct NearHit {
 }
 
 #[derive(Debug)]
+pub struct UnknownPlanet {
+    pub planet: Option<String>,
+    pub x: Option<f64>,
+    pub y: Option<f64>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug)]
 pub struct Waypoint {
     pub id: i64,
     pub name: String,


### PR DESCRIPTION
### Motivation
- Allow users to run `near --unknown --fid <fid> --r <radius>` to find planets near an entry that was skipped/marked unknown during ingestion by using the `planets_unknown` table as the search center. 
- Enforce clear CLI rules so `--fid` is only accepted when `--unknown` is used and to prevent mixing incompatible options in both CLI and GUI prevalidation.

### Description
- Add CLI flags and wiring: updated `src/cli/args.rs` to expose `--unknown` and `--fid`, and threaded the new flags through `src/cli/mod.rs` into the command invocation. 
- Add validation and GUI support: changed `src/cli/validate.rs` to validate the new `--unknown`/`--fid` combinations and updated `src/gui/app.rs` prevalidation to understand the new flags. 
- Implement near-by lookup around unknown planets: updated `src/cli/commands/near.rs` to fetch the unknown row via a new query and use its coordinates as the center (with helpful errors if X/Y are missing), while preserving existing `--planet` and `--x/--y` behavior. 
- Database plumbing and persistence: added `UnknownPlanet` model and `get_unknown_planet_by_fid` query in `src/model.rs` and `src/db/queries.rs`, created/initialized the `planets_unknown` table in `src/db/provision.rs` and `src/db/migrate.rs` (schema v11), updated `src/db/db_update.rs` to populate `planets_unknown` during updates, and refactored `src/db/db_skipped_planets.rs` to read from `planets_unknown` and emit pretty JSON.

### Testing
- Ran `cargo fmt --all`, which completed successfully. 
- Ran `cargo clippy --all-targets --all-features -- -D warnings`, which completed successfully and the project compiled as part of the clippy run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983aa8829a48325b6cb6240ae0f1b60)