### PR TITLE
feat(unknown): add near command for unknown planets around a known pl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.9.10] - 2026-03-21
+
+### Added
+
+- Added `unknown near <planet> --range <parsecs>` command to find unknown planets near a known planet
+- Implemented proximity search from `planets.X` / `planets.Y` to `planets_unknown`
+- Added distance-sorted output for nearby unknown planets
+- Added optional result limiting for nearby unknown planet search
+
+### Improved
+
+- Excluded unknown records without coordinates from proximity search
+- Reused robust squared-distance SQL filtering for spatial lookup
+- Improved interoperability between known-planet search and unknown-planet inspection workflows
+
+### Fixed
+
+- Fixed result collection type mismatch in unknown-near query handling
+
+---
+
 ## [0.9.9] - 2026-03-21
 
 ### ✨ Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,7 +3466,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sw_galaxy_map_cli"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "atty",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "sw_galaxy_map_core"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "atty",
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "sw_galaxy_map_gui"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.9"
+version = "0.9.10"
 edition = "2024"
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]
 description = "Star Wars galaxy explorer and navicomputer with CLI and GUI interfaces, backed by a local SQLite database"

--- a/README.md
+++ b/README.md
@@ -1,413 +1,224 @@
 # sw_galaxy_map
 
-**sw_galaxy_map** is a Rust workspace for exploring the Star Wars galaxy using a local SQLite database, with both CLI and GUI frontends.
+**sw_galaxy_map** is a Rust workspace for exploring the Star Wars galaxy using a local SQLite database, with both CLI
+and GUI frontends.
 
 The application provides tools to:
 
-- search for planets by name or alias,
-- display all available information about a specific planet,
-- find nearby planets within a given radius using Euclidean distance
-  on X/Y coordinates expressed in parsecs.
+* search for planets by name or alias,
+* display detailed information about a planet,
+* find nearby planets using Euclidean distance on X/Y coordinates (parsecs),
+* inspect and manage **unknown (unclassified) planets**,
+* compute hyperspace routes avoiding planetary obstacles.
 
-The project is designed to work offline once the database is available and remains intended primarily for educational and non-commercial use.
+The project is designed to work **offline** once the database is available and is intended for educational and
+non-commercial use.
 
 ---
 
+## Workspace layout (0.9.x)
 
-## Workspace layout in 0.9.x
+The project is organized as a Cargo workspace:
 
-Starting with the 0.9.0 migration, the project is organized as a Cargo workspace with three crates:
+* `sw_galaxy_map_core` — domain logic, routing engine, SQLite access
+* `sw_galaxy_map_cli` — command-line interface
+* `sw_galaxy_map_gui` — egui/eframe graphical interface
 
-- `sw_galaxy_map_core` — shared domain logic, routing, SQLite access, validation, and utilities
-- `sw_galaxy_map_cli` — command-line interface and interactive shell
-- `sw_galaxy_map_gui` — egui/eframe graphical interface
-
-### Running each frontend explicitly
-
-Use the CLI crate when you want terminal-only behavior:
+### Run CLI
 
 ```bash
 cargo run -p sw_galaxy_map_cli
 ```
 
-Use the GUI crate when you want the graphical interface:
+### Run GUI
 
 ```bash
 cargo run -p sw_galaxy_map_gui
 ```
 
-The two frontends are now fully separated:
+---
 
-- `cargo run -p sw_galaxy_map_cli` starts only the CLI
-- `cargo run -p sw_galaxy_map_gui` starts only the GUI
+# 🔎 Planet search
 
-## Unknown planets staging workflow
-
-Version `0.9.6` evolves `planets_unknown` from a minimal skipped-rows bucket into a staging table aligned with the main `planets` schema.
-
-The table now includes:
-
-- an internal `id` primary key for stable editing workflows,
-- `planet_norm` for normalized matching,
-- structural fields mirroring `planets` (`region`, `sector`, `system`, `grid`, `canon`, `legends`, `status`, `ref`, ...),
-- workflow flags such as `reviewed` and `promoted`,
-- free-form `notes` for future manual curation.
-
-Current CLI support includes:
+Search planets by name or alias:
 
 ```bash
-cargo run -p sw_galaxy_map_cli -- unknown search 42 --near 1500
-cargo run -p sw_galaxy_map_cli -- unknown list
-cargo run -p sw_galaxy_map_cli -- unknown list --page 2
-cargo run -p sw_galaxy_map_cli -- unknown list --page 2 --page-size 50
+sw_galaxy_map search tatooine
 ```
 
