### PR TITLE
Validate search/near inputs and optimize `normalize_text`

### DIFF
--- a/crates/sw_galaxy_map_core/src/db/queries.rs
+++ b/crates/sw_galaxy_map_core/src/db/queries.rs
@@ -319,6 +319,15 @@ pub fn search_planets(
     query_norm: &str,
     limit: i64,
 ) -> Result<Vec<PlanetSearchRow>> {
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
+
+    let query_norm = query_norm.trim();
+    if query_norm.is_empty() {
+        return Ok(Vec::new());
+    }
+
     if has_table(con, "planets_fts")? {
         return search_planets_fts(con, query_norm, limit);
     }
@@ -405,6 +414,16 @@ fn search_planets_fts(
 }
 
 pub fn near_planets(con: &Connection, x: f64, y: f64, r: f64, limit: i64) -> Result<Vec<NearHit>> {
+    if !x.is_finite() || !y.is_finite() {
+        anyhow::bail!("Center coordinates must be finite numbers");
+    }
+    if !r.is_finite() || r < 0.0 {
+        anyhow::bail!("Radius must be a finite number >= 0");
+    }
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
+
     let r2 = r * r;
 
     let mut stmt = con.prepare(
@@ -446,6 +465,16 @@ pub fn near_planets_excluding_fid(
     r: f64,
     limit: i64,
 ) -> Result<Vec<NearHit>> {
+    if !x.is_finite() || !y.is_finite() {
+        anyhow::bail!("Center coordinates must be finite numbers");
+    }
+    if !r.is_finite() || r < 0.0 {
+        anyhow::bail!("Radius must be a finite number >= 0");
+    }
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
+
     let r2 = r * r;
 
     let mut stmt = con.prepare(
@@ -1621,4 +1650,91 @@ pub fn list_routes(
         .collect::<rusqlite::Result<Vec<_>>>()?;
 
     Ok((rows, total))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{near_planets, near_planets_excluding_fid, search_planets};
+    use rusqlite::Connection;
+
+    fn setup_search_db() -> Connection {
+        let con = Connection::open_in_memory().expect("in-memory sqlite");
+        con.execute_batch(
+            r#"
+            CREATE TABLE planets (
+                FID INTEGER PRIMARY KEY,
+                Planet TEXT NOT NULL,
+                Region TEXT,
+                Sector TEXT,
+                System TEXT,
+                Grid TEXT,
+                X REAL NOT NULL,
+                Y REAL NOT NULL,
+                deleted INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE planet_search (
+                planet_fid INTEGER NOT NULL,
+                search_norm TEXT NOT NULL
+            );
+            INSERT INTO planets (FID, Planet, Region, Sector, System, Grid, X, Y, deleted) VALUES
+                (1, 'Alderaan', 'Core Worlds', 'Alderaan', 'Alderaan', 'L-4', 10.0, 10.0, 0),
+                (2, 'Tatooine', 'Outer Rim', 'Arkanis', 'Tatoo', 'R-16', 20.0, 25.0, 0),
+                (3, 'Deleted', 'Unknown', NULL, NULL, NULL, 50.0, 50.0, 1);
+            INSERT INTO planet_search (planet_fid, search_norm) VALUES
+                (1, 'alderaan house organa'),
+                (2, 'tatooine luke skywalker'),
+                (3, 'deleted hidden');
+            "#,
+        )
+        .expect("schema setup");
+        con
+    }
+
+    #[test]
+    fn search_planets_ignores_empty_query_and_non_positive_limit() {
+        let con = setup_search_db();
+
+        assert!(
+            search_planets(&con, "", 10)
+                .expect("empty query")
+                .is_empty()
+        );
+        assert!(
+            search_planets(&con, "   ", 10)
+                .expect("blank query")
+                .is_empty()
+        );
+        assert!(
+            search_planets(&con, "alderaan", 0)
+                .expect("zero limit")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn near_planets_validates_inputs_and_filters_results() {
+        let con = setup_search_db();
+
+        let rows = near_planets(&con, 9.0, 9.0, 2.0, 10).expect("near query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].planet, "Alderaan");
+
+        assert!(near_planets(&con, 0.0, 0.0, -1.0, 10).is_err());
+        assert!(near_planets(&con, f64::NAN, 0.0, 1.0, 10).is_err());
+        assert!(
+            near_planets(&con, 0.0, 0.0, 1.0, 0)
+                .expect("zero limit")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn near_planets_excluding_fid_excludes_origin_planet() {
+        let con = setup_search_db();
+
+        let rows =
+            near_planets_excluding_fid(&con, 1, 10.0, 10.0, 30.0, 10).expect("excluding fid");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].planet, "Tatooine");
+    }
 }

--- a/crates/sw_galaxy_map_core/src/utils/normalize.rs
+++ b/crates/sw_galaxy_map_core/src/utils/normalize.rs
@@ -1,6 +1,17 @@
 use regex::Regex;
+use std::sync::OnceLock;
 use unicode_normalization::UnicodeNormalization;
 use unicode_normalization::char::is_combining_mark;
+
+fn non_alnum_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"[^a-z0-9]+").expect("invalid non-alnum regex"))
+}
+
+fn spaces_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\s+").expect("invalid spaces regex"))
+}
 
 pub fn normalize_text(input: &str) -> String {
     let lower = input.trim().to_lowercase();
@@ -8,11 +19,26 @@ pub fn normalize_text(input: &str) -> String {
     // NFKD + rimozione combining marks
     let no_diacritics: String = lower.nfkd().filter(|c| !is_combining_mark(*c)).collect();
 
-    // Solo a-z0-9 -> spazio, collassa spazi
-    // Nota: regex compilata a ogni chiamata; per performance si può usare lazy_static/once_cell.
-    let re_non_alnum = Regex::new(r"[^a-z0-9]+").unwrap();
-    let tmp = re_non_alnum.replace_all(&no_diacritics, " ");
+    // Solo a-z0-9 -> spazio, collassa spazi.
+    let tmp = non_alnum_regex().replace_all(&no_diacritics, " ");
 
-    let re_spaces = Regex::new(r"\s+").unwrap();
-    re_spaces.replace_all(tmp.trim(), " ").to_string()
+    spaces_regex().replace_all(tmp.trim(), " ").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_text;
+
+    #[test]
+    fn normalize_text_removes_diacritics_and_extra_separators() {
+        assert_eq!(
+            normalize_text("  Tàtôôïne -- Outer   Rim "),
+            "tatooine outer rim"
+        );
+    }
+
+    #[test]
+    fn normalize_text_returns_empty_string_for_punctuation_only_input() {
+        assert_eq!(normalize_text("  --__...  "), "");
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent invalid or useless SQL queries and runtime errors caused by empty/whitespace search terms, non-positive limits, or non-finite coordinates passed to proximity queries.
- Improve performance and allocation churn in text normalization by avoiding recompiling regexes on every call.
- Add regression tests that capture these edge cases so they do not regress.

### Description
- Cache the normalization regexes used by `normalize_text` via `OnceLock` to avoid recompiling `Regex` on each call and keep behavior identical; changed file `crates/sw_galaxy_map_core/src/utils/normalize.rs` and added unit tests for diacritics/empty-punctuation inputs.
- Guard `search_planets` to return early for `limit <= 0` and for empty/whitespace `query_norm`, preventing pointless fallback LIKE or FTS queries; changed file `crates/sw_galaxy_map_core/src/db/queries.rs`.
- Validate inputs for `near_planets` and `near_planets_excluding_fid` to ensure coordinates are finite, radius is finite and non-negative, and `limit > 0`, returning errors or empty results accordingly; changed file `crates/sw_galaxy_map_core/src/db/queries.rs`.
- Add in-memory SQLite unit tests covering the new edge-cases and behavior (search blank queries, near validation, and excluding origin FID), located in `crates/sw_galaxy_map_core/src/db/queries.rs` test module.

### Testing
- Ran formatting with `cargo fmt --all` and it completed successfully.
- Ran the test suite with `cargo test` and all unit tests (including newly added regression tests) passed.
- Ran static checks with `cargo clippy -p sw_galaxy_map_core --all-targets -- -D warnings` with no warnings or errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd92752ce88325b35f5179e416b002)