### PR TITLE
Add `unknown edit` CLI + backend update support, validations, normalize caching, tests, bump to 0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,7 +3466,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sw_galaxy_map_cli"
-version = "0.9.6"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "atty",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "sw_galaxy_map_core"
-version = "0.9.6"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "atty",
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "sw_galaxy_map_gui"
-version = "0.9.6"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.6"
+version = "0.9.9"
 edition = "2024"
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]
 description = "Star Wars galaxy explorer and navicomputer with CLI and GUI interfaces, backed by a local SQLite database"

--- a/crates/sw_galaxy_map_cli/README.md
+++ b/crates/sw_galaxy_map_cli/README.md
@@ -60,9 +60,10 @@ cargo run -p sw_galaxy_map_cli -- unknown search 42 --near 1500
 cargo run -p sw_galaxy_map_cli -- unknown list
 cargo run -p sw_galaxy_map_cli -- unknown list --page 2
 cargo run -p sw_galaxy_map_cli -- unknown list --page 2 --page-size 50
+cargo run -p sw_galaxy_map_cli -- unknown edit 42 --planet "Ord Mantell" --region "Mid Rim" --canon true --legend false --reviewed true --notes "manual review"
 ```
 
-`unknown list` now shows the internal unknown `ID` together with the source `FID`, making the table ready for future commands such as `unknown show <id>` and `unknown edit <id>`.
+`unknown list` now shows the internal unknown `ID` together with the source `FID`, and `unknown edit <id>` can update the staging fields directly from a single CLI command.
 
 ---
 

--- a/crates/sw_galaxy_map_cli/src/cli/args.rs
+++ b/crates/sw_galaxy_map_cli/src/cli/args.rs
@@ -182,6 +182,56 @@ pub enum UnknownCmd {
         #[arg(long, default_value_t = 20)]
         limit: i64,
     },
+
+    /// Edit an unknown planet record in `planets_unknown`
+    Edit {
+        /// Internal unknown record ID
+        id: i64,
+
+        /// Planet name
+        #[arg(long)]
+        planet: Option<String>,
+
+        /// Region
+        #[arg(long)]
+        region: Option<String>,
+
+        /// Sector
+        #[arg(long)]
+        sector: Option<String>,
+
+        /// System
+        #[arg(long)]
+        system: Option<String>,
+
+        /// Grid
+        #[arg(long)]
+        grid: Option<String>,
+
+        /// Canon flag (true/false)
+        #[arg(long)]
+        canon: Option<bool>,
+
+        /// Legends flag (true/false)
+        #[arg(long)]
+        legend: Option<bool>,
+
+        /// Canonical region
+        #[arg(long = "cregion")]
+        c_region: Option<String>,
+
+        /// Canonical region (long label)
+        #[arg(long = "cregion-li")]
+        c_region_li: Option<String>,
+
+        /// Reviewed flag (true/false)
+        #[arg(long)]
+        reviewed: Option<bool>,
+
+        /// Free-form notes
+        #[arg(long)]
+        notes: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/sw_galaxy_map_cli/src/cli/commands/unknown.rs
+++ b/crates/sw_galaxy_map_cli/src/cli/commands/unknown.rs
@@ -1,9 +1,10 @@
 use crate::cli::args::UnknownCmd;
-use crate::ui::{info, warning};
+use crate::ui::{info, success, warning};
 use anyhow::Result;
 use rusqlite::Connection;
 use sw_galaxy_map_core::db::queries::{
-    count_unknown_planets, list_unknown_planets_paginated, near_planets_for_unknown_id,
+    UnknownPlanetUpdate, count_unknown_planets, list_unknown_planets_paginated,
+    near_planets_for_unknown_id, update_unknown_planet,
 };
 use sw_galaxy_map_core::validate;
 
@@ -82,6 +83,34 @@ pub fn run(con: &Connection, cmd: &UnknownCmd) -> Result<()> {
             Ok(())
         }
         UnknownCmd::Search { id, near, limit } => run_search(con, *id, *near, *limit),
+        UnknownCmd::Edit {
+            id,
+            planet,
+            region,
+            sector,
+            system,
+            grid,
+            canon,
+            legend,
+            c_region,
+            c_region_li,
+            reviewed,
+            notes,
+        } => run_edit(
+            con,
+            *id,
+            planet.as_deref(),
+            region.as_deref(),
+            sector.as_deref(),
+            system.as_deref(),
+            grid.as_deref(),
+            *canon,
+            *legend,
+            c_region.as_deref(),
+            c_region_li.as_deref(),
+            *reviewed,
+            notes.as_deref(),
+        ),
     }
 }
 
@@ -163,6 +192,88 @@ fn run_search(con: &Connection, id: i64, near: f64, limit: i64) -> Result<()> {
             d = format!("{:.3}", row.distance),
         );
     }
+
+    Ok(())
+}
+
+fn optional_text_update(value: Option<&str>) -> Option<Option<String>> {
+    value.map(|raw| {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_edit(
+    con: &Connection,
+    id: i64,
+    planet: Option<&str>,
+    region: Option<&str>,
+    sector: Option<&str>,
+    system: Option<&str>,
+    grid: Option<&str>,
+    canon: Option<bool>,
+    legend: Option<bool>,
+    c_region: Option<&str>,
+    c_region_li: Option<&str>,
+    reviewed: Option<bool>,
+    notes: Option<&str>,
+) -> Result<()> {
+    let planet = planet.map(str::trim);
+    if matches!(planet, Some("")) {
+        anyhow::bail!("--planet cannot be empty");
+    }
+
+    let update = UnknownPlanetUpdate {
+        planet: planet.map(str::to_string),
+        region: optional_text_update(region),
+        sector: optional_text_update(sector),
+        system: optional_text_update(system),
+        grid: optional_text_update(grid),
+        canon: canon.map(|v| Some(i64::from(v))),
+        legends: legend.map(|v| Some(i64::from(v))),
+        c_region: optional_text_update(c_region),
+        c_region_li: optional_text_update(c_region_li),
+        reviewed: reviewed.map(i64::from),
+        notes: optional_text_update(notes),
+    };
+
+    let touched = update.planet.is_some()
+        || update.region.is_some()
+        || update.sector.is_some()
+        || update.system.is_some()
+        || update.grid.is_some()
+        || update.canon.is_some()
+        || update.legends.is_some()
+        || update.c_region.is_some()
+        || update.c_region_li.is_some()
+        || update.reviewed.is_some()
+        || update.notes.is_some();
+
+    if !touched {
+        anyhow::bail!("No changes requested. Pass at least one edit flag.");
+    }
+
+    let updated = update_unknown_planet(con, id, &update)?;
+
+    success(format!(
+        "Unknown planet #{} updated: planet='{}', reviewed={}, canon={}, legends={}",
+        updated.id,
+        updated.planet,
+        updated.reviewed,
+        updated
+            .canon
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        updated
+            .legends
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+    ));
 
     Ok(())
 }

--- a/crates/sw_galaxy_map_cli/src/cli/mod.rs
+++ b/crates/sw_galaxy_map_cli/src/cli/mod.rs
@@ -365,6 +365,7 @@ fn run_interactive_shell(db_arg: Option<String>) -> Result<()> {
             println!("  route show 42");
             println!("  unknown list");
             println!("  unknown search <id> --near <parsecs>");
+            println!("  unknown edit <id> --planet <name> --region <region>");
             println!("Or REPL help: :help\n");
             continue;
         }

--- a/crates/sw_galaxy_map_core/src/db/queries.rs
+++ b/crates/sw_galaxy_map_core/src/db/queries.rs
@@ -292,6 +292,92 @@ pub fn near_planets_for_unknown_id(
     Ok((unknown, rows))
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct UnknownPlanetUpdate {
+    pub planet: Option<String>,
+    pub region: Option<Option<String>>,
+    pub sector: Option<Option<String>>,
+    pub system: Option<Option<String>>,
+    pub grid: Option<Option<String>>,
+    pub canon: Option<Option<i64>>,
+    pub legends: Option<Option<i64>>,
+    pub c_region: Option<Option<String>>,
+    pub c_region_li: Option<Option<String>>,
+    pub reviewed: Option<i64>,
+    pub notes: Option<Option<String>>,
+}
+
+pub fn update_unknown_planet(
+    con: &Connection,
+    id: i64,
+    update: &UnknownPlanetUpdate,
+) -> Result<UnknownPlanet> {
+    let Some(current) = get_unknown_planet_by_id(con, id)? else {
+        anyhow::bail!("No unknown planet found for id {}", id);
+    };
+
+    let planet = update
+        .planet
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| current.planet.clone());
+    let planet_norm = planet.to_lowercase();
+
+    let region = update.region.clone().unwrap_or(current.region.clone());
+    let sector = update.sector.clone().unwrap_or(current.sector.clone());
+    let system = update.system.clone().unwrap_or(current.system.clone());
+    let grid = update.grid.clone().unwrap_or(current.grid.clone());
+    let canon = update.canon.unwrap_or(current.canon);
+    let legends = update.legends.unwrap_or(current.legends);
+    let c_region = update.c_region.clone().unwrap_or(current.c_region.clone());
+    let c_region_li = update
+        .c_region_li
+        .clone()
+        .unwrap_or(current.c_region_li.clone());
+    let reviewed = update.reviewed.unwrap_or(current.reviewed);
+    let notes = update.notes.clone().unwrap_or(current.notes.clone());
+
+    con.execute(
+        r#"
+        UPDATE planets_unknown
+        SET planet = ?2,
+            planet_norm = ?3,
+            region = ?4,
+            sector = ?5,
+            system = ?6,
+            grid = ?7,
+            canon = ?8,
+            legends = ?9,
+            cregion = ?10,
+            cregion_li = ?11,
+            reviewed = ?12,
+            notes = ?13
+        WHERE id = ?1
+        "#,
+        params![
+            id,
+            planet,
+            planet_norm,
+            region,
+            sector,
+            system,
+            grid,
+            canon,
+            legends,
+            c_region,
+            c_region_li,
+            reviewed,
+            notes,
+        ],
+    )
+    .with_context(|| format!("Failed to update planets_unknown record id={id}"))?;
+
+    get_unknown_planet_by_id(con, id)?
+        .ok_or_else(|| anyhow::anyhow!("Unknown planet disappeared after update: id={id}"))
+}
+
 pub fn get_aliases(con: &Connection, fid: i64) -> Result<Vec<AliasRow>> {
     let mut stmt = con.prepare(
         r#"
@@ -319,6 +405,15 @@ pub fn search_planets(
     query_norm: &str,
     limit: i64,
 ) -> Result<Vec<PlanetSearchRow>> {
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
+
+    let query_norm = query_norm.trim();
+    if query_norm.is_empty() {
+        return Ok(Vec::new());
+    }
+
     if has_table(con, "planets_fts")? {
         return search_planets_fts(con, query_norm, limit);
     }
@@ -405,6 +500,16 @@ fn search_planets_fts(
 }
 
 pub fn near_planets(con: &Connection, x: f64, y: f64, r: f64, limit: i64) -> Result<Vec<NearHit>> {
+    if !x.is_finite() || !y.is_finite() {
+        anyhow::bail!("Center coordinates must be finite numbers");
+    }
+    if !r.is_finite() || r < 0.0 {
+        anyhow::bail!("Radius must be a finite number >= 0");
+    }
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
+
     let r2 = r * r;
 
     let mut stmt = con.prepare(
@@ -446,6 +551,16 @@ pub fn near_planets_excluding_fid(
     r: f64,
     limit: i64,
 ) -> Result<Vec<NearHit>> {
+    if !x.is_finite() || !y.is_finite() {
+        anyhow::bail!("Center coordinates must be finite numbers");
+    }
+    if !r.is_finite() || r < 0.0 {
+        anyhow::bail!("Radius must be a finite number >= 0");
+    }
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
+
     let r2 = r * r;
 
     let mut stmt = con.prepare(
@@ -1621,4 +1736,178 @@ pub fn list_routes(
         .collect::<rusqlite::Result<Vec<_>>>()?;
 
     Ok((rows, total))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        UnknownPlanetUpdate, near_planets, near_planets_excluding_fid, search_planets,
+        update_unknown_planet,
+    };
+    use rusqlite::Connection;
+
+    fn setup_search_db() -> Connection {
+        let con = Connection::open_in_memory().expect("in-memory sqlite");
+        con.execute_batch(
+            r#"
+            CREATE TABLE planets (
+                FID INTEGER PRIMARY KEY,
+                Planet TEXT NOT NULL,
+                Region TEXT,
+                Sector TEXT,
+                System TEXT,
+                Grid TEXT,
+                X REAL NOT NULL,
+                Y REAL NOT NULL,
+                deleted INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE planet_search (
+                planet_fid INTEGER NOT NULL,
+                search_norm TEXT NOT NULL
+            );
+            INSERT INTO planets (FID, Planet, Region, Sector, System, Grid, X, Y, deleted) VALUES
+                (1, 'Alderaan', 'Core Worlds', 'Alderaan', 'Alderaan', 'L-4', 10.0, 10.0, 0),
+                (2, 'Tatooine', 'Outer Rim', 'Arkanis', 'Tatoo', 'R-16', 20.0, 25.0, 0),
+                (3, 'Deleted', 'Unknown', NULL, NULL, NULL, 50.0, 50.0, 1);
+            INSERT INTO planet_search (planet_fid, search_norm) VALUES
+                (1, 'alderaan house organa'),
+                (2, 'tatooine luke skywalker'),
+                (3, 'deleted hidden');
+            "#,
+        )
+        .expect("schema setup");
+        con
+    }
+
+    fn setup_unknown_db() -> Connection {
+        let con = Connection::open_in_memory().expect("in-memory sqlite");
+        con.execute_batch(
+            r#"
+            CREATE TABLE planets_unknown (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                fid         INTEGER,
+                planet      TEXT NOT NULL,
+                planet_norm TEXT NOT NULL,
+                region      TEXT,
+                sector      TEXT,
+                system      TEXT,
+                grid        TEXT,
+                x           REAL,
+                y           REAL,
+                arcgis_hash TEXT,
+                deleted     INTEGER NOT NULL DEFAULT 0,
+                canon       INTEGER,
+                legends     INTEGER,
+                zm          INTEGER,
+                name0       TEXT,
+                name1       TEXT,
+                name2       TEXT,
+                lat         REAL,
+                long        REAL,
+                ref         TEXT,
+                status      TEXT,
+                cregion     TEXT,
+                cregion_li  TEXT,
+                reason      TEXT,
+                reviewed    INTEGER NOT NULL DEFAULT 0,
+                promoted    INTEGER NOT NULL DEFAULT 0,
+                notes       TEXT
+            );
+            INSERT INTO planets_unknown (
+                id, fid, planet, planet_norm, region, sector, system, grid, x, y, canon,
+                legends, cregion, cregion_li, reviewed, promoted, notes
+            ) VALUES (
+                7, 1007, 'TBD World', 'tbd world', 'Unknown Regions', 'Sector A',
+                'System A', 'A-1', 1.0, 2.0, NULL, NULL, NULL, NULL, 0, 0, 'draft'
+            );
+            "#,
+        )
+        .expect("unknown schema setup");
+        con
+    }
+
+    #[test]
+    fn search_planets_ignores_empty_query_and_non_positive_limit() {
+        let con = setup_search_db();
+
+        assert!(
+            search_planets(&con, "", 10)
+                .expect("empty query")
+                .is_empty()
+        );
+        assert!(
+            search_planets(&con, "   ", 10)
+                .expect("blank query")
+                .is_empty()
+        );
+        assert!(
+            search_planets(&con, "alderaan", 0)
+                .expect("zero limit")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn near_planets_validates_inputs_and_filters_results() {
+        let con = setup_search_db();
+
+        let rows = near_planets(&con, 9.0, 9.0, 2.0, 10).expect("near query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].planet, "Alderaan");
+
+        assert!(near_planets(&con, 0.0, 0.0, -1.0, 10).is_err());
+        assert!(near_planets(&con, f64::NAN, 0.0, 1.0, 10).is_err());
+        assert!(
+            near_planets(&con, 0.0, 0.0, 1.0, 0)
+                .expect("zero limit")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn near_planets_excluding_fid_excludes_origin_planet() {
+        let con = setup_search_db();
+
+        let rows =
+            near_planets_excluding_fid(&con, 1, 10.0, 10.0, 30.0, 10).expect("excluding fid");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].planet, "Tatooine");
+    }
+
+    #[test]
+    fn update_unknown_planet_updates_requested_fields_and_planet_norm() {
+        let con = setup_unknown_db();
+
+        let updated = update_unknown_planet(
+            &con,
+            7,
+            &UnknownPlanetUpdate {
+                planet: Some("Ord Mantell".to_string()),
+                region: Some(Some("Mid Rim".to_string())),
+                sector: Some(None),
+                system: Some(Some("Bright Jewel".to_string())),
+                grid: Some(Some("M-12".to_string())),
+                canon: Some(Some(1)),
+                legends: Some(Some(0)),
+                c_region: Some(Some("Mid Rim".to_string())),
+                c_region_li: Some(Some("Mid Rim Territories".to_string())),
+                reviewed: Some(1),
+                notes: Some(Some("verified manually".to_string())),
+            },
+        )
+        .expect("update succeeds");
+
+        assert_eq!(updated.planet, "Ord Mantell");
+        assert_eq!(updated.planet_norm, "ord mantell");
+        assert_eq!(updated.region.as_deref(), Some("Mid Rim"));
+        assert_eq!(updated.sector, None);
+        assert_eq!(updated.system.as_deref(), Some("Bright Jewel"));
+        assert_eq!(updated.grid.as_deref(), Some("M-12"));
+        assert_eq!(updated.canon, Some(1));
+        assert_eq!(updated.legends, Some(0));
+        assert_eq!(updated.c_region.as_deref(), Some("Mid Rim"));
+        assert_eq!(updated.c_region_li.as_deref(), Some("Mid Rim Territories"));
+        assert_eq!(updated.reviewed, 1);
+        assert_eq!(updated.notes.as_deref(), Some("verified manually"));
+    }
 }

--- a/crates/sw_galaxy_map_core/src/utils/normalize.rs
+++ b/crates/sw_galaxy_map_core/src/utils/normalize.rs
@@ -1,6 +1,17 @@
 use regex::Regex;
+use std::sync::OnceLock;
 use unicode_normalization::UnicodeNormalization;
 use unicode_normalization::char::is_combining_mark;
+
+fn non_alnum_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"[^a-z0-9]+").expect("invalid non-alnum regex"))
+}
+
+fn spaces_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\s+").expect("invalid spaces regex"))
+}
 
 pub fn normalize_text(input: &str) -> String {
     let lower = input.trim().to_lowercase();
@@ -8,11 +19,26 @@ pub fn normalize_text(input: &str) -> String {
     // NFKD + rimozione combining marks
     let no_diacritics: String = lower.nfkd().filter(|c| !is_combining_mark(*c)).collect();
 
-    // Solo a-z0-9 -> spazio, collassa spazi
-    // Nota: regex compilata a ogni chiamata; per performance si può usare lazy_static/once_cell.
-    let re_non_alnum = Regex::new(r"[^a-z0-9]+").unwrap();
-    let tmp = re_non_alnum.replace_all(&no_diacritics, " ");
+    // Solo a-z0-9 -> spazio, collassa spazi.
+    let tmp = non_alnum_regex().replace_all(&no_diacritics, " ");
 
-    let re_spaces = Regex::new(r"\s+").unwrap();
-    re_spaces.replace_all(tmp.trim(), " ").to_string()
+    spaces_regex().replace_all(tmp.trim(), " ").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_text;
+
+    #[test]
+    fn normalize_text_removes_diacritics_and_extra_separators() {
+        assert_eq!(
+            normalize_text("  Tàtôôïne -- Outer   Rim "),
+            "tatooine outer rim"
+        );
+    }
+
+    #[test]
+    fn normalize_text_returns_empty_string_for_punctuation_only_input() {
+        assert_eq!(normalize_text("  --__...  "), "");
+    }
 }


### PR DESCRIPTION
### Motivation

- Provide a way to edit staging `planets_unknown` records from the CLI so unknowns can be reviewed and promoted without manual DB access.
- Harden proximity and search helpers with input validation to avoid invalid queries and unexpected results.
- Improve `normalize_text` performance by reusing compiled regexes and add coverage for normalization edge cases.

### Description

- Added an `UnknownCmd::Edit` variant in the CLI args (`crates/sw_galaxy_map_cli/src/cli/args.rs`) with flags for editable fields and workflow flags. 
- Implemented `run_edit` in `crates/sw_galaxy_map_cli/src/cli/commands/unknown.rs`, including `optional_text_update` helper, validation for empty `--planet`, change detection, and a success message; wired the command into the main `run` dispatcher and REPL help.
- Introduced `UnknownPlanetUpdate` and `update_unknown_planet` in `crates/sw_galaxy_map_core/src/db/queries.rs` to apply partial updates, compute `planet_norm`, and persist changes to `planets_unknown`.
- Added input validation to `search_planets`, `near_planets`, and `near_planets_excluding_fid` to handle empty queries, non-finite coordinates, negative radii, and non-positive limits.
- Rewrote `normalize_text` in `crates/sw_galaxy_map_core/src/utils/normalize.rs` to cache compiled `Regex` objects with `OnceLock` and added tests for normalization behavior.
- Updated README (`crates/sw_galaxy_map_cli/README.md`) to document the new `unknown edit` workflow and sample usage, and bumped workspace/package version from `0.9.6` to `0.9.9` in `Cargo.toml` and `Cargo.lock`.
- Adjusted imports to use `success` UI helper when printing updates.
- Added unit tests in `crates/sw_galaxy_map_core/src/db/queries.rs` covering `search_planets` guards, `near_planets` validation, `near_planets_excluding_fid` behavior, and `update_unknown_planet` semantics.

### Testing

- Ran unit tests with `cargo test` and all added and existing tests passed successfully. 
- Exercised `update_unknown_planet` via the new unit test which verifies field updates and `planet_norm` computation and it succeeded. 
- Exercised proximity and search guards via unit tests and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd92752ce88325b35f5179e416b002)