-`unknown list` now shows the internal unknown `ID` together with the source `FID`, making the table ready for future commands such as `unknown show <id>` and `unknown edit <id>`.
+Output includes **coordinates (X/Y)**:
+
+```text
+FID      Planet            Region        Sector         System         Grid     X        Y
+--------------------------------------------------------------------------------------------
+1234     Tatooine          Outer Rim     Arkanis        Tatoo          R-16     1040.12  -333.45
+```
+
+---
+
+# 🧪 Unknown planets workflow
+
+## Overview
+
+Starting from **v0.9.6**, `planets_unknown` is no longer a simple dump of skipped rows, but a **staging table** aligned
+with `planets`.
+
+It is used to:
+
+* inspect incomplete or malformed data
+* manually review and classify entries
+* support future editing/promoting workflows
+
+## Table features
+
+* internal `id` (stable primary key)
+* nullable `fid`, `x`, `y`
+* normalized name (`planet_norm`)
+* structural fields (region, sector, system, etc.)
+* workflow flags:
+
+    * `reviewed`
+    * `promoted`
+* `reason` describing why the row was skipped
+* `notes` for manual annotations
+
+---
+
+## Commands
+
+### List unknown planets
+
+```bash
+sw_galaxy_map unknown list
+sw_galaxy_map unknown list --page 2
+sw_galaxy_map unknown list --page 2 --page-size 50
+```
+
+Features:
+
+* pagination
+* stable internal IDs
+* safe handling of NULL values
+
+---
+
+### Search nearby known planets from an unknown
+
+```bash
+sw_galaxy_map unknown search <id> --near 1500
+```
+
+Uses unknown coordinates → finds nearby known planets.
+
+Fails gracefully if coordinates are missing.
+
+---
+
+### NEW (v0.9.10): Find unknown near a known planet
+
+```bash
+sw_galaxy_map unknown near tatooine --range 1500
+```
+
+Finds unknown planets within a radius from a known planet.
+
+Features:
+
+* uses `planets.X` / `planets.Y`
+* excludes unknown entries without coordinates
+* sorted by distance
+* shows reason and workflow status
+
+Example:
+
+```text
+Unknown planets near Tatooine (X=1040.12, Y=-333.45) within 1500 parsecs
+
+#  12 | fid=9981   | Unknown System Alpha | x=  999.23 | y= -210.88 | dist=145.77 | reason=missing_region
+#  43 | fid=-      | (unknown)            | x= 1102.01 | y= -412.09 | dist= 98.43 | reason=missing_fid
+```
+
+---
+
+# 🗄️ Database lifecycle
+
+## Initialization
+
+```bash
+sw_galaxy_map db init
+```
+
+Now correctly:
+
+* creates full schema (including routes & waypoints)
+* populates both:
+
+    * `planets`
+    * `planets_unknown`
+
+## Update
+
+```bash
+sw_galaxy_map db update
+```
+
+Features:
+
+* incremental sync (no full rebuild)
+* preserves `planets_unknown.id`
+* stable CLI references
+
+---
+
+# 🧭 Routing engine
+
+The routing engine computes hyperspace paths avoiding planetary obstacles.
+
+## Key concepts
+
+* planets = circular obstacles
+* routes = polylines
+* detours = dynamically generated waypoints
+
+---
+
+## Route command
+
+```bash
+sw_galaxy_map route compute tatooine dathomir
+```
+
+---
+
+# 🧷 Waypoints & fingerprinting
+
+Computed waypoints are deduplicated using a **fingerprint**:
+
+* ensures reuse across routes
+* prevents duplicate inserts
+* enables caching
+
+---
+
+# 🗃️ Persistence model
+
+Main tables:
+
+* `planets`
+* `planets_unknown`
+* `waypoints`
+* `routes`
+* `route_waypoints`
+* `route_detours`
 
 ---
 
 ## Acknowledgements
 
-The planetary data used by this project were obtained from the **Star Wars Galaxy Map**
-available at:
+The planetary data used by this project were obtained from the **Star Wars Galaxy Map**:
 
-[Star Wars Galaxy Map](http://www.swgalaxymap.com/): Explore the Galaxy Far, Far Away
+[http://www.swgalaxymap.com/](http://www.swgalaxymap.com/)
 
-The Star Wars Galaxy Map project is created and maintained by **Henry Bernberg**.
-All credit for the original dataset, research, and compilation goes to him.
+Created and maintained by **Henry Bernberg**.
 
-If you find this data valuable, please consider supporting the original author via one
-of the official donation channels:
-
-- [Ko-fi](https://ko-fi.com/J3J0197XZ)
-- [PayPal](https://www.paypal.com/donate?token=rk-LV-u5miGM2sumnvRL5ZiAFjnwIhhLnsSe-mqEnFgDAmeIhBkG6CQamxUxUoR18iwI0mA8h5ruuIk_)
-
-This project uses the data for **educational and non-commercial purposes** only and
-is not affiliated with, endorsed by, or associated with the Star Wars Galaxy Map
-website, Lucasfilm, or The Walt Disney Company.
-
----
-
-## 🧭 Route computation & detour waypoints
-
-The routing engine computes hyperspace routes between two planets using a 2D galactic map (X/Y coordinates in parsecs).
-The ideal route is a straight line between the origin and the destination; however, planets generate **hyperspace no-fly
-zones** that cannot be crossed.
-
-When a route intersects one or more of these zones, the engine dynamically inserts **detour waypoints** to safely bypass
-the obstacle.
-
-### 🌌 Planet obstacles model
-
-- Each planet is treated as a **circular obstacle** in the galactic plane.
-- The obstacle radius is defined by the `--safety` parameter and represents:
-    - gravitational mass shadows
-    - hyperspace shear
-    - interdiction fields
-    - standard astrogation safety margins
-
-- This radius is **not** the physical size of the planet.
-
-### 🔍 Collision detection
-
-For each segment of the current route polyline:
-
-1. The engine computes the **closest point on the segment** to every nearby planet.
-2. If this distance is less than the planet’s safety radius, the segment is considered in **hard collision**.
-3. The first collision along the route (lowest parametric `t`) is resolved before any others.
-
-### 🧩 Detour candidate generation
-
-When a collision is detected on a segment **A** → **B**, the engine generates a set of candidate detour waypoints around
-the collision point **Q**.
-Candidates are placed using different directions to ensure robustness in dense regions:
-
-- **Radial** (**away from planet center**)
-  Strongly preferred: pushes the route directly outside the no-fly zone.
-
-- **Lateral** (**left/right of the segment**)
-  Classic bypass around the obstacle.
-
-- **Forward** / **backward** (**along the route direction**)
-  Useful in clustered systems.
-
-- Diagonal directions
-  Improve chances of escaping complex obstacle layouts.
-
-The distance of each candidate from the collision point is:
-
-```ini
-offset = obstacle_radius + clearance
-```
-
-If no valid candidate is found, the offset is progressively increased using:
-
-```ini
-offset *= offset_growth
-```
-
-This process is repeated up to `max_offset_tries`.
-
-### ⚖️ Candidate evaluation & scoring
-
-Each candidate waypoint **W** is evaluated by splitting the segment into:
-
-- **A** → **W**
-- **W** → **B**
-
-Both segments must be collision-free.
-
-Valid candidates are scored using a weighted cost function:
-
-1. **Base length**
-
-Total path length increase:
-
-```ini
-base = |A→W| + |W→B|
-```
-
-2. **Turn penalty**
-
-Penalizes sharp angles (zig-zag routes):
-
-```ini
-turn = turn_weight × (1 − cosθ)
-```
-
-3. **Backtracking penalty**
-
-Penalizes detours that move backward relative to the overall direction:
-
-```ini
-back = back_weight × max(0, −dot(dir(A→B), dir(A→W)))
-```
-
-4. **Proximity penalty**
-
-Soft penalty for passing close to other planets (even without collision):
-
-- Applies within a configurable warning band:
-  ```ini
-    warning_radius = obstacle_radius + proximity_margin
-  ```
-
-- Grows quadratically as the route approaches the obstacle.
-
-**Total score**
-
-```ini
-total = base + turn + back + proximity
-```
-
-The candidate with the **lowest total score** is selected.
-
-### 🧠 Iterative routing
-
-- The chosen waypoint is inserted into the route.
-- The process restarts from the beginning of the polyline.
-- The algorithm stops when:
-    - no collisions remain, or
-    - max_iters is reached.
-
-Each detour decision (collision, chosen waypoint, score breakdown) is recorded and can be:
-
-- printed in debug output
-- visualized
-- persisted to the database
-
-### ✨ Result
-
-The final route consists of:
-
-- a polyline of waypoints (start, detours, destination)
-- total route length
-- a chronological list of detour decisions explaining why each waypoint exists
-
-This approach produces routes that are:
-
-- safe
-- explainable
-- stable
-- suitable for both CLI usage and future visualization layers
-
----
-
-## 🗄️ Persistence model (SQLite DB design)
-
-The project persists computed routes and generated detour waypoints in the local SQLite database to support:
-
-- caching (avoid recomputing the same route repeatedly)
-- inspection/debugging (`route show`, `route last`)
-- future visualization (map rendering, route replay, analytics)
-- building a growing catalog of navigation waypoints
-
-Routes and waypoints are persisted using the following tables.
-
-### 📍 waypoints
-
-Global waypoint catalog. It contains both:
-
-- **manual waypoints** (user-defined: junctions, buoys, etc.)
-- **computed waypoints** (generated by the router when bypassing obstacles)
-
-Each waypoint is a point in the galactic plane:
-
-| Column        | Type       | Notes                                           |
-|---------------|------------|-------------------------------------------------|
-| `id`          | INTEGER PK | Waypoint identifier                             |
-| `name`        | TEXT       | Human-friendly name                             |
-| `name_norm`   | TEXT       | Normalized name (unique lookup key)             |
-| `x`, `y`      | REAL       | Coordinates in parsecs                          |
-| `kind`        | TEXT       | e.g. `manual`, `junction`, `computed`           |
-| `fingerprint` | TEXT NULL  | **Only for computed** waypoints; used for dedup |
-| `note`        | TEXT NULL  | Optional free text                              |
-| `created_at`  | TEXT       | UTC timestamp                                   |
-| `updated_at`  | TEXT NULL  | UTC timestamp                                   |
-
-**Computed waypoint deduplication** (`fingerprint`)
-Computed waypoints may be generated multiple times across different routes or parameter sets.
-To avoid inserting duplicates, computed waypoints use a stable **fingerprint** (hash/string) that represents the
-generated
-waypoint identity (e.g. geometry + obstacle context + offset model).
-
-When persisting computed waypoints the engine performs an **upsert** keyed by `fingerprint`:
-
-- if a waypoint with the same fingerprint exists → reuse it
-- otherwise → insert a new computed waypoint
-
-This yields a growing, reusable navigation catalog over time.
-
-### 🪐 waypoint_planets
-
-Associates a waypoint with one or more nearby/related planets.
-
-This is useful for:
-
-- “anchor” planets for a waypoint (e.g. “near Corellia”)
-- computed waypoints generated while bypassing specific obstacles
-- future UI/visualization (grouping waypoints around systems)
-
-| Column        | Type                        | Notes                             |
-|---------------|-----------------------------|-----------------------------------|
-| `id`          | INTEGER PK                  | Link identifier                   |
-| `waypoint_id` | INTEGER FK → `waypoints.id` | Waypoint                          |
-| `planet_fid`  | INTEGER FK → `planets.FID`  | Planet                            |
-| `role`        | TEXT                        | e.g. `anchor`, `near`, `obstacle` |
-| `distance`    | REAL NULL                   | Optional distance (parsecs)       |
-| `created_at`  | TEXT                        | UTC timestamp                     |
-
-A waypoint can be linked to multiple planets, and a planet can have multiple related waypoints.
-
-### 🧭 routes
-
-Routes are persisted as “cache entries” between a pair of planets.
-
-**Important design rule**: routes are **unique per origin/destination** pair.
-
-This ensures that:
-
-- running the same route again with different parameters updates the record
-- the database does not accumulate duplicates for the same FROM → TO
-- `route last <from> <to>` is well-defined
-
-| Column            | Type                       | Notes                                                          |
-|-------------------|----------------------------|----------------------------------------------------------------|
-| `id`              | INTEGER PK                 | Route identifier                                               |
-| `from_planet_fid` | INTEGER FK → `planets.FID` | Origin                                                         |
-| `to_planet_fid`   | INTEGER FK → `planets.FID` | Destination                                                    |
-| `algo_version`    | TEXT                       | Router version string (e.g. `router_v1`)                       |
-| `options_json`    | TEXT                       | Serialized options used (`safety`, `clearance`, weights, etc.) |
-| `length`          | REAL NULL                  | Total route length (parsecs)                                   |
-| `iterations`      | INTEGER NULL               | Router iterations                                              |
-| `status`          | TEXT                       | `ok` / `error`                                                 |
-| `error`           | TEXT NULL                  | Error details if status=`error`                                |
-| `created_at`      | TEXT                       | UTC timestamp                                                  |
-| `updated_at`      | TEXT NULL                  | UTC timestamp                                                  |
-
-Uniqueness is enforced by a unique index:
-
-- `(from_planet_fid, to_planet_fid)` is unique
-
-**Upsert semantics**
-
-Recomputing a route performs an **UPSERT**:
-
-- update route metadata (`options_json`, `length`, etc.)
-- update `updated_at`
-- replace route polyline and detour details (see below)
-
-### 🧷 route_waypoints
-
-Stores the final polyline (ordered list of points) for a route.
-
-Each row represents one waypoint in the route, identified by its sequence index (`seq`).
-
-Waypoints may refer to entries in the global waypoint catalog (`waypoints.id`) or may be “raw” coordinates.
-
-| Column        | Type                             | Notes                          |
-|---------------|----------------------------------|--------------------------------|
-| `id`          | INTEGER PK                       | Row identifier                 |
-| `route_id`    | INTEGER FK → `routes.id`         | Route                          |
-| `seq`         | INTEGER                          | Order in the polyline (0..N-1) |
-| `x`, `y`      | REAL                             | Waypoint coordinates           |
-| `waypoint_id` | INTEGER NULL FK → `waypoints.id` | Optional link to catalog       |
-| `kind`        | TEXT                             | e.g. `start`, `detour`, `end`  |
-| `created_at`  | TEXT                             | UTC timestamp                  |
-
-**Replace strategy**
-On route recomputation, the engine removes and reinserts the polyline:
-
-- `DELETE FROM route_waypoints WHERE route_id = ?`
-- insert the new ordered polyline
-
-This keeps the stored route consistent with the latest `options_json`.
-
-### 🧠 route_detours
-
-Stores detailed decisions made by the router while building the route.
-
-Detours are persisted to enable:
-
-- debugging and replay
-- future visualization (e.g. show which planet caused each detour)
-- metrics and tuning (scores, offsets)
-
-| Column                                                                     | Type                     | Notes                                |
-|----------------------------------------------------------------------------|--------------------------|--------------------------------------|
-| `id`                                                                       | INTEGER PK               | Row identifier                       |
-| `route_id`                                                                 | INTEGER FK → `routes.id` | Route                                |
-| `idx`                                                                      | INTEGER                  | Detour index (chronological order)   |
-| `iteration`                                                                | INTEGER                  | Router iteration                     |
-| `segment_index`                                                            | INTEGER                  | Which segment was split              |
-| `obstacle_id`                                                              | INTEGER                  | Planet fid treated as obstacle       |
-| `obstacle_x`, `obstacle_y`                                                 | REAL                     | Obstacle center                      |
-| `obstacle_radius`                                                          | REAL                     | Safety radius used                   |
-| `closest_t`                                                                | REAL                     | Parametric t of closest point        |
-| `closest_qx`, `closest_qy`                                                 | REAL                     | Closest point on segment             |
-| `closest_dist`                                                             | REAL                     | Distance at collision time           |
-| `offset_used`                                                              | REAL                     | Offset used for candidate generation |
-| `wp_x`, `wp_y`                                                             | REAL                     | Chosen detour waypoint               |
-| `score_base`, `score_turn`, `score_back`, `score_proximity`, `score_total` | REAL                     | Score breakdown                      |
-| `created_at`                                                               | TEXT                     | UTC timestamp                        |
-
-**Replace strategy**
-
-Same as route polyline:
-
-- `DELETE FROM route_detours WHERE route_id = ?`
-- insert the new detour decision list
-
-### ✅ Persistence workflow (high-level)
-
-When running `route compute <from> <to> [<via>...]`:
-1. Resolve the planet sequence to fids.
-2. Compute each leg in memory (FROM→TO, then TO→NEXT, etc.).
-3. Upsert each leg into `routes` (unique per pair).
-4. Replace the associated polylines in `route_waypoints`.
-5. Replace the associated decision logs in `route_detours`.
-6. For each detour waypoint:
-   - upsert into `waypoints` if computed (via `fingerprint`)
-   - optionally link waypoint ↔ planets in `waypoint_planets`
-
-This ensures that the database always holds the most recent “best known” route for each pair.
+This project is for **educational and non-commercial use only** and is not affiliated with Lucasfilm or Disney.

--- a/crates/sw_galaxy_map_cli/src/cli/args.rs
+++ b/crates/sw_galaxy_map_cli/src/cli/args.rs
@@ -183,6 +183,16 @@ pub enum UnknownCmd {
         limit: i64,
     },
 
+    Near {
+        planet: String,
+
+        #[arg(long = "range")]
+        range: f64,
+
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
+
     /// Edit an unknown planet record in `planets_unknown`
     Edit {
         /// Internal unknown record ID

--- a/crates/sw_galaxy_map_cli/src/cli/commands/unknown.rs
+++ b/crates/sw_galaxy_map_cli/src/cli/commands/unknown.rs
@@ -3,8 +3,9 @@ use crate::ui::{info, success, warning};
 use anyhow::Result;
 use rusqlite::Connection;
 use sw_galaxy_map_core::db::queries::{
-    UnknownPlanetUpdate, count_unknown_planets, list_unknown_planets_paginated,
-    near_planets_for_unknown_id, update_unknown_planet,
+    UnknownPlanetUpdate, count_unknown_planets, find_planet_by_norm,
+    list_unknown_planets_paginated, near_planets_for_unknown_id, near_unknown_planets,
+    update_unknown_planet,
 };
 use sw_galaxy_map_core::validate;
 
@@ -83,6 +84,52 @@ pub fn run(con: &Connection, cmd: &UnknownCmd) -> Result<()> {
             Ok(())
         }
         UnknownCmd::Search { id, near, limit } => run_search(con, *id, *near, *limit),
+
+        UnknownCmd::Near {
+            planet,
+            range,
+            limit,
+        } => {
+            if *range <= 0.0 {
+                anyhow::bail!("--range must be greater than 0");
+            }
+
+            let source = find_planet_by_norm(con, planet)?
+                .ok_or_else(|| anyhow::anyhow!("Planet '{}' not found.", planet))?;
+
+            let hits = near_unknown_planets(con, source.x, source.y, *range, *limit as i64)?;
+
+            println!(
+                "Unknown planets near {} (FID={}, X={:.3}, Y={:.3}) within {:.2} parsecs",
+                source.planet, source.fid, source.x, source.y, range
+            );
+            println!();
+
+            if hits.is_empty() {
+                println!("No unknown planets found within the requested range.");
+                return Ok(());
+            }
+
+            for h in hits {
+                println!(
+                    "#{:>4} | fid={:<6} | {:<30} | x={} | y={} | dist={:>8.2} | reason={}",
+                    h.id,
+                    h.fid
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "-".to_string()),
+                    h.planet,
+                    h.x.map(|v| format!("{v:.2}"))
+                        .unwrap_or_else(|| "-".to_string()),
+                    h.y.map(|v| format!("{v:.2}"))
+                        .unwrap_or_else(|| "-".to_string()),
+                    h.distance,
+                    h.reason.as_deref().unwrap_or("-"),
+                );
+            }
+
+            Ok(())
+        }
+
         UnknownCmd::Edit {
             id,
             planet,

--- a/crates/sw_galaxy_map_core/src/db/queries.rs
+++ b/crates/sw_galaxy_map_core/src/db/queries.rs
@@ -1,7 +1,8 @@
 use crate::db::has_table;
 use crate::model::{
-    AliasRow, NearHit, Planet, PlanetSearchRow, RouteListRow, RoutingObstacleRow, UnknownPlanet,
-    Waypoint, WaypointLinkRow, WaypointListRow, WaypointPlanetLink, WaypointRouteRow,
+    AliasRow, NearHit, Planet, PlanetSearchRow, RouteListRow, RoutingObstacleRow, UnknownNearHit,
+    UnknownPlanet, Waypoint, WaypointLinkRow, WaypointListRow, WaypointPlanetLink,
+    WaypointRouteRow,
 };
 pub(crate) use crate::model::{RouteDetourRow, RouteLoaded, RouteRow, RouteWaypointRow};
 use crate::routing::router::{DetourDecision, Route as ComputedRoute, RouteOptions};
@@ -173,6 +174,54 @@ pub fn find_planet_for_info(con: &Connection, key_norm: &str) -> Result<Option<P
         return Ok(Some(p));
     }
     find_planet_by_alias_norm(con, key_norm)
+}
+
+pub fn near_unknown_planets(
+    con: &Connection,
+    x: f64,
+    y: f64,
+    range: f64,
+    limit: i64,
+) -> rusqlite::Result<Vec<UnknownNearHit>> {
+    let sql = r#"
+        SELECT
+            u.id,
+            u.fid,
+            u.planet,
+            u.x,
+            u.y,
+            u.reason,
+            u.reviewed,
+            u.promoted,
+            (((u.x - ?1) * (u.x - ?1)) +
+             ((u.y - ?2) * (u.y - ?2))) AS distance_sq
+        FROM planets_unknown u
+        WHERE u.x IS NOT NULL
+          AND u.y IS NOT NULL
+          AND (((u.x - ?1) * (u.x - ?1)) +
+               ((u.y - ?2) * (u.y - ?2))) <= (?3 * ?3)
+        ORDER BY distance_sq ASC, u.planet ASC
+        LIMIT ?4
+    "#;
+
+    let mut stmt = con.prepare(sql)?;
+    let rows = stmt.query_map((x, y, range, limit), |r| {
+        let distance_sq: f64 = r.get(8)?;
+
+        Ok(UnknownNearHit {
+            id: r.get(0)?,
+            fid: r.get(1)?,
+            planet: r.get(2)?,
+            x: r.get(3)?,
+            y: r.get(4)?,
+            reason: r.get(5)?,
+            reviewed: r.get(6)?,
+            promoted: r.get(7)?,
+            distance: distance_sq.sqrt(),
+        })
+    })?;
+
+    rows.collect()
 }
 
 pub fn get_unknown_planet_by_id(con: &Connection, id: i64) -> Result<Option<UnknownPlanet>> {

--- a/crates/sw_galaxy_map_core/src/model.rs
+++ b/crates/sw_galaxy_map_core/src/model.rs
@@ -291,3 +291,17 @@ pub struct PlanetSearchRow {
     pub x: f64,
     pub y: f64,
 }
+
+/// Represents an unknown planet hit near a known planet.
+#[derive(Debug, Clone)]
+pub struct UnknownNearHit {
+    pub id: i64,
+    pub fid: Option<i64>,
+    pub planet: String,
+    pub x: Option<f64>,
+    pub y: Option<f64>,
+    pub reason: Option<String>,
+    pub reviewed: i64,
+    pub promoted: i64,
+    pub distance: f64,
+}


### PR DESCRIPTION
…anet

- add `unknown near <planet> --range <parsecs>`
- search planets_unknown using source planet X/Y coordinates
- exclude unknown rows without coordinates
- sort results by ascending distance
- use robust squared-distance SQL filtering
- fix result collection typing in query layer