### PR TITLE
feat(sync): add curated CSV overlay pipeline on top of ArcGIS baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4387,10 +4387,11 @@ dependencies = [
 
 [[package]]
 name = "sw_galaxy_map_sync"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
+ "csv",
  "indicatif",
  "regex",
  "reqwest",

--- a/crates/sw_galaxy_map_sync/CHANGELOG.md
+++ b/crates/sw_galaxy_map_sync/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to `sw_galaxy_map_sync` will be documented in this file.
+
+The format is based on Keep a Changelog
+and this project follows Semantic Versioning.
+
+---
+
+## [0.3.1] - 2026-05-09
+
+### Added
+
+- add curated CSV overlay pipeline
+- support official semicolon-separated Disney CSV
+- support full planets/export CSV format
+- add exact planet match logic
+- add Roman suffix/base-name fallback matching
+- add curated-only planet insertion
+- add overlay status tracking:
+    - active
+    - modified
+    - inserted
+    - deleted
+    - skipped
+- add `--mark-deleted`
+- add `--dry-run`
+- add auto-detection for CSV format
+- add CSV overlay summary reporting
+
+### Changed
+
+- redesign sync workflow around:
+    - ArcGIS baseline
+    - CSV overlay pipeline
+- reuse SQLite repository layer for overlay operations
+- improve normalized comparison helpers
+- improve CLI sync integration
+
+### Fixed
+
+- fix NOT NULL insertion failures for curated-only rows
+- fix overlay rerun idempotency
+- fix suffix matching edge cases
+
+---
+
+## [0.3.0] - 2026-05-08
+
+### Added
+
+- redesign crate as ArcGIS-first ingestion pipeline
+- reuse ArcGIS provider from `sw_galaxy_map_core`
+- add normalized ArcGIS ingestion
+- add JSON export support
+- split records into:
+    - planets
+    - planets_unknown
+- preserve unnamed ArcGIS records
+- auto-create missing `planets_unknown`
+- add stable FID + hash upsert logic
+- add safe schema bootstrap handling
+- add dry-run support
+
+### Changed
+
+- remove legacy CSV-first architecture
+- remove experimental sqlx/MySQL integration
+- standardize on rusqlite
+
+### Fixed
+
+- avoid destructive schema rebuilds
+- fix ArcGIS unnamed record handling
+- fix workspace sqlite dependency conflicts

--- a/crates/sw_galaxy_map_sync/Cargo.toml
+++ b/crates/sw_galaxy_map_sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map_sync"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]
 description = "ArcGIS-first synchronization and ingestion tool for the Star Wars galaxy map and Astronavis datasets"
@@ -15,6 +15,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+csv.workspace = true
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/sw_galaxy_map_sync/README.md
+++ b/crates/sw_galaxy_map_sync/README.md
@@ -1,23 +1,18 @@
 # sw_galaxy_map_sync
 
-ArcGIS-first synchronization and ingestion tool for the `sw_galaxy_map` workspace and the future Astronavis data pipeline.
+ArcGIS-first synchronization and ingestion tool for the `sw_galaxy_map` workspace and the future Astronavis™ data
+pipeline.
 
-Version `0.3.0` resets the crate around a cleaner architecture:
+`sw_galaxy_map_sync` is responsible for:
 
-```text
-sw_galaxy_map_sync = orchestration CLI
-sw_galaxy_map_core = ArcGIS source/provider logic
-```
-
-The crate does not duplicate ArcGIS logic. It reuses the already working provider from:
-
-```rust
-sw_galaxy_map_core::provision::arcgis
-```
+* importing and normalizing ArcGIS data,
+* preserving unnamed ArcGIS records,
+* synchronizing curated official CSV overlays,
+* maintaining the SQLite baseline used by the CLI, GUI and future API layers.
 
 ---
 
-## Architecture
+# Architecture
 
 ```text
 ArcGIS FeatureServer
@@ -26,36 +21,117 @@ ArcGIS FeatureServer
 sw_galaxy_map_core::provision::arcgis
         │
         ▼
-sw_galaxy_map_sync source adapter
+sw_galaxy_map_sync
         │
-        ▼
-ArcGIS classifier
-   ├── known planets   → planets
-   └── unnamed records → planets_unknown
+        ├── ArcGIS baseline import
+        │       ├── planets
+        │       └── planets_unknown
+        │
+        └── Curated CSV overlay
+                └── planets.status
+```
+
+The crate intentionally reuses the ArcGIS provider already implemented in:
+
+```rust
+sw_galaxy_map_core::provision::arcgis
+```
+
+This avoids duplicated source logic and keeps ArcGIS handling centralized inside the core crate.
+
+---
+
+# Data Philosophy
+
+The synchronization pipeline is intentionally split into two layers.
+
+## 1. ArcGIS Baseline
+
+ArcGIS is treated as the canonical coordinate and source-data baseline.
+
+This layer provides:
+
+* stable FID identifiers,
+* X/Y coordinates,
+* raw source metadata,
+* unknown or unnamed records,
+* normalized ArcGIS ingestion.
+
+## 2. Curated Official CSV Overlay
+
+The curated CSV overlay is treated as the canonical naming and metadata validation layer.
+
+This layer provides:
+
+* official naming validation,
+* curated Region/Sector/Grid corrections,
+* status tracking,
+* logical deletion handling,
+* curated-only systems missing from ArcGIS.
+
+This design allows Astronavis™ to preserve:
+
+* stable coordinates,
+* curated naming,
+* historical ArcGIS data,
+* unknown records,
+* future manual corrections.
+
+---
+
+# Current Features
+
+## ArcGIS Pipeline
+
+* Download planet records from ArcGIS.
+* Normalize ArcGIS attributes into stable internal models.
+* Export normalized ArcGIS data to JSON.
+* Split ArcGIS records into:
+
+    * known planets,
+    * unnamed/unknown records.
+* Import/upsert known records into `planets`.
+* Import/upsert unnamed records into `planets_unknown`.
+* Auto-create `planets_unknown` when missing.
+* Preserve unknown ArcGIS source records.
+* Stable FID + hash upsert logic.
+* `--dry-run` support.
+
+## CSV Overlay Pipeline
+
+* Import curated Disney/official CSV overlays.
+* Support semicolon-separated official CSV files.
+* Support full planets/export CSV files.
+* Exact planet-name matching.
+* Roman suffix/base-name fallback matching.
+* Curated-only row insertion.
+* Overlay status tracking.
+* Logical deletion support.
+* Dry-run overlay validation.
+
+---
+
+# Coordinate Policy
+
+ArcGIS X/Y values are currently treated as the canonical stored coordinates.
+
+Coordinates are currently stored as parsecs.
+
+Values are rounded to 3 decimal places before insertion/update.
+
+Recommended long-term policy:
+
+```text
+DB canonical coordinates: parsec
+UI/export coordinates   : light years
+conversion              : ly = pc * 3.26156
 ```
 
 ---
 
-## Current Features
+# Unknown ArcGIS Records
 
-- Download planet records from ArcGIS.
-- Normalize ArcGIS attributes into a stable internal model.
-- Export normalized ArcGIS data to JSON.
-- Split ArcGIS records into:
-  - known planets,
-  - unknown unnamed ArcGIS records.
-- Import/upsert known records into `planets`.
-- Import/upsert unnamed records into `planets_unknown`.
-- Auto-create `planets_unknown` from the `planets` column layout when missing.
-- Support `--dry-run` for safe validation.
-- Keep SQLite handled through `rusqlite`.
-- Avoid `sqlx` for now to prevent workspace-level `libsqlite3-sys` conflicts.
-
----
-
-## Unknown ArcGIS Records
-
-ArcGIS sometimes contains records without a usable planet name.
+ArcGIS sometimes exposes records without a usable planet name.
 
 These records are not discarded.
 
@@ -65,62 +141,73 @@ Instead, they are preserved in:
 planets_unknown
 ```
 
-The `planets_unknown` table is created automatically if missing, using the same column names and SQLite column types as the configured `planets` table.
-
 Records are stored with:
 
-- original ArcGIS `FID`,
-- empty `Planet`,
-- empty `planet_norm`,
-- available region/sector/system/grid data,
-- available X/Y coordinates,
-- ArcGIS hash,
-- source flags.
+* original ArcGIS `FID`,
+* original source metadata,
+* available coordinates,
+* ArcGIS source hash,
+* canonical/legends flags.
 
-This allows later inspection, review and promotion without losing source data.
+This allows later:
+
+* inspection,
+* promotion,
+* manual correction,
+* future coordinate reconciliation.
 
 ---
 
-## Coordinate Policy
+# Quick Start
 
-ArcGIS X/Y values are currently treated as the canonical stored coordinates.
+## 1. Import ArcGIS baseline
 
-At this stage they are stored as parsecs, matching the ArcGIS source.
+```bash
+cargo run -p sw_galaxy_map_sync -- arcgis import \
+  --db res/sw_planets.sqlite
+```
 
-Values are rounded to 3 decimal places before DB insertion/update.
+## 2. Overlay official CSV
 
-Recommended long-term policy:
-
-```text
-DB canonical coordinates: parsec
-UI/export coordinates   : light years, when needed
-conversion              : ly = pc * 3.26156
+```bash
+cargo run -p sw_galaxy_map_sync -- csv overlay \
+  --db res/sw_planets.sqlite \
+  --csv res/star_wars_galaxy_systems_official_semicolon.csv
 ```
 
 ---
 
-## Commands
+# Commands
 
-### Show help
+## Show help
 
 ```bash
 cargo run -p sw_galaxy_map_sync -- --help
 ```
 
-### Show ArcGIS commands
+## ArcGIS commands
 
 ```bash
 cargo run -p sw_galaxy_map_sync -- arcgis --help
 ```
 
----
-
-## ArcGIS: Fetch
-
-Download ArcGIS data and save normalized records as JSON.
+## CSV overlay commands
 
 ```bash
-cargo run -p sw_galaxy_map_sync -- arcgis fetch --out res/arcgis_planets.json
+cargo run -p sw_galaxy_map_sync -- csv --help
+```
+
+---
+
+# ArcGIS Commands
+
+## Fetch ArcGIS JSON
+
+Download ArcGIS data and export normalized records as JSON.
+
+```bash
+cargo run -p sw_galaxy_map_sync -- arcgis fetch \
+  --out res/arcgis_planets.json
 ```
 
 Optional page size:
@@ -131,7 +218,7 @@ cargo run -p sw_galaxy_map_sync -- arcgis fetch \
   --out res/arcgis_planets.json
 ```
 
-Output format:
+Generated JSON format:
 
 ```json
 {
@@ -146,10 +233,7 @@ Output format:
       "grid": "G-7",
       "x": 0.0,
       "y": 0.0,
-      "arcgis_hash": "...",
-      "canon": 1,
-      "legends": 0,
-      "raw": {}
+      "arcgis_hash": "..."
     }
   ],
   "unknown": [
@@ -163,10 +247,7 @@ Output format:
       "grid": "...",
       "x": 0.0,
       "y": 0.0,
-      "arcgis_hash": "...",
-      "canon": 1,
-      "legends": 0,
-      "raw": {}
+      "arcgis_hash": "..."
     }
   ]
 }
@@ -174,16 +255,14 @@ Output format:
 
 ---
 
-## ArcGIS: Import into SQLite
-
-Download from ArcGIS and upsert into SQLite:
+## Import ArcGIS into SQLite
 
 ```bash
 cargo run -p sw_galaxy_map_sync -- arcgis import \
   --db res/sw_planets.sqlite
 ```
 
-Use custom tables:
+Custom tables:
 
 ```bash
 cargo run -p sw_galaxy_map_sync -- arcgis import \
@@ -202,12 +281,140 @@ cargo run -p sw_galaxy_map_sync -- arcgis import \
 
 ---
 
-## SQLite Expectations
+# CSV Overlay Pipeline
 
-The import command expects a `planets`-like table with at least these columns:
+Version `0.3.1` introduces curated CSV overlays on top of the ArcGIS baseline.
+
+Workflow:
+
+```text
+1. ArcGIS import
+   ArcGIS → planets / planets_unknown
+
+2. CSV overlay
+   official CSV → planets status/update layer
+```
+
+---
+
+# Supported CSV Formats
+
+## Official semicolon CSV
+
+Curated Disney/current official list format:
+
+```csv
+system;sector;region;grid
+Adelphi;Kibilini;Outer Rim Territories;P-17
+23 Mere;;Colonies;M-13
+```
+
+Default delimiter:
+
+```text
+;
+```
+
+---
+
+## Full planets/export CSV
+
+Full table/export-style format:
+
+```csv
+FID,Planet,planet_norm,Region,Sector,System,Grid,X,Y,arcgis_hash,deleted,Canon,Legends,...
+```
+
+Default delimiter:
+
+```text
+,
+```
+
+---
+
+# CSV Overlay Commands
+
+## Dry run
+
+```bash
+cargo run -p sw_galaxy_map_sync -- csv overlay \
+  --db res/sw_planets_overlay_test.sqlite \
+  --csv res/star_wars_galaxy_systems_official_semicolon.csv \
+  --format official \
+  --delimiter ";" \
+  --dry-run
+```
+
+## Real overlay
+
+```bash
+cargo run -p sw_galaxy_map_sync -- csv overlay \
+  --db res/sw_planets_overlay_test.sqlite \
+  --csv res/star_wars_galaxy_systems_official_semicolon.csv \
+  --format official \
+  --delimiter ";"
+```
+
+## Mark deleted
+
+```bash
+cargo run -p sw_galaxy_map_sync -- csv overlay \
+  --db res/sw_planets_overlay_test.sqlite \
+  --csv res/star_wars_galaxy_systems_official_semicolon.csv \
+  --format official \
+  --delimiter ";" \
+  --mark-deleted
+```
+
+## Auto-detection mode
+
+```bash
+cargo run -p sw_galaxy_map_sync -- csv overlay \
+  --db res/sw_planets_overlay_test.sqlite \
+  --csv res/star_wars_galaxy_systems_official_semicolon.csv
+```
+
+---
+
+# Overlay Matching Logic
+
+For every CSV row, the overlay pipeline attempts:
+
+1. exact planet match,
+2. Roman suffix/base-name fallback match,
+3. curated-only insertion when no match exists.
+
+Examples:
+
+```text
+Yavin      ↔ Yavin IV
+Yavin IV   ↔ Yavin
+```
+
+---
+
+# Overlay Status Values
+
+The overlay updates the `status` column using:
+
+| Status     | Meaning                                                         |
+|------------|-----------------------------------------------------------------|
+| `active`   | CSV row matches the existing DB metadata                        |
+| `modified` | CSV row updated metadata for an existing DB row                 |
+| `inserted` | CSV row was inserted as a curated-only row                      |
+| `deleted`  | DB row is not represented in the CSV overlay                    |
+| `skipped`  | Row was represented logically but required no status transition |
+
+---
+
+# SQLite Expectations
+
+The pipeline expects a `planets`-like table containing at least:
 
 ```sql
-FID INTEGER,
+FID
+INTEGER,
 Planet TEXT,
 planet_norm TEXT,
 Region TEXT,
@@ -219,111 +426,131 @@ Y REAL,
 arcgis_hash TEXT,
 deleted INTEGER,
 Canon INTEGER,
-Legends INTEGER
+Legends INTEGER,
+status TEXT
 ```
 
-The upsert is based on `FID`.
-
-The implementation intentionally uses manual `SELECT` + `INSERT`/`UPDATE` instead of `ON CONFLICT`, so `planets_unknown` does not require a primary-key constraint.
-
----
-
-## Why MySQL is not included yet
-
-MySQL is part of the future Astronavis direction, but version `0.3.0` intentionally avoids adding `sqlx`.
-
-Reason:
-
-- the workspace already uses `rusqlite`,
-- enabling `sqlx/sqlite` can pull another incompatible `libsqlite3-sys`,
-- the sync model must be stabilized before adding remote DB backends.
-
-Recommended roadmap:
+The upsert logic is based on:
 
 ```text
-v0.3.0  ArcGIS-first SQLite ingestion
-v0.3.x  CSV merge on top of ArcGIS baseline
+FID + arcgis_hash
+```
+
+The implementation intentionally avoids `ON CONFLICT` to keep compatibility with:
+
+```text
+planets_unknown
+```
+
+without requiring PK constraints.
+
+---
+
+# Why sqlx/MySQL is not included yet
+
+MySQL is part of the long-term Astronavis™ roadmap, but `v0.3.x` intentionally avoids adding `sqlx`.
+
+Reasons:
+
+* the workspace already standardizes on `rusqlite`,
+* `sqlx/sqlite` can introduce `libsqlite3-sys` conflicts,
+* the synchronization model must stabilize first.
+
+Planned roadmap:
+
+```text
+v0.3.0  ArcGIS-first ingestion
+v0.3.1  Curated CSV overlay pipeline
 v0.4.0  Repository abstraction
 v0.5.0  MySQL backend
+v0.6.0  Astronavis API integration
 ```
 
 ---
 
-## Suggested Tests
+# Suggested Tests
 
-### 1. Build
+## Build
 
 ```bash
 cargo build -p sw_galaxy_map_sync
 ```
 
-### 2. Format
+## Format
 
 ```bash
 cargo fmt --all -- --check
 ```
 
-### 3. Clippy
+## Clippy
 
 ```bash
 cargo clippy -p sw_galaxy_map_sync --all-targets --all-features -- -D warnings
 ```
 
-### 4. Unit tests
+## Unit tests
 
 ```bash
 cargo test -p sw_galaxy_map_sync
 ```
 
-### 5. Fetch ArcGIS JSON
+---
 
-```bash
-cargo run -p sw_galaxy_map_sync -- arcgis fetch --out res/arcgis_planets.json
-```
-
-Verify:
-
-- the JSON file exists,
-- it contains `known` and `unknown` arrays,
-- unnamed ArcGIS records are in `unknown`.
-
-### 6. Dry-run import
-
-```bash
-cargo run -p sw_galaxy_map_sync -- arcgis import --db res/sw_planets.sqlite --dry-run
-```
-
-Expected behavior:
-
-- fetches ArcGIS data,
-- normalizes records,
-- prints known/unknown statistics,
-- does not modify the DB.
-
-### 7. Real import on a copy
+# Recommended End-to-End Test
 
 ```powershell
-Copy-Item .\res\sw_planets.sqlite .\res\sw_planets_arcgis_test.sqlite
+Remove-Item .\res\sw_planets_overlay_test.sqlite -ErrorAction SilentlyContinue
 
 cargo run -p sw_galaxy_map_sync -- arcgis import `
-  --db res/sw_planets_arcgis_test.sqlite
+  --db res/sw_planets_overlay_test.sqlite
+
+cargo run -p sw_galaxy_map_sync -- csv overlay `
+  --db res/sw_planets_overlay_test.sqlite `
+  --csv res/star_wars_galaxy_systems_official_semicolon.csv `
+  --format official `
+  --delimiter ";" `
+  --dry-run
+
+cargo run -p sw_galaxy_map_sync -- csv overlay `
+  --db res/sw_planets_overlay_test.sqlite `
+  --csv res/star_wars_galaxy_systems_official_semicolon.csv `
+  --format official `
+  --delimiter ";"
+
+cargo run -p sw_galaxy_map_sync -- csv overlay `
+  --db res/sw_planets_overlay_test.sqlite `
+  --csv res/star_wars_galaxy_systems_official_semicolon.csv `
+  --format official `
+  --delimiter ";" `
+  --mark-deleted
 ```
 
-Verify:
+Expected overlay summary:
 
-- known records are inserted/updated in `planets`,
-- unnamed records are inserted/updated in `planets_unknown`,
-- `planets_unknown` is created if missing,
-- `arcgis_hash` changes only when source data changes,
-- `deleted = 0` for imported records.
+```text
+Rows read
+Inserted
+Active
+Modified
+Deleted
+Skipped
+Dry run
+```
 
 ---
 
-## License
+# License
 
 Licensed under either:
 
-- MIT License
-- Apache License 2.0
+* MIT License
+* Apache License 2.0
 
 at your option.
+
+---
+
+# Branding Notice
+
+Astronavis™ branding assets, logos, icons, wallpapers and visual identity materials are not covered by the open-source
+licenses and remain pro

--- a/crates/sw_galaxy_map_sync/src/cli.rs
+++ b/crates/sw_galaxy_map_sync/src/cli.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+use crate::models::CsvOverlayFormat;
+
 /// ArcGIS-first synchronization and ingestion tool.
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
@@ -15,6 +17,10 @@ pub enum Commands {
     /// ArcGIS data ingestion commands.
     #[command(subcommand)]
     Arcgis(ArcgisCommand),
+
+    /// CSV overlay commands.
+    #[command(subcommand)]
+    Csv(CsvCommand),
 }
 
 /// ArcGIS command group.
@@ -52,6 +58,45 @@ pub enum ArcgisCommand {
         /// ArcGIS page size.
         #[arg(long, default_value_t = 2000)]
         page_size: i64,
+
+        /// Run without applying database changes.
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+    },
+}
+
+/// CSV command group.
+#[derive(Debug, Subcommand)]
+pub enum CsvCommand {
+    /// Apply a curated CSV overlay over the ArcGIS baseline.
+    Overlay {
+        /// SQLite database path.
+        #[arg(long)]
+        db: PathBuf,
+
+        /// CSV overlay file.
+        #[arg(long)]
+        csv: PathBuf,
+
+        /// Target known planets table.
+        #[arg(long, default_value = "planets")]
+        table: String,
+
+        /// Target unknown planets table.
+        #[arg(long, default_value = "planets_unknown")]
+        unknown_table: String,
+
+        /// CSV format: auto, official, full.
+        #[arg(long, default_value = "auto")]
+        format: CsvOverlayFormat,
+
+        /// CSV delimiter. If omitted, it is detected from the header.
+        #[arg(long)]
+        delimiter: Option<String>,
+
+        /// Mark DB records not present in the CSV as deleted/skipped.
+        #[arg(long, default_value_t = false)]
+        mark_deleted: bool,
 
         /// Run without applying database changes.
         #[arg(long, default_value_t = false)]

--- a/crates/sw_galaxy_map_sync/src/db/sqlite.rs
+++ b/crates/sw_galaxy_map_sync/src/db/sqlite.rs
@@ -1,9 +1,12 @@
 use anyhow::{Context, Result, bail};
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::models::{NormalizedPlanet, UpsertOutcome};
+use crate::models::{
+    CsvOverlayOutcome, CsvOverlayRow, NormalizedPlanet, PlanetDbRow, UpsertOutcome,
+};
+use crate::utils::{build_planet_norm, cmp_key, same_overlay_fields, strip_roman_suffix};
 
-/// SQLite repository for ArcGIS planet imports.
+/// SQLite repository for planet synchronization/import operations.
 pub struct SqlitePlanetRepository<'conn> {
     conn: &'conn Connection,
     table: String,
@@ -20,59 +23,11 @@ impl<'conn> SqlitePlanetRepository<'conn> {
 
     /// Ensure that this repository table exists.
     pub fn ensure_table_exists(&self) -> Result<()> {
-        if !self.table_exists()? {
+        if !table_exists(self.conn, &self.table)? {
             bail!("Target table '{}' does not exist", self.table);
         }
 
         Ok(())
-    }
-
-    /// Create a table with the same column names/types as another table if missing.
-    ///
-    /// This is used for `planets_unknown`. We intentionally do not rely on
-    /// `ON CONFLICT`, so the cloned table does not need to preserve indexes
-    /// or primary-key constraints.
-    pub fn create_like_if_missing(
-        conn: &'conn Connection,
-        source_table: &str,
-        target_table: &str,
-    ) -> Result<Self> {
-        let repo = Self::new(conn, target_table);
-
-        if repo.table_exists()? {
-            return Ok(repo);
-        }
-
-        let columns = table_columns(conn, source_table)
-            .with_context(|| format!("Unable to inspect source table '{source_table}'"))?;
-
-        if columns.is_empty() {
-            bail!("Source table '{source_table}' does not exist or has no columns");
-        }
-
-        let column_sql = columns
-            .iter()
-            .map(|column| {
-                let ty = if column.ty.trim().is_empty() {
-                    "TEXT"
-                } else {
-                    column.ty.as_str()
-                };
-
-                format!("{} {}", quote_ident(&column.name), ty)
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        let sql = format!(
-            "CREATE TABLE IF NOT EXISTS {} ({})",
-            quote_ident(target_table),
-            column_sql
-        );
-
-        conn.execute(&sql, [])?;
-
-        Ok(repo)
     }
 
     /// Upsert a normalized ArcGIS planet into the target table.
@@ -86,26 +41,95 @@ impl<'conn> SqlitePlanetRepository<'conn> {
         }
 
         if existing_hash.is_some() {
-            self.update_planet(planet)?;
+            self.update_arcgis_planet(planet)?;
             Ok(UpsertOutcome::Updated)
         } else {
-            self.insert_planet(planet)?;
+            self.insert_arcgis_planet(planet)?;
             Ok(UpsertOutcome::Inserted)
         }
     }
 
-    fn table_exists(&self) -> Result<bool> {
-        let exists = self
-            .conn
-            .query_row(
-                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1 LIMIT 1",
-                params![self.table],
-                |_| Ok(()),
-            )
-            .optional()?
-            .is_some();
+    /// Apply one official CSV overlay row to the target table.
+    pub fn apply_csv_overlay_row(
+        &self,
+        row: &CsvOverlayRow,
+        dry_run: bool,
+    ) -> Result<CsvOverlayOutcome> {
+        if let Some(existing) = self.find_exact_match(row)? {
+            return self.apply_csv_match(existing, row, dry_run, false);
+        }
 
-        Ok(exists)
+        if let Some(existing) = self.find_suffix_match(row)? {
+            return self.apply_csv_match(existing, row, dry_run, true);
+        }
+
+        if !dry_run {
+            self.insert_csv_overlay_row(row)?;
+        }
+
+        Ok(CsvOverlayOutcome::Inserted)
+    }
+
+    /// Mark records not represented by the CSV overlay as deleted/skipped.
+    pub fn mark_deleted_not_in_csv(
+        &self,
+        csv_rows: &[CsvOverlayRow],
+        dry_run: bool,
+    ) -> Result<(usize, usize)> {
+        let db_rows = self.load_planet_rows()?;
+        let mut deleted = 0usize;
+        let mut skipped = 0usize;
+
+        for db_row in db_rows {
+            if exists_in_csv(&db_row, csv_rows) {
+                if db_row.status.trim().is_empty() {
+                    skipped += 1;
+                    if !dry_run {
+                        self.set_status(db_row.fid, "skipped")?;
+                    }
+                }
+            } else {
+                deleted += 1;
+                if !dry_run {
+                    self.set_status(db_row.fid, "deleted")?;
+                }
+            }
+        }
+
+        Ok((deleted, skipped))
+    }
+
+    fn apply_csv_match(
+        &self,
+        existing: PlanetDbRow,
+        row: &CsvOverlayRow,
+        dry_run: bool,
+        suffix_match: bool,
+    ) -> Result<CsvOverlayOutcome> {
+        if same_overlay_fields(
+            &existing.sector,
+            &existing.region,
+            &existing.grid,
+            &row.sector,
+            &row.region,
+            &row.grid,
+        ) {
+            if !dry_run {
+                self.set_status(existing.fid, "active")?;
+            }
+
+            Ok(CsvOverlayOutcome::Active)
+        } else {
+            if !dry_run {
+                self.update_csv_overlay_row(existing.fid, row, "modified")?;
+            }
+
+            Ok(if suffix_match {
+                CsvOverlayOutcome::ModifiedSuffix
+            } else {
+                CsvOverlayOutcome::ModifiedExact
+            })
+        }
     }
 
     fn find_existing_arcgis_hash_by_fid(&self, fid: i64) -> Result<Option<String>> {
@@ -121,7 +145,59 @@ impl<'conn> SqlitePlanetRepository<'conn> {
             .map_err(Into::into)
     }
 
-    fn insert_planet(&self, planet: &NormalizedPlanet) -> Result<()> {
+    fn find_exact_match(&self, row: &CsvOverlayRow) -> Result<Option<PlanetDbRow>> {
+        let target = cmp_key(&row.system);
+        let rows = self.load_planet_rows()?;
+
+        Ok(rows
+            .into_iter()
+            .find(|db_row| cmp_key(&db_row.planet) == target))
+    }
+
+    fn find_suffix_match(&self, row: &CsvOverlayRow) -> Result<Option<PlanetDbRow>> {
+        let target = cmp_key(&row.system);
+        let target_base = strip_roman_suffix(&target);
+        let rows = self.load_planet_rows()?;
+
+        Ok(rows.into_iter().find(|db_row| {
+            let db_key = cmp_key(&db_row.planet);
+            let db_base = strip_roman_suffix(&db_key);
+
+            db_base == target || db_key == target_base || db_base == target_base
+        }))
+    }
+
+    fn load_planet_rows(&self) -> Result<Vec<PlanetDbRow>> {
+        let sql = format!(
+            "SELECT FID,
+                    COALESCE(Planet, ''),
+                    COALESCE(Sector, ''),
+                    COALESCE(Region, ''),
+                    COALESCE(Grid, ''),
+                    COALESCE(status, '')
+             FROM {}
+             WHERE COALESCE(deleted, 0) = 0",
+            quote_ident(&self.table)
+        );
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(PlanetDbRow {
+                    fid: row.get(0)?,
+                    planet: row.get(1)?,
+                    sector: row.get(2)?,
+                    region: row.get(3)?,
+                    grid: row.get(4)?,
+                    status: row.get(5)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(rows)
+    }
+
+    fn insert_arcgis_planet(&self, planet: &NormalizedPlanet) -> Result<()> {
         let sql = format!(
             "INSERT INTO {}
                 (FID, Planet, planet_norm, Region, Sector, System, Grid, X, Y,
@@ -152,7 +228,7 @@ impl<'conn> SqlitePlanetRepository<'conn> {
         Ok(())
     }
 
-    fn update_planet(&self, planet: &NormalizedPlanet) -> Result<()> {
+    fn update_arcgis_planet(&self, planet: &NormalizedPlanet) -> Result<()> {
         let sql = format!(
             "UPDATE {}
              SET
@@ -192,45 +268,96 @@ impl<'conn> SqlitePlanetRepository<'conn> {
 
         Ok(())
     }
-}
 
-#[derive(Debug)]
-struct TableColumn {
-    name: String,
-    ty: String,
-}
+    fn insert_csv_overlay_row(&self, row: &CsvOverlayRow) -> Result<()> {
+        let fid = self.next_fid()?;
+        let planet_norm = build_planet_norm(&row.system);
+        let sql = format!(
+            "INSERT INTO {}
+                (FID, Planet, planet_norm, Region, Sector, System, Grid,
+                 X, Y, arcgis_hash, deleted, Canon, Legends, status)
+             VALUES
+                (?1, ?2, ?3, ?4, ?5, ?6, ?7,
+                 ?8, ?9, '', 0, 1, 0, 'inserted')",
+            quote_ident(&self.table)
+        );
 
-fn table_columns(conn: &Connection, table: &str) -> Result<Vec<TableColumn>> {
-    let sql = format!("PRAGMA table_info({})", quote_ident(table));
-    let mut stmt = conn.prepare(&sql)?;
+        self.conn.execute(
+            &sql,
+            params![
+                fid,
+                row.system,
+                planet_norm,
+                row.region,
+                row.sector,
+                row.system,
+                row.grid,
+                0.0_f64,
+                0.0_f64,
+            ],
+        )?;
 
-    let columns = stmt
-        .query_map([], |row| {
-            Ok(TableColumn {
-                name: row.get(1)?,
-                ty: row.get(2)?,
-            })
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(())
+    }
 
-    Ok(columns)
-}
+    fn update_csv_overlay_row(&self, fid: i64, row: &CsvOverlayRow, status: &str) -> Result<()> {
+        let planet_norm = build_planet_norm(&row.system);
+        let sql = format!(
+            "UPDATE {}
+             SET
+                Planet = ?2,
+                planet_norm = ?3,
+                Region = ?4,
+                Sector = ?5,
+                System = ?6,
+                Grid = ?7,
+                deleted = 0,
+                status = ?8
+             WHERE FID = ?1",
+            quote_ident(&self.table)
+        );
 
-fn quote_ident(value: &str) -> String {
-    format!("\"{}\"", value.replace('"', "\"\""))
-}
+        self.conn.execute(
+            &sql,
+            params![
+                fid,
+                row.system,
+                planet_norm,
+                row.region,
+                row.sector,
+                row.system,
+                row.grid,
+                status,
+            ],
+        )?;
 
-fn round3(value: f64) -> f64 {
-    (value * 1000.0).round() / 1000.0
+        Ok(())
+    }
+
+    fn set_status(&self, fid: i64, status: &str) -> Result<()> {
+        let sql = format!(
+            "UPDATE {} SET status = ?2, deleted = 0 WHERE FID = ?1",
+            quote_ident(&self.table)
+        );
+
+        self.conn.execute(&sql, params![fid, status])?;
+
+        Ok(())
+    }
+
+    fn next_fid(&self) -> Result<i64> {
+        let sql = format!(
+            "SELECT COALESCE(MAX(FID), 0) + 1 FROM {}",
+            quote_ident(&self.table)
+        );
+
+        self.conn
+            .query_row(&sql, [], |row| row.get(0))
+            .map_err(Into::into)
+    }
 }
 
 /// Ensures that the required sync tables exist without destroying existing data.
-///
-/// If the main `planets` table is missing, the database is considered
-/// uninitialized and the canonical core schema is created.
-///
-/// If only `planets_unknown` is missing, only that table is created by cloning
-/// the column layout from `planets`.
 pub fn ensure_required_schema(
     conn: &Connection,
     planets_table: &str,
@@ -276,9 +403,6 @@ pub fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
 
 /// Creates `target_table` with the same column names and SQLite column types
 /// as `source_table`.
-///
-/// This intentionally does not copy indexes, triggers, constraints or FTS
-/// objects. It is used only for `planets_unknown`.
 pub fn create_table_like(conn: &Connection, source_table: &str, target_table: &str) -> Result<()> {
     if table_exists(conn, target_table)? {
         return Ok(());
@@ -314,4 +438,53 @@ pub fn create_table_like(conn: &Connection, source_table: &str, target_table: &s
     conn.execute(&sql, [])?;
 
     Ok(())
+}
+
+fn exists_in_csv(db_row: &PlanetDbRow, csv_rows: &[CsvOverlayRow]) -> bool {
+    let db_name = cmp_key(&db_row.planet);
+    let db_base = strip_roman_suffix(&db_name);
+
+    csv_rows.iter().any(|row| {
+        let csv_name = cmp_key(&row.system);
+        let csv_base = strip_roman_suffix(&csv_name);
+
+        db_name == csv_name
+            || db_base == csv_name
+            || db_name == csv_base
+            || db_base == csv_base
+            || (cmp_key(&db_row.sector) == cmp_key(&row.sector)
+                && cmp_key(&db_row.region) == cmp_key(&row.region)
+                && cmp_key(&db_row.grid) == cmp_key(&row.grid))
+    })
+}
+
+#[derive(Debug)]
+struct TableColumn {
+    name: String,
+    ty: String,
+}
+
+fn table_columns(conn: &Connection, table: &str) -> Result<Vec<TableColumn>> {
+    let sql = format!("PRAGMA table_info({})", quote_ident(table));
+    let mut stmt = conn.prepare(&sql)?;
+
+    let columns = stmt
+        .query_map([], |row| {
+            Ok(TableColumn {
+                name: row.get(1)?,
+                ty: row.get(2)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    Ok(columns)
+}
+
+fn quote_ident(value: &str) -> String {
+    let escaped = value.replace('"', "\"\"");
+    format!("\"{escaped}\"")
+}
+
+fn round3(value: f64) -> f64 {
+    (value * 1000.0).round() / 1000.0
 }

--- a/crates/sw_galaxy_map_sync/src/main.rs
+++ b/crates/sw_galaxy_map_sync/src/main.rs
@@ -1,9 +1,10 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use clap::Parser;
-use sw_galaxy_map_sync::cli::{ArcgisCommand, Cli, Commands};
+use sw_galaxy_map_sync::cli::{ArcgisCommand, Cli, Commands, CsvCommand};
 use sw_galaxy_map_sync::pipeline::arcgis_import::{
     ArcgisFetchOptions, ArcgisImportOptions, fetch_arcgis_to_file, import_arcgis_to_sqlite,
 };
+use sw_galaxy_map_sync::pipeline::csv_overlay::{CsvOverlayOptions, apply_csv_overlay};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -51,5 +52,63 @@ fn main() -> Result<()> {
                 Ok(())
             }
         },
+        Commands::Csv(command) => match command {
+            CsvCommand::Overlay {
+                db,
+                csv,
+                table,
+                unknown_table,
+                format,
+                delimiter,
+                mark_deleted,
+                dry_run,
+            } => {
+                let delimiter = parse_delimiter(delimiter)?;
+                let stats = apply_csv_overlay(&CsvOverlayOptions {
+                    db,
+                    csv,
+                    table,
+                    unknown_table,
+                    format,
+                    delimiter,
+                    dry_run,
+                    mark_deleted,
+                })?;
+
+                println!();
+                println!("CSV overlay completed.");
+                println!("Rows read        : {}", stats.rows_read);
+                println!("Inserted         : {}", stats.inserted);
+                println!("Active           : {}", stats.active);
+                println!("Modified exact   : {}", stats.modified_exact);
+                println!("Modified suffix  : {}", stats.modified_suffix);
+                println!("Deleted          : {}", stats.deleted);
+                println!("Skipped          : {}", stats.skipped);
+                println!("Dry run          : {}", stats.dry_run);
+
+                Ok(())
+            }
+        },
     }
+}
+
+fn parse_delimiter(value: Option<String>) -> Result<Option<u8>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+
+    let mut chars = value.chars();
+    let Some(ch) = chars.next() else {
+        bail!("CSV delimiter cannot be empty");
+    };
+
+    if chars.next().is_some() {
+        bail!("CSV delimiter must be a single character");
+    }
+
+    if !ch.is_ascii() {
+        bail!("CSV delimiter must be an ASCII character");
+    }
+
+    Ok(Some(ch as u8))
 }

--- a/crates/sw_galaxy_map_sync/src/models.rs
+++ b/crates/sw_galaxy_map_sync/src/models.rs
@@ -86,3 +86,69 @@ pub enum UpsertOutcome {
     Updated,
     Skipped,
 }
+
+/// Supported CSV overlay input formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CsvOverlayFormat {
+    /// Auto-detect the format from CSV headers.
+    Auto,
+    /// Official Disney-style curated CSV: system;sector;region;grid.
+    Official,
+    /// Full ArcGIS/export CSV containing the planets table columns.
+    Full,
+}
+
+impl std::str::FromStr for CsvOverlayFormat {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "official" => Ok(Self::Official),
+            "full" => Ok(Self::Full),
+            other => anyhow::bail!("Unsupported CSV overlay format: {other}"),
+        }
+    }
+}
+
+/// One normalized row read from a CSV overlay source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CsvOverlayRow {
+    pub system: String,
+    pub sector: String,
+    pub region: String,
+    pub grid: String,
+}
+
+/// One database row used by the CSV overlay matching phase.
+#[derive(Debug, Clone)]
+pub struct PlanetDbRow {
+    pub fid: i64,
+    pub planet: String,
+    pub sector: String,
+    pub region: String,
+    pub grid: String,
+    pub status: String,
+}
+
+/// Result classification for a single CSV overlay row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CsvOverlayOutcome {
+    Inserted,
+    Active,
+    ModifiedExact,
+    ModifiedSuffix,
+}
+
+/// Aggregate statistics produced by the CSV overlay pipeline.
+#[derive(Debug, Clone, Default)]
+pub struct CsvOverlayStats {
+    pub rows_read: usize,
+    pub inserted: usize,
+    pub active: usize,
+    pub modified_exact: usize,
+    pub modified_suffix: usize,
+    pub deleted: usize,
+    pub skipped: usize,
+    pub dry_run: bool,
+}

--- a/crates/sw_galaxy_map_sync/src/pipeline/csv_overlay.rs
+++ b/crates/sw_galaxy_map_sync/src/pipeline/csv_overlay.rs
@@ -1,0 +1,85 @@
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use std::path::PathBuf;
+
+use crate::db::sqlite::{SqlitePlanetRepository, ensure_required_schema};
+use crate::models::{CsvOverlayFormat, CsvOverlayOutcome, CsvOverlayStats};
+use crate::sources::csv::load_overlay_csv;
+
+/// Options for the official CSV overlay pipeline.
+#[derive(Debug, Clone)]
+pub struct CsvOverlayOptions {
+    pub db: PathBuf,
+    pub csv: PathBuf,
+    pub table: String,
+    pub unknown_table: String,
+    pub format: CsvOverlayFormat,
+    pub delimiter: Option<u8>,
+    pub dry_run: bool,
+    pub mark_deleted: bool,
+}
+
+/// Apply a curated CSV overlay on top of the ArcGIS baseline.
+pub fn apply_csv_overlay(options: &CsvOverlayOptions) -> Result<CsvOverlayStats> {
+    let rows = load_overlay_csv(&options.csv, options.format, options.delimiter)?;
+
+    let mut stats = CsvOverlayStats {
+        rows_read: rows.len(),
+        dry_run: options.dry_run,
+        ..CsvOverlayStats::default()
+    };
+
+    if options.dry_run {
+        let conn = Connection::open(&options.db)
+            .with_context(|| format!("Unable to open DB: {}", options.db.display()))?;
+        ensure_required_schema(&conn, &options.table, &options.unknown_table)?;
+        let repo = SqlitePlanetRepository::new(&conn, &options.table);
+        repo.ensure_table_exists()?;
+
+        for row in &rows {
+            match repo.apply_csv_overlay_row(row, true)? {
+                CsvOverlayOutcome::Inserted => stats.inserted += 1,
+                CsvOverlayOutcome::Active => stats.active += 1,
+                CsvOverlayOutcome::ModifiedExact => stats.modified_exact += 1,
+                CsvOverlayOutcome::ModifiedSuffix => stats.modified_suffix += 1,
+            }
+        }
+
+        if options.mark_deleted {
+            let (deleted, skipped) = repo.mark_deleted_not_in_csv(&rows, true)?;
+            stats.deleted = deleted;
+            stats.skipped = skipped;
+        }
+
+        return Ok(stats);
+    }
+
+    let mut conn = Connection::open(&options.db)
+        .with_context(|| format!("Unable to open DB: {}", options.db.display()))?;
+
+    ensure_required_schema(&conn, &options.table, &options.unknown_table)?;
+
+    let tx = conn.transaction()?;
+    {
+        let repo = SqlitePlanetRepository::new(&tx, &options.table);
+        repo.ensure_table_exists()?;
+
+        for row in &rows {
+            match repo.apply_csv_overlay_row(row, false)? {
+                CsvOverlayOutcome::Inserted => stats.inserted += 1,
+                CsvOverlayOutcome::Active => stats.active += 1,
+                CsvOverlayOutcome::ModifiedExact => stats.modified_exact += 1,
+                CsvOverlayOutcome::ModifiedSuffix => stats.modified_suffix += 1,
+            }
+        }
+
+        if options.mark_deleted {
+            let (deleted, skipped) = repo.mark_deleted_not_in_csv(&rows, false)?;
+            stats.deleted = deleted;
+            stats.skipped = skipped;
+        }
+    }
+    tx.commit()?;
+
+    Ok(stats)
+}

--- a/crates/sw_galaxy_map_sync/src/pipeline/mod.rs
+++ b/crates/sw_galaxy_map_sync/src/pipeline/mod.rs
@@ -1,1 +1,2 @@
 pub mod arcgis_import;
+pub mod csv_overlay;

--- a/crates/sw_galaxy_map_sync/src/sources/csv.rs
+++ b/crates/sw_galaxy_map_sync/src/sources/csv.rs
@@ -1,0 +1,141 @@
+use anyhow::{Context, Result, bail};
+use csv::{ReaderBuilder, StringRecord};
+use std::path::Path;
+
+use crate::models::{CsvOverlayFormat, CsvOverlayRow};
+use crate::utils::normalize_text;
+
+/// Load and normalize CSV overlay rows.
+pub fn load_overlay_csv(
+    path: &Path,
+    format: CsvOverlayFormat,
+    delimiter: Option<u8>,
+) -> Result<Vec<CsvOverlayRow>> {
+    let delimiter = match delimiter {
+        Some(value) => value,
+        None => detect_delimiter(path, format)?,
+    };
+
+    let mut rdr = ReaderBuilder::new()
+        .delimiter(delimiter)
+        .flexible(true)
+        .from_path(path)
+        .with_context(|| format!("Unable to open CSV overlay file: {}", path.display()))?;
+
+    let headers = rdr.headers()?.clone();
+    let detected_format = detect_format(&headers, format)?;
+    let mapping = CsvColumnMapping::from_headers(&headers, detected_format)?;
+
+    let mut rows = Vec::new();
+
+    for result in rdr.records() {
+        let record = result?;
+        let row = mapping.row_from_record(&record)?;
+
+        if row.system.trim().is_empty() {
+            continue;
+        }
+
+        rows.push(row);
+    }
+
+    Ok(rows)
+}
+
+fn detect_delimiter(path: &Path, format: CsvOverlayFormat) -> Result<u8> {
+    if format == CsvOverlayFormat::Official {
+        return Ok(b';');
+    }
+
+    if format == CsvOverlayFormat::Full {
+        return Ok(b',');
+    }
+
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Unable to inspect CSV delimiter: {}", path.display()))?;
+    let first_line = content.lines().next().unwrap_or_default();
+
+    let semicolon_count = first_line.matches(';').count();
+    let comma_count = first_line.matches(',').count();
+
+    if semicolon_count > comma_count {
+        Ok(b';')
+    } else {
+        Ok(b',')
+    }
+}
+
+fn detect_format(headers: &StringRecord, requested: CsvOverlayFormat) -> Result<CsvOverlayFormat> {
+    if requested != CsvOverlayFormat::Auto {
+        return Ok(requested);
+    }
+
+    let normalized = headers
+        .iter()
+        .map(|header| header.trim().to_lowercase())
+        .collect::<Vec<_>>();
+
+    let has_official_columns = ["system", "sector", "region", "grid"]
+        .iter()
+        .all(|column| normalized.iter().any(|header| header == column));
+
+    let has_full_columns = ["planet", "region", "sector", "system", "grid"]
+        .iter()
+        .all(|column| normalized.iter().any(|header| header == column));
+
+    if has_full_columns && normalized.iter().any(|header| header == "fid") {
+        Ok(CsvOverlayFormat::Full)
+    } else if has_official_columns {
+        Ok(CsvOverlayFormat::Official)
+    } else {
+        bail!("Unable to detect CSV overlay format from headers: {headers:?}")
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CsvColumnMapping {
+    system: usize,
+    sector: Option<usize>,
+    region: Option<usize>,
+    grid: Option<usize>,
+}
+
+impl CsvColumnMapping {
+    fn from_headers(headers: &StringRecord, format: CsvOverlayFormat) -> Result<Self> {
+        let system_name = match format {
+            CsvOverlayFormat::Auto => unreachable!("format must be detected before mapping"),
+            CsvOverlayFormat::Official => "system",
+            CsvOverlayFormat::Full => "System",
+        };
+
+        Ok(Self {
+            system: find_required_header(headers, system_name)?,
+            sector: find_optional_header(headers, "sector"),
+            region: find_optional_header(headers, "region"),
+            grid: find_optional_header(headers, "grid"),
+        })
+    }
+
+    fn row_from_record(&self, record: &StringRecord) -> Result<CsvOverlayRow> {
+        Ok(CsvOverlayRow {
+            system: normalize_text(record.get(self.system).unwrap_or_default()),
+            sector: normalize_text(optional_value(record, self.sector)),
+            region: normalize_text(optional_value(record, self.region)),
+            grid: normalize_text(optional_value(record, self.grid)),
+        })
+    }
+}
+
+fn find_required_header(headers: &StringRecord, name: &str) -> Result<usize> {
+    find_optional_header(headers, name).with_context(|| format!("Missing CSV header '{name}'"))
+}
+
+fn find_optional_header(headers: &StringRecord, name: &str) -> Option<usize> {
+    headers
+        .iter()
+        .position(|header| header.trim().eq_ignore_ascii_case(name))
+}
+
+fn optional_value(record: &StringRecord, index: Option<usize>) -> &str {
+    index.and_then(|idx| record.get(idx)).unwrap_or_default()
+}

--- a/crates/sw_galaxy_map_sync/src/sources/mod.rs
+++ b/crates/sw_galaxy_map_sync/src/sources/mod.rs
@@ -1,1 +1,2 @@
 pub mod arcgis;
+pub mod csv;

--- a/crates/sw_galaxy_map_sync/src/utils.rs
+++ b/crates/sw_galaxy_map_sync/src/utils.rs
@@ -21,6 +21,51 @@ pub fn hash_source(value: &serde_json::Value) -> String {
     format!("{:016x}", hasher.finish())
 }
 
+/// Build a comparison key for CSV overlay matching.
+pub fn cmp_key(value: &str) -> String {
+    normalize_text(value)
+        .to_lowercase()
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect()
+}
+
+/// Remove a trailing Roman numeral suffix from a normalized comparison key.
+///
+/// This helps matching rows such as `Yavin` against DB records like `Yavin IV`.
+pub fn strip_roman_suffix(value: &str) -> String {
+    const ROMAN_SUFFIXES: &[&str] = &[
+        "i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix", "x", "xi", "xii", "xiii", "xiv",
+        "xv", "xvi", "xvii", "xviii", "xix", "xx",
+    ];
+
+    for suffix in ROMAN_SUFFIXES.iter().rev() {
+        if value.len() > suffix.len() && value.ends_with(suffix) {
+            let prefix = &value[..value.len() - suffix.len()];
+            if !prefix.is_empty() {
+                return prefix.to_string();
+            }
+        }
+    }
+
+    value.to_string()
+}
+
+/// Returns true when a database row and a CSV overlay row contain identical
+/// curated metadata.
+pub fn same_overlay_fields(
+    db_sector: &str,
+    db_region: &str,
+    db_grid: &str,
+    csv_sector: &str,
+    csv_region: &str,
+    csv_grid: &str,
+) -> bool {
+    normalize_text(db_sector) == normalize_text(csv_sector)
+        && normalize_text(db_region) == normalize_text(csv_region)
+        && normalize_text(db_grid) == normalize_text(csv_grid)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/res/star_wars_galaxy_systems_official_semicolon.csv
+++ b/res/star_wars_galaxy_systems_official_semicolon.csv
@@ -1,0 +1,6758 @@
+system;sector;region;grid
+5251977;Quence;Outer Rim Territories;P-18
+Adelphi;Kibilini;Outer Rim Territories;P-17
+23 Mere;;Colonies;M-13
+Adikaria;;Core Worlds;K-12
+2GS-91E20;;Core Worlds;M-11
+Adim;Adari;Inner Rim;M-9
+A-Foroon;Arkanis;Outer Rim Territories;R-16
+Adin;Lostar;Expansion Region;M-7
+Aaeton;;Core Worlds;K-9
+Adinax Nebula;Semagi;Mid Rim;I-16
+Aakaash;Oplovis;Outer Rim Territories;M-5
+Adner;Yataga;Expansion Region;N-16
+Aaloth;Gaulus;Outer Rim Territories;S-17
+Adoris;Senex;Mid Rim;L-17
+Aar;Nijune;Outer Rim Territories;N-5
+Adras;Seswenna;Outer Rim Territories;M-17
+Aargau;;Core Worlds;L-10
+Adratharpe;;Mid Rim;H-15
+Aargonar;Perkell;Mid Rim;Q-7
+Adrathorpe;;Wild Space;H-11
+Aaris;Kathol;Outer Rim Territories;M-21
+Aduba;Bheriz;Outer Rim Territories;U-11
+Aaron;Tharin;Outer Rim Territories;S-8
+Adumar;;Wild Space;J-6
+Ab Dalis;Gaulus;Outer Rim Territories;R-17
+Aefao;Corosi;Outer Rim Territories;N-5
+Ab'Bshingh;Sujimis;Outer Rim Territories;O-19
+Aeneid;Kessel;Outer Rim Territories;T-10
+Abaarian;Abaar;Mid Rim;K-7
+Aeos;Chopani;Outer Rim Territories;M-3
+Abafar;Quelii;Outer Rim Territories;O-6
+Aesolian;;Wild Space;I-15
+Abar;Tragan Cluster;Outer Rim Territories;N-5
+Aestilan;Demetras;Outer Rim Territories;P-7
+Abbaji;Zuma (Spar);Outer Rim Territories;H-16
+Aeten;;Wild Space;J-6
+Abecederia;Noolian;Mid Rim;Q-13
+Affa;;Inner Rim;M-13
+Abednedo;;Colonies;N-12
+Affadar;Fellwe;Expansion Region;L-8
+Abelor;Yushan;Mid Rim;K-17
+Affavan;;Hutt Space;S-12
+Abersyn;Cyrillian Protectorate;Expansion Region;O-12
+Agamar;Lahara;Outer Rim Territories;M-5
+Abhean;Maldrood;Mid Rim;R-7
+Agaris;;Wild Space;G-14
+Abo Dreth;Corporate Sector;Outer Rim Territories;S-3
+Agash;Great Agash;Expansion Region;K-15
+Abonshee;Fakir;Colonies;K-9
+Aggarda;Metatessu;Mid Rim;R-10
+Abraxas;Yushan;Mid Rim;K-17
+Agoliba-Tu;Veragi;Outer Rim Territories;K-3
+Abraxin;Tion Hegemony;Outer Rim Territories;S-6
+Agomar;Seswenna;Outer Rim Territories;M-18
+Abregado;;Core Worlds;K-13
+Agon;Ash Worlds;Outer Rim Territories;T-7
+Abridon;Koradin;Outer Rim Territories;J-18
+Agora;Sluis;Outer Rim Territories;M-19
+Abrihom;Rayter;Outer Rim Territories;J-19
+Agridorn;;Colonies;N-12
+Abrion Major;Abrion;Outer Rim Territories;S-15
+Agriworld-2079;M'shinni;Mid Rim;L-7
+Absanz;Allied Tion;Outer Rim Territories;S-6
+Aguarl;Mbandamonte;Expansion Region;N-15
+Absit;Tunka;Outer Rim Territories;I-19
+Ahakista;Myto;Outer Rim Territories;K-3
+Abtin;Danjar;Outer Rim Territories;N-19
+Ahch-To;;Unknown Regions;F-13
+Abyss;Ash Worlds;Outer Rim Territories;S-7
+Ahn Krantarium;Esuain;Mid Rim;P-7
+Ac'fren;Calaron;Outer Rim Territories;T-9
+Ai'ken Prime;;Inner Rim;O-10
+Acachla;;Colonies;N-10
+Aida;Aida;Mid Rim;Q-13
+Achillea;Tapani;Colonies;L-13
+Aikhibba;Fei Hu;Mid Rim;P-13
+Acomber;;Colonies;M-9
+Ailon;;Inner Rim;N-12
+Actlyon;Jjannex;Outer Rim Territories;K-19
+Aiqin;Airam;Outer Rim Territories;L-20
+Adalog;Mytaranor;Mid Rim;Q-10
+Ajan Kloss;Cademimu;Outer Rim Territories;L-5
+Adamastor;;Core Worlds;L-9
+Ak-Hurst;Tarabba;Outer Rim Territories;M-19
+Adana;;Deep Core;L-10
+Akiva;Meerian;Outer Rim Territories;O-6
+Adari;Adari;Inner Rim;M-9
+Akkadese Maelstrom;Kessel;Outer Rim Territories;T-10
+Adarlon;Minos Cluster;Outer Rim Territories;M-20
+Aklasian Nebula;Kastolar;Mid Rim;R-10
+Akrit'tar;Calaron;Outer Rim Territories;T-9
+Alnaria;;Colonies;J-9
+Akuria;Oplovis;Outer Rim Territories;M-5
+Aloxl;;Deep Core;L-10
+Al'doleem;Hune;Mid Rim;Q-12
+Aloxor;Kontahr;Mid Rim;R-11
+Alabash;Fakir;Colonies;K-9
+Alpheridies;Farstey;Expansion Region;O-8
+Alagon;Tennuutta;Mid Rim;Q-7
+Alphoresis;Grumani;Outer Rim Territories;M-17
+Alakatha;Var Hagen;Mid Rim;M-16
+Alpinn;Kanz;Outer Rim Territories;N-4
+Alamass;Calaron;Outer Rim Territories;T-9
+Alsakan;Alsaka;Core Worlds;L-9
+Alarevi;Gaulus;Outer Rim Territories;S-17
+Altair;Thrasybule;Outer Rim Territories;P-6
+Alashan;;Wild Space;J-5
+Altano;Piryn Shar;Expansion Region;K-16
+Alaspin;Suolriep;Outer Rim Territories;S-8
+Altarrn;Glythe;Mid Rim;J-7
+Alassa Major;Vilonis;Mid Rim;O-16
+Altawar;Corellian;Core Worlds;M-11
+Alba;Belsmuth;Outer Rim Territories;O-6
+Althir;Rolion;Outer Rim Territories;P-6
+Albarrio;Albarrio;Outer Rim Territories;K-5
+Altier;Altier;Expansion Region;O-13
+Albecus;;Core Worlds;L-9
+Altikar;Toblain;Outer Rim Territories;O-18
+Albrae-Don;Sern;Colonies;L-13
+Altooni;Corellian;Core Worlds;M-11
+Alchenaut;Alchenaut;Expansion Region;L-16
+Altor;Zoraster;Outer Rim Territories;U-13
+Alderaan;Alderaan;Core Worlds;M-10
+Altora;Dalonbian;Outer Rim Territories;L-3
+Alderath;Alderath;Mid Rim;L-7
+Altratonne;Ash Worlds;Outer Rim Territories;S-7
+Alderbathe;Churnis;Mid Rim;J-6
+Altunna;Cassander;Outer Rim Territories;K-5
+Aldereen;;Inner Rim;M-14
+Altyr;Morshdine;Outer Rim Territories;O-5
+Aldhani;Cademimu;Outer Rim Territories;M-6
+Aludia;Trilon;Outer Rim Territories;H-16
+Aldin;Aldino;Mid Rim;J-17
+Alui;Alui;Mid Rim;O-17
+Aldivy;Illisurevimurasi;Outer Rim Territories;Q-4
+Alun;Oriolan;Mid Rim;J-16
+Aldo Spach;Jospro;Outer Rim Territories;S-7
+Alurion;Raioballo;Outer Rim Territories;L-4
+Aldraig;Alderaan;Core Worlds;M-10
+Alvadorjia;Andirma;Expansion Region;L-15
+Alee;;Hutt Space;R-9
+Alvorine;Yminis;Outer Rim Territories;S-14
+Aleen;Bright Jewel;Mid Rim;L-7
+Alzar;Thanium;Outer Rim Territories;R-6
+Aleen Minor;;Inner Rim;M-13
+Alzoc;Sujimis;Outer Rim Territories;P-19
+Aleron;Tapani;Colonies;L-13
+Amaltanna;Kanz;Outer Rim Territories;N-4
+Alfestril;;Inner Rim;N-12
+Amar;Airon;Inner Rim;O-10
+Algara;Lambda;Mid Rim;P-15
+Amarin;Allied Tion;Outer Rim Territories;S-6
+Algarian;Dufilvian;Mid Rim;Q-15
+Amaxine Station;Tunka;Outer Rim Territories;J-19
+Algarra;Thrasybule;Outer Rim Territories;P-6
+Ambria;Airon;Inner Rim;O-10
+Algnadesh;Hapes Cluster;Inner Rim;O-9
+Amethia Prime;;Inner Rim;L-14
+Algor;Cronese Mandate;Outer Rim Territories;S-6
+Amfar;;Inner Rim;O-8
+Algunnis;Trax;Mid Rim;Q-10
+Amloch;Rayter;Outer Rim Territories;J-19
+Alion;;Inner Rim;L-14
+Ammon;Ciutric;Outer Rim Territories;N-5
+Alios;Rachuk;Colonies;N-11
+Ammuud;Corporate Sector;Outer Rim Territories;S-4
+Alis Point;Tamarin;Outer Rim Territories;N-18
+Amorphiia;Eidoloni;Mid Rim;L-16
+Alisandor;Tapani;Colonies;L-13
+Amorris;Quelii;Outer Rim Territories;O-6
+Alk'Lellish;Sumitra;Expansion Region;N-7
+Ampliquen;Meridian;Outer Rim Territories;R-7
+Alkenak;;Core Worlds;M-12
+Anadeen;;Inner Rim;O-9
+Alland;;Core Worlds;K-10
+Anantapar;Javin (Yarith);Outer Rim Territories;K-18
+Allandor;Tapani;Colonies;L-13
+Anarak;Wyl;Outer Rim Territories;R-4
+Allanteen;Tynna;Expansion Region;O-14
+Anaxes;Antemeridian;Outer Rim Territories;R-7
+Allard;Svivreni;Outer Rim Territories;O-19
+Ancathia;Albarrio;Outer Rim Territories;K-5
+Alliga;Phelleem;Outer Rim Territories;S-7
+Anchoron;Mayagil;Outer Rim Territories;M-18
+Allst Prime;Taldot;Mid Rim;Q-8
+Andalia;Hapes Cluster;Inner Rim;O-9
+Alluuvia;Elrood;Outer Rim Territories;M-19
+Andara;;Core Worlds;L-13
+Allyuen;Javin (Anoat);Outer Rim Territories;K-18
+Andasala;Cor'ric;Outer Rim Territories;P-18
+Almagest, The;;Inner Rim;J-13
+Andelm;Svivreni;Outer Rim Territories;O-19
+Almak;Almak;Mid Rim;J-17
+Ando;Lambda;Mid Rim;Q-15
+Almakar;;Inner Rim;N-9
+Andooweel;Arkanis;Outer Rim Territories;R-16
+Almania;Mortex (Almanian);Outer Rim Territories;S-5
+Andosha;Lambda;Mid Rim;P-15
+Almar;Elrood;Outer Rim Territories;M-19
+Andraven;Wazta;Outer Rim Territories;J-18
+Almera;;Inner Rim;M-8
+Andulia;Doldur;Mid Rim;P-15
+Andurkoss;Nouane;Inner Rim;N-8
+Aplooine;Grumani;Outer Rim Territories;N-17
+Anduvia;Immalia;Expansion Region;K-8
+Apoka;Dohlbani;Mid Rim;R-14
+Anelsana;Farstey;Expansion Region;O-8
+Aq Vetina;Relgim;Outer Rim Territories;M-4
+Anemcoro;Albarrio;Outer Rim Territories;K-5
+Aquaris;Sumitra;Expansion Region;N-7
+Anga;Sarka;Mid Rim;Q-8
+Aquella;Senex;Mid Rim;L-17
+Angcord;;Inner Rim;I-13
+Aquilae;;Colonies;N-12
+Angeria;Venaarian;Mid Rim;O-8
+Aquilaris;Sanbra;Outer Rim Territories;O-17
+Angor;Myto;Outer Rim Territories;K-4
+Aquilaris Minor;Grumani;Outer Rim Territories;M-17
+Angrallia;Fath;Outer Rim Territories;K-6
+Arabanth;Hapes Cluster;Inner Rim;O-9
+Angratha;Senex;Mid Rim;L-18
+Aradia;;Core Worlds;K-10
+Anic;Xan;Mid Rim;Q-15
+Arah;Dantus;Outer Rim Territories;J-6
+Ank Ki'Shor;Indrexu;Outer Rim Territories;S-5
+Arakein;;Inner Rim;N-8
+Ank Kit'aar;Druess;Mid Rim;O-15
+Aralia;Antemeridian;Outer Rim Territories;R-7
+Ankhural;;Hutt Space;R-9
+Aramal;Ryborean;Expansion Region;J-8
+Ankori;Kossa;Expansion Region;P-10
+Aramand;Brak;Expansion Region;O-14
+Ankot Station;Brema;Outer Rim Territories;M-17
+Aramanoo;Bheriz;Outer Rim Territories;U-10
+Ankus;;Mid Rim;I-7
+Arami;Galov;Outer Rim Territories;T-13
+Annaj;Zuma (Moddell);Outer Rim Territories;H-16
+Arantara;Daimar;Mid Rim;Q-16
+Annamar;Bes Ber Bikade;Expansion Region;L-15
+Arapia;Dalchon;Outer Rim Territories;R-18
+Annoo;Tharin;Outer Rim Territories;S-8
+Arashar;;Inner Rim;J-8
+Anoat;Javin (Anoat);Outer Rim Territories;K-18
+Arat Fraca;;Colonies;M-12
+Anobis;Bright Jewel;Mid Rim;L-7
+Arath;Tunka;Outer Rim Territories;J-19
+Anorelga;Braxant;Outer Rim Territories;K-3
+Arbiflux;Dalonbian;Outer Rim Territories;L-3
+Anoth;;Wild Space;J-20
+Arbooine;(Arboo);Outer Rim Territories;T-17
+Ansarra;Iskin;Mid Rim;O-16
+Arbra;Bon'nyuw-Luq;Outer Rim Territories;N-17
+Ansata;;Core Worlds;M-11
+Arbular;Lambda;Mid Rim;Q-15
+Ansek;Eidoloni;Mid Rim;M-17
+Arc of Eden;Immalia;Expansion Region;K-8
+Ansillivog;Majoor;Expansion Region;N-15
+Arcadi;;Inner Rim;N-10
+Ansion;Churnis;Mid Rim;I-6
+Arcan;Cronese Mandate;Outer Rim Territories;S-6
+Anstares;Juvex;Mid Rim;L-17
+Arcana;Lahara;Outer Rim Territories;M-5
+Antakaria;Bothan;Mid Rim;R-14
+Archae Teuthis;Brevost;Expansion Region;O-14
+Antamont;Meridian;Outer Rim Territories;R-6
+Archais;Hapes Cluster;Inner Rim;O-9
+Antar;;Inner Rim;N-12
+Archenar;Metatessu;Mid Rim;R-10
+Antared;Esstran;Outer Rim Territories;Q-4
+Archeon Nebula;Lothal;Outer Rim Territories;T-7
+Antares;;Inner Rim;N-12
+Arcopola;Spadja;Outer Rim Territories;Q-5
+Anteevy;Esuain;Mid Rim;P-7
+Arcura;;Inner Rim;L-8
+Antemeridias;Antemeridian;Outer Rim Territories;R-7
+Arda;Gordian Reach;Outer Rim Territories;Q-6
+Anthan;Braxant;Outer Rim Territories;K-3
+Ardennia;Fath;Outer Rim Territories;K-6
+Anthus;Brema;Outer Rim Territories;M-17
+Ardis;;Unknown Regions;G-3
+Antillion;D'Astan;Outer Rim Territories;O-6
+Ardroxia;Elochar;Mid Rim;R-9
+Antine;;Outer Rim Territories;I-19
+Ardru;Iseno;Inner Rim;N-13
+Antipose;Centrality;Outer Rim Territories;U-8
+Argai;Cronese Mandate;Outer Rim Territories;S-6
+Antiquity;Senex;Mid Rim;L-18
+Argai Minor;Haldeen;Colonies;M-9
+Antmuel;Chopani;Outer Rim Territories;M-3
+Argavat;;Colonies;J-13
+Anto's Star;Saijo;Outer Rim Territories;K-20
+Argazda;Kanz;Outer Rim Territories;N-4
+Antolus;Sarka;Mid Rim;Q-8
+Argo;Tragan Cluster;Outer Rim Territories;N-5
+Anturus;Senex;Mid Rim;L-18
+Argoba;Trilon;Outer Rim Territories;H-15
+Anukara;Prackla;Expansion Region;O-8
+Argoon;Tion Hegemony;Outer Rim Territories;S-6
+Anx Minor;Raioballo;Outer Rim Territories;L-4
+Argovia;Endocray;Mid Rim;S-14
+Anzat;Bryx;Mid Rim;R-7
+Argul;D'Aelgoth;Mid Rim;L-17
+Anzell;Bryx;Mid Rim;R-7
+Argus;Lambda;Mid Rim;P-16
+Aostai;;Wild Space;I-13
+Aria Prime;;Inner Rim;O-9
+Apatros;Savareen;Outer Rim Territories;Q-16
+Ariarch-17;Ariarch;Mid Rim;J-6
+Apgar;Hilo;Expansion Region;O-13
+Aricho;Danjar (Siannach);Outer Rim Territories;N-18
+Aphran;;Inner Rim;K-8
+Aridinia;;Inner Rim;M-13
+Apiliria;;Wild Space;T-5
+Aridka;Hertae;Mid Rim;Q-14
+Aridus;Narvath;Expansion Region;O-14
+Asog;Esstran;Outer Rim Territories;Q-4
+Arieli;Authala;Expansion Region;P-12
+Asran;Brak;Expansion Region;O-14
+Aris;Albarrio;Outer Rim Territories;K-5
+Asrat;;Inner Rim;N-8
+Aris Minor;Parmel;Outer Rim Territories;O-18
+Ast Kikorie;Zuma (Moddell);Outer Rim Territories;H-16
+Arkam;;Inner Rim;M-14
+Astenban;Seswenna;Outer Rim Territories;M-18
+Arkania;;Colonies;M-8
+Asteph'skaff;;Wild Space;I-6
+Arkanis;Arkanis;Outer Rim Territories;R-17
+Asterios;Narrant;Mid Rim;I-16
+Arkax Station;;Inner Rim;M-14
+Asternin;Tamarin;Outer Rim Territories;N-19
+Arkinnea;Axion;Expansion Region;P-10
+Astrali;Var Hagen;Mid Rim;M-16
+Arkonne;Tarabba;Outer Rim Territories;M-19
+Asturias;Epsi Collective;Expansion Region;M-16
+Arkuda;Gordian Reach;Outer Rim Territories;Q-6
+Asuin;;Hutt Space;S-11
+Arleen;Centrality;Outer Rim Territories;T-8
+Asusto;Gordian Reach;Outer Rim Territories;P-5
+Arli;Mayagil;Outer Rim Territories;N-18
+Asyrphus;Perkell;Mid Rim;Q-7
+Armath;Mikaster;Expansion Region;N-15
+At Attin;Quelii;Outer Rim Territories;N-6
+Arnot Station;Far Xandil;Mid Rim;P-16
+At Aytuu;Trilon;Outer Rim Territories;G-15
+Arnt;;Inner Rim;N-8
+Atalia;Varada;Outer Rim Territories;H-19
+Arorua;Sertar;Outer Rim Territories;R-5
+Atanu;Alderath;Mid Rim;L-7
+Arporatal-Lanin;Juvex;Mid Rim;K-18
+Atapap;;Inner Rim;N-12
+Arquata Station;Bes Ber Bikade;Expansion Region;L-15
+Atchorb;Corporate Sector;Outer Rim Territories;S-3
+Arrakan;Kalamith;Outer Rim Territories;P-5
+Athallia;Athallia;Expansion Region;M-15
+Arramanx;Cronese Mandate;Outer Rim Territories;S-6
+Athamar;Hewett;Mid Rim;M-7
+Arreyel;;Inner Rim;M-14
+Ather;Atravis;Outer Rim Territories;L-20
+Arrgaw;Kira;Expansion Region;N-16
+Athio;Mayagil;Outer Rim Territories;N-18
+Arrochar;;Hutt Space;S-8
+Athiss;Esstran (Sith Worlds);Outer Rim Territories;R-4
+Arron Prime;Cassander;Outer Rim Territories;L-5
+Athus Klee;Kalamith;Outer Rim Territories;P-5
+Atoa;Ghost Nebula;Expansion Region;P-10
+Arsteni;;Colonies;L-8
+Atollon;Lothal;Outer Rim Territories;T-7
+Artemesium;Lifh;Mid Rim;R-8
+Ator;;Core Worlds;M-10
+Artesia;Hangshan;Expansion Region;P-11
+Atorra;Gordian Reach;Outer Rim Territories;Q-5
+Arthon;Ottega;Mid Rim;L-6
+Atraken;Rolion;Outer Rim Territories;Q-7
+Arthuria;Merthian;Expansion Region;N-14
+Atrakus;Mikaster;Expansion Region;M-15
+Artiod Minor;Morellian CW*;Wild Space;S-3
+Atravis;Atravis;Outer Rim Territories;L-19
+Artom;Nuon e Safyd;Expansion Region;P-12
+Atron;Senex;Mid Rim;L-18
+Artorias;Myto;Outer Rim Territories;K-3
+Attahox;Hocatar;Expansion Region;P-12
+Artus Prime;Kwymar;Outer Rim Territories;Q-4
+Atterol;Atravis;Outer Rim Territories;L-19
+Aruza;;Expansion Region;I-14
+Atterra;Kanz;Outer Rim Territories;N-4
+Arvaka Prime;;Inner Rim;N-9
+Aturi Cluster;Hook Nebula;Outer Rim Territories;O-18
+Arvala;Sevetta;Outer Rim Territories;S-15
+Atzerri;;Inner Rim;M-13
+Arveesh Station;Eclorar;Mid Rim;Q-12
+Aubadas;Tunka;Outer Rim Territories;I-19
+Arvina;Quiberon;Outer Rim Territories;S-15
+Aur;;Colonies;J-13
+Arzid;Calaron;Outer Rim Territories;T-9
+Auratera;Vorzyd;Outer Rim Territories;R-6
+Asamin;Strabin;Mid Rim;M-7
+Aurea;Corellian;Core Worlds;M-11
+Asation;Veragi (Gree Enclave);Outer Rim Territories;K-3
+Auril;Auril;Outer Rim Territories;R-6
+Ash Moon 1;Jubilar (Kartovian);Outer Rim Territories;T-7
+Aurimaus;;Wild Space;I-16
+Ashas Ree;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Austan;Arkanis;Outer Rim Territories;R-16
+Ashas Rine;Mortex;Outer Rim Territories;R-5
+Avedot;;Colonies;L-8
+Ashash;Zarracina;Expansion Region;N-14
+Avenel;;Inner Rim;O-8
+Asher;Sprizen;Outer Rim Territories;N-5
+Avenelle;Lantillian;Mid Rim;P-9
+Asheris;Tagge Space;Core Worlds;L-9
+Averam;Seswenna;Outer Rim Territories;M-18
+Ashkas-kov;Shelsha;Colonies;M-9
+Averill;Teraab;Mid Rim;P-11
+Ashteri's Cloud;Kessel;Outer Rim Territories;T-10
+Avernio;;Unknown Regions;G-5
+Askaj;Cegul;Outer Rim Territories;M-20
+Avery;Belderone;Outer Rim Territories;R-6
+Askaria;Askarian;Expansion Region;P-12
+Avidich;Chiss Space*;Unknown Regions;E-8
+Askkto-Fen;;Wild Space;P-19
+Aviles Prime;Hythrope;Expansion Region;M-15
+Asmall;Ara Dyelle;Inner Rim;O-9
+Awalia;Raioballo;Outer Rim Territories;L-4
+Asmeru;Senex;Mid Rim;L-17
+AX-456;Barma;Colonies;M-9
+Axion;Axion;Expansion Region;P-10
+Baltro;Onatos;Mid Rim;R-15
+Axtria;;Core Worlds;L-9
+Bamasia;;Inner Rim;N-9
+Axxila;D'Astan;Outer Rim Territories;O-5
+Bamayar;Maldrood;Mid Rim;R-7
+Aybaria;Steniplis;Outer Rim Territories;L-19
+Bampa'k;Prefsbelt;Outer Rim Territories;K-5
+Ayceezee;Kanz;Outer Rim Territories;N-4
+Ban-Satir;Corporate Sector;Outer Rim Territories;S-4
+Aylayl;;Hutt Space;S-12
+Banas;Sanbra;Outer Rim Territories;O-17
+Aynaboni;;Outer Rim Territories;J-5
+Banasthau;;Inner Rim;O-11
+Ayoh;Phelleem;Outer Rim Territories;S-7
+Bancar;Rayter;Outer Rim Territories;J-19
+Azbrian;;Core Worlds;L-12
+Banchii;Jjannex;Outer Rim Territories;K-19
+Azna;Demetras;Outer Rim Territories;P-6
+Bandomeer;Meerian;Outer Rim Territories;O-6
+Aztubek;Javin;Outer Rim Territories;K-18
+Bandonia;;Core Worlds;L-10
+Azum;Itopol;Expansion Region;K-15
+Bandorra;;Colonies;N-10
+Azura;Oricho;Outer Rim Territories;M-6
+Banfoden Prime;Alchenaut;Expansion Region;L-16
+Azure;Truum;Mid Rim;P-8
+Bannistar Station;Hevvrol;Mid Rim;O-15
+Azzameen Station;Garis;Outer Rim Territories;N-17
+Bantoo;Samix;Outer Rim Territories;Q-19
+B-Foroon;Arkanis;Outer Rim Territories;R-16
+Bantu;Emmo;Core Worlds;M-12
+B'Knos;;Wild Space;G-16
+Banvhar Station;Kriz;Outer Rim Territories;J-18
+B'nish;Tharin;Outer Rim Territories;S-8
+Bar Neth;Albarrio;Outer Rim Territories;K-5
+B'trilla;Gordian Reach;Outer Rim Territories;Q-5
+Bar'leth;;Core Worlds;M-10
+Baarstal;Sanbra;Outer Rim Territories;N-17
+Baraan-Fa;Grumani;Outer Rim Territories;N-17
+Babali;Corva;Outer Rim Territories;P-3
+Barab;Albanin;Outer Rim Territories;U-12
+Babbadod;;Inner Rim;N-14
+Barabaras;;Mid Rim;J-15
+Bacia;;Inner Rim;M-14
+Barabesh;;Mid Rim;I-16
+Bacrana;Brak;Expansion Region;O-14
+Baraboo;;Core Worlds;M-11
+Bactriasa;;Inner Rim;O-10
+Baradas;;Colonies;L-8
+Badfellow Station;;Core Worlds;M-10
+Baralou;Varada;Outer Rim Territories;H-20
+Badtibira;;Core Worlds;K-12
+Baramorra;Carrion;Outer Rim Territories;J-4
+Baes Logia;Quence;Outer Rim Territories;O-18
+Barancar;Cronese Mandate;Outer Rim Territories;S-6
+Baffia;;Deep Core;L-12
+Barayfe;Alchenaut;Expansion Region;L-16
+Baffop;Tamarin;Outer Rim Territories;O-19
+Barbadel;;Core Worlds;K-13
+Bahalian;Astal;Outer Rim Territories;P-18
+Barbeen;;Deep Core;L-10
+Bahlah;Thesme;Outer Rim Territories;O-6
+Barcaria;Sombure;Mid Rim;K-16
+Bajic;Bajic;Outer Rim Territories;P-18
+Barcola;;Colonies;N-10
+Bakisian Drift;Tragan Cluster;Outer Rim Territories;N-5
+Bardelberan;Churnis;Mid Rim;J-6
+Bakkah;Thrasybule;Outer Rim Territories;P-6
+Bardotta;Shasos;Colonies;K-13
+Baklek;;Inner Rim;N-12
+Bardram Scoft;;Unknown Regions;D-7
+Bakura;;Wild Space;G-16
+Barenth;Drannik;Expansion Region;K-8
+Bal'demnic;Auril;Outer Rim Territories;R-7
+Barison;Gordian Reach;Outer Rim Territories;Q-6
+Balagash;Hali;Expansion Region;O-9
+Barkhesh;Seitia;Outer Rim Territories;K-19
+Balaidas;;Colonies;L-8
+Barlok;Marcol;Inner Rim;L-8
+Balamak;Taldot;Mid Rim;Q-9
+Barnaba;Tapani;Colonies;L-13
+Balanor;Noonian;Outer Rim Territories;M-6
+Barnahof;Yminis;Outer Rim Territories;S-14
+Balaria;;Core Worlds;M-12
+Baroli;Baroli;Expansion Region;N-14
+Baldavia;Hapes Cluster;Inner Rim;O-9
+Baroonda;Calaron;Outer Rim Territories;T-9
+Baldur;Nojic;Expansion Region;P-9
+Baros;Lothal;Outer Rim Territories;U-7
+Balfron;Dolomar;Core Worlds;K-9
+Barpine;Weneen;Outer Rim Territories;N-6
+Balis-Baurgh;Sombure;Mid Rim;K-16
+Barraken;Varada;Outer Rim Territories;H-19
+Balith;;Inner Rim;N-7
+Barroth;Kriz;Outer Rim Territories;K-19
+Balli;Abrion;Outer Rim Territories;S-15
+Bars Barka;Barsa;Mid Rim;J-6
+Ballum;Kastolar;Mid Rim;Q-10
+Barseg;Allied Tion;Outer Rim Territories;S-6
+Balmorra;;Colonies;M-10
+Bartokan;Tamarin;Outer Rim Territories;N-19
+Balnab;Bright Jewel;Mid Rim;L-7
+Barton;Colundra;Outer Rim Territories;S-5
+Balosar;;Core Worlds;L-12
+Barundi;Thanium;Outer Rim Territories;S-5
+Balowa;Daalang;Mid Rim;Q-12
+Basan;Churba;Mid Rim;P-15
+Baltimn;Chorlian;Outer Rim Territories;S-4
+Basarais;Kossa;Expansion Region;O-11
+Baltizaar;Corthenia;Mid Rim;K-7
+Basath;;Colonies;J-13
+Basilisk;;Core Worlds;L-9
+Belukat;Corpheli;Expansion Region;M-7
+Baskarn;Noonian;Outer Rim Territories;M-6
+Belvaria;Corweillian;Mid Rim;P-15
+Baskron;Trax;Mid Rim;Q-10
+Benath;;Wild Space;I-7
+Bassadro;;Colonies;L-13
+Bendeluum;Javin (Anoat);Outer Rim Territories;K-18
+Bassel;;Inner Rim;N-13
+Bendii;Seitia;Outer Rim Territories;K-19
+Basta Core;Wyl;Outer Rim Territories;R-4
+Bendone;Bosph;Outer Rim Territories;R-3
+Bastatha;;Inner Rim;N-10
+Benetage;Thanium;Outer Rim Territories;R-6
+Basteel;Corva;Outer Rim Territories;P-3
+Bengat;;Inner Rim;J-8
+Bastion;Braxant;Outer Rim Territories;K-3
+Bengely;Tamarin;Outer Rim Territories;N-19
+Bastooine;Graador;Mid Rim;I-17
+Benglor;Onatos;Mid Rim;R-15
+Bathoris;;Inner Rim;N-8
+Benja-Rihn;Sevastol;Mid Rim;Q-14
+Batonn;Ash Worlds (Batonn);Outer Rim Territories;T-7
+Benkal;;Wild Space;H-17
+Bator Bai;Senex;Mid Rim;L-18
+Bentora;Samix;Outer Rim Territories;Q-19
+Batorine;;Colonies;J-9
+Benwabula;Shadola;Outer Rim Territories;U-7
+Batravia;Serathrace;Expansion Region;P-11
+Ber de Val;;Colonies;M-9
+Batuu;Trilon;Outer Rim Territories;G-15
+Berason;Eclorar;Mid Rim;Q-12
+Batuv;Askarian;Expansion Region;P-12
+Berchest;Anthos;Inner Rim;N-8
+Baummu;Shadola;Outer Rim Territories;U-8
+Berea;Elrood;Outer Rim Territories;M-19
+Bavana;Sertar;Outer Rim Territories;R-5
+Beris;Fei Hu;Mid Rim;Q-13
+Bavva;Javin (Anoat);Outer Rim Territories;K-18
+Bernilla;;Inner Rim;L-14
+Baylagon;;Core Worlds;M-10
+Beroq;Baroli;Expansion Region;N-14
+Baylin Cluster;Trans-Nebular;Mid Rim;R-16
+Berri;;Inner Rim;N-9
+Bayora;Extorin;Expansion Region;J-15
+Berrol's Donn;Kriz;Outer Rim Territories;K-19
+Bazaar;Halthor;Outer Rim Territories;M-6
+Berrun;;Colonies;M-10
+Bazarre;Cademimu;Outer Rim Territories;M-6
+Berullia;Quence;Outer Rim Territories;O-18
+Beauchen;Vensori;Mid Rim;P-8
+Berzite;;Wild Space;U-8
+Beckoning Call Starr;;Inner Rim;O-10
+Bes;Airam;Outer Rim Territories;M-20
+Bedlam;Thusa;Mid Rim;O-7
+Besberra;Cegul;Outer Rim Territories;L-20
+Bedlam Pulsar;Thusa;Mid Rim;O-7
+Bescane;Obtrexta;Outer Rim Territories;K-3
+Beetle Nebula;Bon'nyuw-Luq;Outer Rim Territories;N-18
+Besero;;Deep Core;L-10
+Begali;;Inner Rim;M-8
+Beshka;Aparo;Outer Rim Territories;R-3
+Begamor;Lahara;Outer Rim Territories;M-5
+Besn;Mayagil;Outer Rim Territories;N-18
+Begeren;Esstran (Sith Worlds);Outer Rim Territories;R-4
+Besnia;;Colonies;N-12
+Beheboth;Sanbra;Outer Rim Territories;O-17
+Bespin;Javin (Anoat);Outer Rim Territories;K-18
+Beixander;;Mid Rim;H-15
+Bessimir;;Core Worlds;L-9
+Belasco;Belasco;Expansion Region;O-11
+Bestal;Varada;Outer Rim Territories;I-19
+Belassar;Sarla;Expansion Region;J-8
+Bestine;;Inner Rim;M-14
+Belat;Vilonis;Mid Rim;O-16
+Bestoon;;Colonies;J-9
+Belazura;;Colonies;M-13
+Beta Olikark;Wyl;Outer Rim Territories;S-4
+Belderone;Belderone;Outer Rim Territories;R-6
+Beta Rhama;Dalchon;Outer Rim Territories;R-17
+Beledeen;;Colonies;K-13
+Betal;;Wild Space;J-5
+Belgaroth;;Core Worlds;K-13
+Betha;Corva;Outer Rim Territories;P-4
+Belial;Sanbra;Outer Rim Territories;N-17
+Bethal;Tapani;Colonies;L-13
+Belkadan;Dalonbian;Outer Rim Territories;L-1
+Bethars;Emmo;Core Worlds;M-12
+Belladoon;Myto;Outer Rim Territories;K-3
+Betolio;Tapani;Colonies;L-13
+Bellassa;;Core Worlds;M-11
+Betshish;Gordian Reach;Outer Rim Territories;P-5
+Bellis;Demetras;Outer Rim Territories;P-7
+Bettel;Javin (Yarith);Outer Rim Territories;K-18
+Belloria;Seswenna;Outer Rim Territories;M-18
+Betthanie;Wornal;Mid Rim;K-16
+Belnar;Belnar;Colonies;M-9
+Bettok;Velcar;Outer Rim Territories;J-4
+Belovia;Ombakond;Expansion Region;P-12
+Bevell;;Inner Rim;L-8
+Belsavis;Bozhnee;Outer Rim Territories;L-18
+Bevin;Rolion;Outer Rim Territories;Q-6
+Belshar Othacuu;Belshar;Mid Rim;J-7
+Bextar;Velcar;Outer Rim Territories;J-4
+Belsmuth;Belsmuth;Outer Rim Territories;O-6
+Bezha;;Colonies;N-10
+Belthu;Demetras;Outer Rim Territories;O-7
+Bezim;Vorc;Mid Rim;J-7
+Beltire;Narrant;Mid Rim;J-17
+Beznaz;Quiberon;Outer Rim Territories;T-15
+Beltrix;;Inner Rim;M-14
+Bhargebba;Esstran (Sith Worlds);Outer Rim Territories;R-4
+Bheriz;Bheriz;Outer Rim Territories;U-10
+Bogano;Mieru'kar;Outer Rim Territories;N-3
+Bhuna Sound;Yushan;Mid Rim;K-17
+Bogden;;Inner Rim;M-8
+Bianas;Tapani;Colonies;L-13
+Bogo Rai;;Unknown Regions;E-8
+Bid'jerma;Prefsbelt;Outer Rim Territories;J-5
+Bogoa;Immerian Outback;Expansion Region;N-14
+Biewa;Corporate Sector;Outer Rim Territories;S-4
+Boiyuh;;Colonies;J-9
+Biitu;Cassander (Tadrin);Outer Rim Territories;K-5
+Bolad;Tharin;Outer Rim Territories;S-8
+Biivren;Biivren;Expansion Region;P-9
+Bolbotarp;Corellian;Core Worlds;M-11
+Bilbringi;;Inner Rim;J-8
+Boldavia;;Expansion Region;I-9
+Bilios;Tapani;Colonies;L-13
+Boledge;;Inner Rim;N-12
+Billaron;Chitarghar;Expansion Region;K-15
+Bolenia;;Core Worlds;K-9
+Bilzen;;Wild Space;U-12
+Boltiga;;Colonies;M-13
+Bimin Three;Majoor;Expansion Region;N-15
+Boltrunia;Baxel;Outer Rim Territories;U-11
+Bimmiel;Kanz;Outer Rim Territories;N-4
+Bomis Koori;Wornal;Mid Rim;K-16
+Bimmisaari;Halla;Mid Rim;R-9
+Bomodon;Churba;Mid Rim;O-15
+Binaros;Kathol;Outer Rim Territories;M-21
+Bompreil;Demetras;Outer Rim Territories;P-7
+Binquaros;Ciutric;Outer Rim Territories;N-5
+Bonadan;Corporate Sector;Outer Rim Territories;S-3
+Biravia;Venaarian;Mid Rim;O-7
+Boneworld, The;Toblain;Outer Rim Territories;N-18
+Birba;;Deep Core;M-10
+Bontormia;Bortele;Mid Rim;R-8
+Birgis;Dalonbian;Outer Rim Territories;M-3
+Boonta;Suolriep;Outer Rim Territories;S-8
+Birix;Bryx;Mid Rim;R-8
+Boordii;Sumitra;Expansion Region;N-7
+Birjis;Dalchon;Outer Rim Territories;R-17
+Boosodia;;Inner Rim;N-8
+Birren;;Inner Rim;O-10
+Bootana Shagplan;;Hutt Space;S-10
+Birsingrial;;Core Worlds;L-10
+Boothi;Abrion;Outer Rim Territories;S-15
+Birukay;(Gardaji);Outer Rim Territories;M-1
+Boranall;Doldur;Mid Rim;P-15
+Bisellia;Clacis;Outer Rim Territories;K-4
+Boranda;Manda;Mid Rim;R-14
+Biskar;;Inner Rim;K-14
+Borao;;Inner Rim;M-14
+Bissillirus;Trax;Mid Rim;Q-10
+Borcorash;Weneen;Outer Rim Territories;N-6
+Bith;;Core Worlds;L-13
+Borga;Yminis;Outer Rim Territories;S-14
+Bitmus Cloud;Wazta;Outer Rim Territories;J-18
+Boriin;;Inner Rim;N-14
+Bittelari Cluster;Fath;Outer Rim Territories;K-6
+Borkeen;Belsmuth;Outer Rim Territories;O-6
+Bivoli;;Inner Rim;L-15
+Borkyne;Bes Ber Bikade;Expansion Region;L-15
+Bizikia;Kwymar;Outer Rim Territories;P-4
+Borlax;Jidlor Marches;Mid Rim;J-16
+Black Bantha;;Inner Rim;K-8
+Borleias;;Colonies;K-9
+Black Delve, The;Har Worlds;Expansion Region;J-16
+Borloria;Dentari;Expansion Region;O-8
+Black Hole of Nakat;;Inner Rim;N-7
+Borlov;Tunka;Outer Rim Territories;J-19
+Black Hole of Quintas;Kriz;Outer Rim Territories;J-19
+Bormea;Bormea;Core Worlds;L-9
+Black Nebula;;Colonies;M-12
+Bormter;;Wild Space;H-14
+Black Widow Nebula;Calaron;Outer Rim Territories;T-9
+Bormus;Dustig;Mid Rim;N-16
+Blackfel;Greater Plooriod;Expansion Region;M-7
+Boro-borosa;Senex;Mid Rim;L-18
+Blacktar Cyst;Oktos;Mid Rim;R-12
+Bororn;Rseik;Outer Rim Territories;N-20
+Blair Cluster;Airam;Outer Rim Territories;L-20
+Borosk;Prefsbelt;Outer Rim Territories;K-5
+Blarrum;Mayagil;Outer Rim Territories;N-18
+Bortele Cluster;Bortele;Mid Rim;R-8
+Blathar;Yucrales;Mid Rim;R-15
+Bortras;Brema (Reithcas);Outer Rim Territories;M-18
+Blenjeel;Dufilvian;Mid Rim;Q-15
+Boruga;;Core Worlds;L-10
+Bleuf;;Core Worlds;L-13
+Bos-Una;;Inner Rim;J-14
+Blimph;Kastolar;Mid Rim;Q-10
+Bosch;;Core Worlds;K-10
+Blood Nest;Halori;Mid Rim;P-7
+Bosph;Bosph;Outer Rim Territories;Q-3
+Bloxia;;Wild Space;I-7
+Bosthirda;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Blutopia;Vensensor;Expansion Region;K-16
+Botajef;Belsmuth;Outer Rim Territories;O-6
+Blyte;Tapani;Colonies;L-13
+Bothawui;Bothan;Mid Rim;R-14
+Bnach;Calaron;Outer Rim Territories;T-9
+Bothsoliman;Hollan;Mid Rim;M-7
+Bnar;Braxant;Outer Rim Territories;K-3
+Botor;Botor Enclave;Core Worlds;K-12
+Boden;Videnda;Outer Rim Territories;M-18
+Boudolayz;;Colonies;N-12
+Bodoria;Andirma;Expansion Region;L-15
+Bovo Yagen;Kailion;Expansion Region;O-13
+Bodrin;Elrood;Outer Rim Territories;M-20
+Bowane Nebula;Tungra (Fand);Outer Rim Territories;K-18
+Bofa;Steniplis;Outer Rim Territories;M-18
+Boxer Point Station;Prackla;Expansion Region;O-8
+Boz Pity;Halla;Mid Rim;S-9
+Buamlon Central;Esstran;Outer Rim Territories;Q-4
+Boztrok;Aparo;Outer Rim Territories;R-3
+Bubble of the Lost;;Wild Space;O-3
+Bpfassh;Sluis;Outer Rim Territories;M-19
+Buchich;Calamari;Outer Rim Territories;U-6
+Bracca;Lantillian;Mid Rim;P-9
+Budpock;Meridian;Outer Rim Territories;R-7
+Braccio;;Wild Space;I-5
+Bulano;;Core Worlds;M-10
+Brachi;Sertar;Outer Rim Territories;R-5
+Bundil;Ferra;Outer Rim Territories;S-16
+Brachnis Chorios;Meridian;Outer Rim Territories;R-7
+Bundim;Trax;Mid Rim;Q-10
+Brackna;Doldur;Mid Rim;P-15
+Bunduki;Pacanth Reach;Outer Rim Territories;H-16
+Bracront;Tarabba;Outer Rim Territories;M-19
+Bunka;Illisurevimurasi;Outer Rim Territories;Q-4
+Bragkis;Belderone;Outer Rim Territories;R-6
+Buoyant;;Inner Rim;J-14
+Bramior;;Inner Rim;M-9
+Burna;Cademimu;Outer Rim Territories;L-6
+Branteez;Tolonda;Outer Rim Territories;Q-17
+Burnin Konn;Javin (Anoat);Outer Rim Territories;K-18
+Brask Oto;;Unknown Regions;H-7
+Burnsi;Dustig;Mid Rim;N-16
+Bravais;;Inner Rim;O-9
+Bursant;Taldot;Mid Rim;Q-9
+Bravis;Spadja;Outer Rim Territories;R-5
+Burska;;Mid Rim;I-7
+Bray;Piryn Shar;Expansion Region;K-16
+Bursoll;;Wild Space;H-17
+Breeka;Cadavine;Outer Rim Territories;P-17
+Burundang;Harron;Expansion Region;O-11
+Brella Temior;Barma;Colonies;M-9
+Buruunin;Atravis;Outer Rim Territories;L-19
+Brendok;;Wild Space;Q-2
+Byblos;;Colonies;M-12
+Brentaal;Bormea;Core Worlds;L-9
+Byllura;Grumani;Outer Rim Territories;N-17
+Bresallis;Cadma;Outer Rim Territories;T-8
+Bynarria;Lantillian;Mid Rim;P-8
+Bresan;Kathol;Outer Rim Territories;M-21
+Byrnum Maw;;Inner Rim;L-8
+Breshig;Mandalore;Outer Rim Territories;O-7
+Byrsym;Paqwepori;Mid Rim;P-15
+Breshkall;Khuiumin;Outer Rim Territories;O-19
+Byss;;Deep Core;K-11
+Bresnia;Tandon;Mid Rim;Q-14
+C-Foroon;Arkanis;Outer Rim Territories;R-16
+Breta Yaga;Mieru'kar;Outer Rim Territories;O-3
+Caamas;;Core Worlds;M-9
+Bretta;Ojoster;Outer Rim Territories;N-7
+Caaraz;Stensen;Outer Rim Territories;H-17
+Brevost;Brevost;Expansion Region;O-15
+Caarimon;Meridian;Outer Rim Territories;R-7
+Bri'ahl;Bri'ahl;Outer Rim Territories;I-17
+Caarsin Station;Lannik Wilds;Mid Rim;R-13
+Bri'n;Lothal;Outer Rim Territories;U-7
+Cabarria;;Colonies;M-13
+Bridin Anchorage;Portmoak;Outer Rim Territories;P-18
+Cadannia;Msst;Mid Rim;P-7
+Brield;;Colonies;M-12
+Cademimu;Cademimu;Outer Rim Territories;M-6
+Brightday;;Inner Rim;K-8
+Cadinth;Allied Tion;Outer Rim Territories;S-6
+Brigia;Tion Hegemony;Outer Rim Territories;T-6
+Cadma;Centrality;Outer Rim Territories;T-8
+Brink Station;;Wild Space;O-3
+Cadomai;Aparo (Catarlo);Outer Rim Territories;R-3
+Brint-wo;Koradin;Outer Rim Territories;I-18
+Cal-Seti;Torranix;Core Worlds;K-10
+Brintooin;Seswenna;Outer Rim Territories;M-18
+Calabar;;Core Worlds;L-9
+Briston;Shelsha;Colonies;M-9
+Calabosh;Arc d'Stot;Expansion Region;K-15
+Britaxis Minor;;Inner Rim;O-11
+Calast;Grohl;Outer Rim Territories;R-16
+Brix;;Colonies;N-10
+Calcoraan;;Inner Rim;O-10
+Brochiib;Trianii Space*;Wild Space;S-3
+Calderos Station;Bryx;Mid Rim;R-8
+Brodo Asogi;Perinn;Outer Rim Territories;J-4
+Caldoni;;Core Worlds;M-12
+Brodogon;Bozhnee;Outer Rim Territories;L-18
+Caldra Prime;Ado;Mid Rim;M-17
+Broest;;Core Worlds;L-10
+Caldra Tertius;Ado;Mid Rim;M-17
+Brolsam;Kathol;Outer Rim Territories;M-21
+Calfa;Hapes Cluster;Inner Rim;O-9
+Bromlarch;Vish;Mid Rim;O-16
+Calgon;Meridian;Outer Rim Territories;R-7
+Bronsoon;Gordian Reach;Outer Rim Territories;P-6
+Caliban;Savareen;Outer Rim Territories;Q-17
+Bront;Svivreni;Outer Rim Territories;O-19
+Calior;Seitia;Outer Rim Territories;K-20
+Brosi;Corporate Sector;Outer Rim Territories;S-3
+Calipsa;Tapani;Colonies;L-13
+Brunet;Prefsbelt;Outer Rim Territories;J-5
+Calladus;Ojoster;Outer Rim Territories;N-7
+Bruvia;Harron Marches;Expansion Region;P-11
+Calline;Dail;Outer Rim Territories;Q-18
+Bryexx;Varvenna;Colonies;M-13
+Callonia;Fakir;Colonies;K-9
+Bryndar;Dalicron;Outer Rim Territories;K-19
+Callos;Brema;Outer Rim Territories;M-17
+Brynnaria;;Inner Rim;O-9
+Calonica;Vensensor;Expansion Region;K-16
+Bryx;Bryx;Mid Rim;R-8
+Caloria;Tapani;Colonies;L-13
+Bseto;Msst;Mid Rim;P-7
+Caltinia;Senex;Mid Rim;L-17
+Caltrop Belt;Elrood;Outer Rim Territories;M-20
+Carratos;;Inner Rim;K-8
+Calumdarian;Immalia;Expansion Region;K-8
+Carreras;Atravis;Outer Rim Territories;L-19
+Calus;;Inner Rim;L-15
+Carrivar;;Unknown Regions;G-9
+Caluula;Tion Hegemony;Outer Rim Territories;T-6
+Carruthia;D'Astan;Outer Rim Territories;O-6
+Camaria;Tarabba;Outer Rim Territories;M-19
+Carsanza;Juvex;Mid Rim;L-17
+Camblia;;Colonies;L-13
+Cartao;Prackla;Expansion Region;O-8
+Cambria;;Deep Core;L-10
+Carto;Surron;Expansion Region;O-13
+Camden;Morshdine;Outer Rim Territories;O-5
+Cartusio;;Core Worlds;J-12
+Camen;Tamarin;Outer Rim Territories;N-18
+Carvandir;Carvandir;Expansion Region;J-7
+Camson;Abrion;Outer Rim Territories;S-15
+Carz;Svivreni;Outer Rim Territories;O-20
+Camus;Illisurevimurasi;Outer Rim Territories;Q-4
+Casfield;Tennuutta;Mid Rim;Q-7
+Canastra;;Core Worlds;K-10
+Caska;;Inner Rim;N-14
+Candoria;;Colonies;J-13
+Cassander;Cassander;Outer Rim Territories;K-5
+Candovant;;Colonies;N-12
+Cassidode;Aparo;Outer Rim Territories;R-3
+Canoliss;Sluis;Outer Rim Territories;M-19
+Castell;;Colonies;M-9
+Canti;Tapani;Colonies;L-13
+Castilon;Tashtor;Mid Rim;I-16
+Cantonica;Corporate Sector;Outer Rim Territories;S-4
+Cataalda;Onatos;Mid Rim;R-15
+Cantras Gola;Perinn;Outer Rim Territories;J-4
+Cataract of Moons;Tungra (Fand);Outer Rim Territories;K-18
+Cantros;Saijo;Outer Rim Territories;J-20
+Cathar;Quelii;Outer Rim Territories;N-6
+Canyon;Montitian Grant;Expansion Region;J-15
+Cathis;Jjannex;Outer Rim Territories;K-19
+Capella;Gordian Reach;Outer Rim Territories;Q-6
+Catlia;Chiss Space*;Unknown Regions;G-8
+Caphexdis;Homon;Mid Rim;M-7
+Cato Neimoidia;Quellor;Colonies;N-11
+Caprioril;Dolomar;Core Worlds;K-9
+Cattamascar;Bakura;Outer Rim Territories;G-16
+Capza;Velcar;Outer Rim Territories;K-4
+Caulbon;;Inner Rim;L-14
+Caraad;;Colonies;L-8
+Cauldron Nebula;Corva;Outer Rim Territories;P-3
+Caragon-Viner;;Colonies;N-12
+Caulus Tertius;;Inner Rim;M-8
+Carajam;Dalonbian;Outer Rim Territories;M-3
+Cauper;Tapani;Colonies;L-13
+Caramm;Talcene;Mid Rim;R-8
+Caursito;;Colonies;K-8
+Caranthanax;Wazta;Outer Rim Territories;J-18
+Cavaell;Emmo;Core Worlds;M-12
+Caraxl;Cassander;Outer Rim Territories;K-5
+Cavamina;Doldur;Mid Rim;P-15
+Carbos;Roche;Mid Rim;Q-8
+Caviness;Charra;Expansion Region;P-14
+Carburo;Itopol;Expansion Region;K-15
+Cedonne;Dononter;Mid Rim;I-16
+Carcel;Locris;Expansion Region;O-8
+Cedre;Quelii;Outer Rim Territories;O-6
+Carconth;;Core Worlds;M-11
+Cedrell;Emmo;Core Worlds;M-12
+Cardekkia;Corellian;Core Worlds;M-11
+Cegul;Cegul;Outer Rim Territories;M-20
+Cardellia;Ojoster;Outer Rim Territories;N-7
+Ceiran;;Inner Rim;N-14
+Cardo Minor;Meerian;Outer Rim Territories;O-6
+Ceitia;Bryx;Mid Rim;R-8
+Cardogia;Tashtor;Mid Rim;J-16
+Cejansij;Halla;Mid Rim;R-9
+Cardooine;Jospro;Outer Rim Territories;R-7
+Cel Amiin;Cantons of Lahag;Expansion Region;J-15
+Cardovyte;Oricho;Outer Rim Territories;M-6
+Celanon;D'Astan;Outer Rim Territories;O-6
+Cardua;;Core Worlds;L-10
+Celdaru;;Wild Space;I-8
+Carest;;Inner Rim;N-8
+Celegia;Noori;Expansion Region;O-10
+Cargamalis;Bruanii;Mid Rim;K-18
+Celen;Elochar;Mid Rim;R-9
+Carida;;Colonies;M-9
+Celes;Herdessa;Mid Rim;Q-16
+Carlac;Prefsbelt;Outer Rim Territories;K-5
+Celestial Wake, The;Kriz;Outer Rim Territories;K-19
+Carlania;Hapes Cluster;Inner Rim;O-9
+Celsor;Hook Nebula;Outer Rim Territories;O-17
+Carlem;;Core Worlds;L-10
+Celwis;;Unknown Regions;F-8
+Carlix's Folly;Tharin;Outer Rim Territories;S-8
+Centares;Maldrood;Mid Rim;R-7
+Carmeen;Altier;Expansion Region;O-13
+Centori;Iskin;Mid Rim;O-16
+Carnelion;;Wild Space;J-5
+Cerberon;;Deep Core;L-10
+Carnovia;;Hutt Space;S-12
+Cerea;Semagi;Mid Rim;I-16
+Carnth;M'shinni;Mid Rim;M-7
+Cerenia;Mbandamonte;Expansion Region;N-15
+Carosi;Nembus;Outer Rim Territories;P-4
+Cerifisis;Varada;Outer Rim Territories;I-19
+Carpagia;;Colonies;L-9
+Cerilia;Xappyh;Outer Rim Territories;Q-3
+Carpastor;Rolion;Outer Rim Territories;Q-7
+Ceriun;Nuiri;Outer Rim Territories;Q-6
+Carrandar Secundus;Portmoak;Outer Rim Territories;P-18
+Cermau;Bakura;Outer Rim Territories;H-16
+Cerosha;Jospro;Outer Rim Territories;R-7
+Chelloa;Grumani;Outer Rim Territories;M-17
+Cerroban;Bon'nyuw-Luq;Outer Rim Territories;N-18
+Chemvau;;Colonies;M-13
+CeSai;Illisurevimurasi;Outer Rim Territories;Q-4
+Chenley Prime;Savareen;Outer Rim Territories;Q-17
+Cesya;Tapani;Colonies;L-13
+Chennis;Greater Plooriod;Expansion Region;M-7
+Ceti 597;Hollan;Mid Rim;M-7
+Chenowei;Gordian Reach;Outer Rim Territories;Q-5
+Cezith;Clacis;Outer Rim Territories;K-4
+Cheravh;Mandalore;Outer Rim Territories;O-7
+Ch'hodos;Esstran (Sith Worlds);Outer Rim Territories;R-4
+Cherridan;Belnar;Colonies;M-9
+Ch'manss;Var Hagen;Mid Rim;M-17
+Cheruba;Hapes Cluster;Inner Rim;O-9
+Ch'zimi'kho;Zeemacht Cluster;Inner Rim;N-8
+Chespea;Rayter (Berenge);Outer Rim Territories;J-19
+Chaaktil;;Inner Rim;N-14
+Chestrashus;;Wild Space;Q-3
+Chaastern;Shelsha;Colonies;M-9
+Chibbier;Stensen;Outer Rim Territories;I-17
+Chabosh;Lahara;Outer Rim Territories;M-5
+Chibias;Sombure;Mid Rim;K-17
+Chad;Jospro;Outer Rim Territories;R-7
+Chiloon Rift;;Wild Space;O-3
+Chadawa;Croynar;Inner Rim;N-14
+Chiron;Ash Worlds;Outer Rim Territories;T-7
+Chagar;Khuiumin;Outer Rim Territories;O-19
+Chirrion;Rolion;Outer Rim Territories;Q-6
+Chagaria;Danjar;Outer Rim Territories;N-18
+Choah;Mortex;Outer Rim Territories;S-5
+Chal Hudda;Garis;Outer Rim Territories;N-17
+Choi;;Inner Rim;M-13
+Chalacta;Metatessu;Mid Rim;R-10
+Chokan;Maerdocian;Mid Rim;Q-13
+Chalcedon;Tashtor;Mid Rim;I-16
+Chol Nebula;;Outer Rim Territories;T-5
+Challon;;Core Worlds;L-9
+Cholganna;;Outer Rim Territories;T-5
+Chamble;Mytaranor;Mid Rim;Q-10
+Chommell Minor;Chommell;Mid Rim;O-17
+Chamm;;Core Worlds;M-12
+Chonsetta;Metatessu;Mid Rim;R-9
+Champala;;Inner Rim;L-8
+Chorax;Rachuk;Colonies;N-11
+Champat;;Core Worlds;M-12
+Chorgad;Fei Hu;Mid Rim;Q-13
+Chanceuxi;Kanz;Outer Rim Territories;N-4
+Chorin;;Inner Rim;N-14
+Chandaar;Cronese Mandate;Outer Rim Territories;S-6
+Chorra;Bamula;Inner Rim;J-13
+Chandar's Folly;Saijo;Outer Rim Territories;J-20
+Chortose;Rseik;Outer Rim Territories;N-20
+Chandel;Ojoster;Outer Rim Territories;N-6
+Chosper;Hapes Cluster;Inner Rim;O-9
+Chandrila;Bormea;Core Worlds;L-9
+Choss;;Colonies;J-13
+Changa;Tolonda;Outer Rim Territories;Q-18
+Chrellis;Lahara;Outer Rim Territories;M-5
+Chankin;Jidlor Marches;Mid Rim;I-16
+Chrelythiumn;;Wild Space;K-2
+Chanosant;Harron;Expansion Region;O-11
+Chrenthoan Abyss;Chrenthoa;Inner Rim;J-14
+Charbodia;;Inner Rim;N-9
+Christophsis;Savareen;Outer Rim Territories;Q-16
+Chardaan;;Inner Rim;N-14
+Chroma Zed;Maerdocian;Mid Rim;Q-12
+Chardis;Trilon;Outer Rim Territories;H-16
+Chroman;D'Aelgoth;Mid Rim;K-17
+Charenthoth;;Colonies;N-9
+Chrome Citadel;Harron;Expansion Region;O-11
+Chargona;Citlik;Expansion Region;O-15
+Chromovon;Nembus;Outer Rim Territories;P-4
+Charis;Kathol;Outer Rim Territories;M-21
+Chrona;;Inner Rim;O-8
+Charissia;Bartahn;Inner Rim;L-15
+Chryya;Dustig;Mid Rim;M-17
+Charmath;Farrfin;Core Worlds;K-9
+Chundu;Cegul;Outer Rim Territories;L-20
+Charra;Charra;Expansion Region;P-14
+Churr;Quellor;Colonies;N-12
+Charros;Numesira;Mid Rim;R-9
+Churruma;Velcar;Outer Rim Territories;J-5
+Charubah;Hapes Cluster;Inner Rim;O-9
+Chuzalla;Tammuz;Outer Rim Territories;T-14
+Chashima;Auril;Outer Rim Territories;S-6
+Chyron;Har Worlds;Expansion Region;J-16
+Chasidron Shoals;Bortele;Mid Rim;R-8
+Cianap;Piryn Shar;Expansion Region;K-16
+Chasin;;Core Worlds;M-12
+Ciaox Verith;Croynar;Inner Rim;M-14
+Chasmeene;;Inner Rim;O-10
+Cificap;Herdessa;Mid Rim;Q-16
+Chateuse;Tungra;Outer Rim Territories;K-19
+Cilare;Veragi;Outer Rim Territories;K-3
+Chaykin;Chaykin;Expansion Region;O-14
+Cilpar;;Colonies;L-13
+Chazwa;Orus;Inner Rim;N-8
+Cimarosa;Irnaj;Mid Rim;K-17
+Cheedoa;;Colonies;M-12
+Cinnabar;Corellian;Core Worlds;M-11
+Cheelit;Semagi;Mid Rim;I-16
+Cioral;Chiss Space*;Unknown Regions;F-8
+Cheeyoom Matee;;Core Worlds;K-9
+Cioran;;Core Worlds;L-12
+Chekria;Shelsha;Colonies;M-9
+Ciratu;Immerian Outback;Expansion Region;N-14
+Cheku;Brevost;Expansion Region;O-15
+Circarpous;Circarpous;Expansion Region;O-12
+Chelleya;Seswenna;Outer Rim Territories;M-18
+Circumtore;;Hutt Space;S-12
+Cirilia;Lannik Space;Mid Rim;R-13
+Corbett Cluster;Corbett;Mid Rim;I-17
+Cirra;Brak;Expansion Region;O-14
+Corbos;Esstran;Outer Rim Territories;Q-5
+Cirrus;Dantus;Outer Rim Territories;J-6
+Cordes;;Inner Rim;N-9
+Cirtappa;Alui;Mid Rim;O-17
+Cordota;Lantillian;Mid Rim;P-8
+Cirus;Arkanis;Outer Rim Territories;R-17
+Corellia;Corellian;Core Worlds;M-11
+Citlik;Citlik;Expansion Region;O-14
+Corfai;Corellian;Core Worlds;M-11
+Ciutric;Ciutric;Outer Rim Territories;N-5
+Corg;;Wild Space;O-20
+Clabron;;Core Worlds;K-13
+Coriallis;;Core Worlds;K-9
+Claer;Sern;Colonies;L-13
+Corips;;Inner Rim;N-14
+Clak'dor;Mayagil;Outer Rim Territories;M-18
+Corjain;Kathol;Outer Rim Territories;M-21
+Clantaano;Albanin;Outer Rim Territories;U-12
+Corlaasi;Minos Cluster;Outer Rim Territories;M-20
+Clar, The;;Wild Space;I-20
+Corlass;Cronese Mandate;Outer Rim Territories;S-6
+Clariv;Tion Hegemony;Outer Rim Territories;S-6
+Corlax;Allied Tion;Outer Rim Territories;S-6
+Clear View;;Wild Space;U-13
+Corlus;Woostri;Expansion Region;M-16
+Clendor;;Inner Rim;O-8
+Cormit;Chiss Space*;Unknown Regions;F-8
+Clerion;Palamut;Expansion Region;N-13
+Cornesia;Manda;Mid Rim;R-14
+Cloak of the Sith, The;Abrion;Outer Rim Territories;S-15
+Coronar;;Colonies;L-9
+Clyne;Corellian;Core Worlds;M-11
+Corosi;Corosi;Outer Rim Territories;N-6
+Clysm;D'Astan;Outer Rim Territories;O-5
+Corphelion;Corpheli;Expansion Region;M-7
+Cmaoli Di;Brema;Outer Rim Territories;M-17
+Corrdair;Hevvrol;Mid Rim;O-15
+Coachelle;Terr'skiar;Mid Rim;P-10
+Corrida;Corridan;Core Worlds;J-10
+Cobal;;Core Worlds;K-13
+Corroth;;Colonies;N-9
+Codia;;Mid Rim;H-15
+Corsin;Greater Plooriod;Expansion Region;M-7
+Cog Hive Seven;Tharin;Outer Rim Territories;S-8
+Corson Prime;Tharin (Periphery);Outer Rim Territories;S-8
+Cole-Haddon;Dalonbian;Outer Rim Territories;M-3
+Corstris;Quelii;Outer Rim Territories;O-6
+Colla;;Inner Rim;N-9
+Cortella;;Core Worlds;K-9
+Collus;Thuldin's Grant;Expansion Region;J-15
+Corthenia;Corthenia;Mid Rim;K-7
+Colonial Station Camco;Chiss Space*;Unknown Regions;F-8
+Cortilium Major;Eucer;Mid Rim;Q-7
+Colonial Station Chaf;Chiss Space*;Unknown Regions;F-9
+Cortina;;Core Worlds;K-12
+Cols;Kastolar;Mid Rim;Q-10
+Corulag;Bormea;Core Worlds;L-9
+Colsassa;Jospro;Outer Rim Territories;R-7
+Corus;Wyl;Outer Rim Territories;S-4
+Columex;Vorzyd;Outer Rim Territories;R-6
+Coruscant;Corusca (Coruscant);Core Worlds;L-9
+Columus;;Core Worlds;M-11
+Coruschal;;Core Worlds;K-10
+Colunda Prime;Phelleem (Colunda);Outer Rim Territories;S-7
+Coruscul;;Core Worlds;L-10
+Comantira;Atravis;Outer Rim Territories;L-19
+Corutarn;;Core Worlds;M-10
+Cometwash, The;Gordian Reach;Outer Rim Territories;Q-6
+Corva;Corva;Outer Rim Territories;P-4
+Comkin;;Inner Rim;N-7
+Corva Yag;Rseik;Outer Rim Territories;N-20
+Commenor;;Colonies;N-10
+Corvanni;Neshig;Inner Rim;N-9
+Comra;Prefsbelt;Outer Rim Territories;J-5
+Corvis Minor;Ciutric;Outer Rim Territories;N-5
+Cona;Inner Cluster;Inner Rim;O-11
+Corvus;Cronese Mandate;Outer Rim Territories;S-6
+Concord Dawn;Mandalore;Outer Rim Territories;O-7
+Corweillia;Corweillian;Mid Rim;P-15
+Condular;;Core Worlds;M-12
+Cosia;;Deep Core;M-11
+Conjenus;Vish;Mid Rim;N-16
+Cosmatanic Steppes;Grohl;Outer Rim Territories;R-16
+Constancia;;Deep Core;K-12
+Cotellier;Rseik;Outer Rim Territories;N-20
+Contruum;Truum;Mid Rim;O-8
+Coth Fuuras;Deadalis;Expansion Region;J-8
+Coonee;Brevost;Expansion Region;O-15
+Coto-Xana;;Colonies;L-9
+Coorimbus;Tapani;Colonies;L-13
+Council;Javin (Anoat);Outer Rim Territories;K-18
+Copero;Chiss Space*;Unknown Regions;F-9
+Couronne;Couronne;Expansion Region;P-10
+Cophrigin;Ash Worlds;Outer Rim Territories;T-7
+Cousault;Semagi;Mid Rim;I-16
+Copperline;Vatha;Expansion Region;K-16
+Coveway;Koradin;Outer Rim Territories;I-18
+Copul;Pallis;Inner Rim;N-14
+Cowl Crucible;Oricho;Outer Rim Territories;M-5
+Cor I;Tapani;Colonies;L-13
+Coxixia;;Core Worlds;M-12
+Cor II;Tapani;Colonies;L-13
+Coyerti;Bortele;Mid Rim;S-8
+Cor III;Tapani;Colonies;L-13
+Coyn;Elrood;Outer Rim Territories;M-20
+Corann;;Core Worlds;M-9
+Craci;Corporate Sector;Outer Rim Territories;R-4
+Corbantis;Chaykin;Expansion Region;O-14
+Crait;Bon'nyuw-Luq;Outer Rim Territories;N-17
+Crakull;;Unknown Regions;G-10
+CZ-198;;Unknown Regions;H-5
+Cranan;Arkanis;Outer Rim Territories;R-16
+Czerialus;Kailion;Expansion Region;O-13
+Crandel;;Wild Space;U-11
+D'Anjon Nebula;Arkanis;Outer Rim Territories;R-16
+Crash's Drift;Corellian;Core Worlds;M-11
+D'Assem;Greater Plooriod;Expansion Region;M-7
+Credaan;;Inner Rim;M-14
+D'faria;Hune;Mid Rim;Q-12
+Crella;Tapani;Colonies;L-13
+D'ian;Corporate Sector;Outer Rim Territories;S-3
+Cridark;Baroli;Expansion Region;N-15
+D'janis;Halm;Mid Rim;J-16
+Criigo;Ash Worlds;Outer Rim Territories;T-7
+D'Nile;Hertae;Mid Rim;Q-14
+Crintlia;Outer Jalor;Mid Rim;I-7
+D'Qar;Sanbra;Outer Rim Territories;O-17
+Crispin;;Wild Space;S-3
+D'rinba;Sombure;Mid Rim;K-17
+Critoki;Esstran;Outer Rim Territories;Q-4
+Da-Vlunn;;Hutt Space;R-11
+Criton's Point;Myto;Outer Rim Territories;K-3
+Daalang;Daalang;Mid Rim;Q-12
+Critonia;;Mid Rim;I-15
+Dachat;;Core Worlds;K-9
+Cro-Akon;Thuldin's Grant;Expansion Region;J-15
+Daclavian;Perkell;Mid Rim;Q-7
+Croce;Yminis;Outer Rim Territories;S-14
+Dactruria;Clacis;Outer Rim Territories;J-4
+Croluthe Zenj;Lannik Space;Mid Rim;R-13
+Daedalon;Ktilac Regions;Inner Rim;N-9
+Crombach Nebula;Belsmuth;Outer Rim Territories;O-6
+Daedus;Samix;Outer Rim Territories;Q-19
+Cron Drift;Auril;Outer Rim Territories;R-6
+Daemen;Woostri;Expansion Region;M-16
+Crondre;Dufilvian;Mid Rim;R-15
+Daermor;Corporate Sector;Outer Rim Territories;S-3
+Crossing Lanes Station;D'Astan;Outer Rim Territories;O-5
+Dagary Minor;;Inner Rim;M-8
+Crothy;Seitia;Outer Rim Territories;K-19
+Dagelin Minor;Cadma;Outer Rim Territories;T-8
+Crovna;Senex;Mid Rim;L-17
+Daghee;Thusa;Mid Rim;O-7
+Croyden;;Inner Rim;M-13
+Dagobah;Sluis;Outer Rim Territories;M-19
+Crseih;Pakuuni;Outer Rim Territories;T-6
+Dagro;Esuain;Mid Rim;P-7
+Crucival;Tion Hegemony;Outer Rim Territories;S-6
+Dagu;Instrop;Outer Rim Territories;S-16
+Crul;Lannik Wilds;Mid Rim;R-13
+Dahrtag;;Core Worlds;J-13
+Crushank Nebulae;Tantra;Outer Rim Territories;M-19
+Dahvil;Rayter;Outer Rim Territories;J-19
+Crustai;;Unknown Regions;H-8
+Daimar;Daimar;Mid Rim;Q-16
+Cryon;Meram;Outer Rim Territories;O-4
+Daimla;Kallea;Outer Rim Territories;K-21
+Crystal Web Station;Palamut;Expansion Region;N-13
+Dairka;Churba;Mid Rim;P-15
+Crystan;;Deep Core;L-12
+Daivak;Karthakk;Outer Rim Territories;Q-17
+Crytal Nest;;Wild Space;H-20
+Daiyu;Hocatar;Expansion Region;P-12
+Csaus;Chiss Space*;Unknown Regions;F-9
+Dakaret;Oktos;Mid Rim;Q-12
+Csilla;Chiss Space*;Unknown Regions;F-8
+Dakot;Mortex;Outer Rim Territories;R-5
+Cuirilla;Mbandamonte;Expansion Region;N-15
+Dakshee;Barma;Colonies;M-9
+Cujicor;Pakuuni;Outer Rim Territories;T-5
+Dalandae;;Colonies;M-9
+Cularin;Thaere;Expansion Region;P-14
+Dalastine;;Inner Rim;L-14
+Culroon;;Wild Space;P-20
+Dalchon;Dalchon;Outer Rim Territories;R-17
+Curreck;Sertar;Outer Rim Territories;R-5
+Dalcretti;;Inner Rim;O-8
+Cusver;;Deep Core;M-12
+Dalicron;Dalicron;Outer Rim Territories;K-19
+Cuthbern;Wazta;Outer Rim Territories;J-18
+Dalisor;Yushan;Mid Rim;K-17
+Cuvacia;;Core Worlds;K-13
+Dallenor;Aldino;Mid Rim;J-17
+Cuyacan;Sepan;Expansion Region;P-13
+Dalna;Tunka (Dalnan);Outer Rim Territories;I-19
+Cvetaen;Sumitra;Expansion Region;N-7
+Dalonia;Maerdocian;Mid Rim;Q-13
+Cyax;;Hutt Space;S-11
+Dalos;Nilgaard;Outer Rim Territories;S-5
+Cybloc;Meridian;Outer Rim Territories;R-7
+Dalron;Ariarch;Mid Rim;J-6
+Cyborrea;;Hutt Space;S-9
+Daltarra;Pakuuni;Outer Rim Territories;T-5
+Cyclor;Alui;Mid Rim;N-17
+Daltarri;Truum;Mid Rim;P-8
+Cyclorria;;Inner Rim;N-9
+Daluba;Esstran;Outer Rim Territories;P-5
+Cydorria;;Colonies;K-13
+Daluuj;Albanin;Outer Rim Territories;U-13
+Cygnus;Kontahr;Mid Rim;R-11
+Damanos;Belderone;Outer Rim Territories;Q-6
+Cyimarra;Senex;Mid Rim;L-17
+Damendine;Calamari;Outer Rim Territories;U-6
+Cymoon;Bes Ber Bikade;Expansion Region;L-15
+Daminia;Perkell;Mid Rim;Q-7
+Cyphar;Spirva;Mid Rim;L-17
+Damonite Yors-B;Meridian;Outer Rim Territories;R-7
+Cyrillia;Cyrillian Protectorate;Expansion Region;O-12
+Damoria;;Colonies;N-11
+Cyrkon;Al'Nasrl;Outer Rim Territories;T-13
+Dampher;Tapani;Colonies;L-13
+Damualer Triac;;Inner Rim;O-10
+De'etta;Sanbra;Outer Rim Territories;O-17
+Danadine;Dail;Outer Rim Territories;Q-18
+De'nel;Brak;Expansion Region;O-14
+Danalbeth;Teraab;Mid Rim;P-11
+Deadon;Dantus;Outer Rim Territories;K-6
+Danchian Prime;Dail;Outer Rim Territories;Q-18
+Debray;;Core Worlds;M-10
+Dancreti;;Inner Rim;N-14
+Declavia;;Core Worlds;M-11
+Dandalas;Farlax;Core Worlds;K-10
+Deersheba;Iskin;Mid Rim;O-16
+Dandelo;Tammuz;Outer Rim Territories;T-14
+Dega;Elrood;Outer Rim Territories;M-20
+Dandoran;;Hutt Space;R-9
+Degarian;;Colonies;L-13
+Dandrian;Belderone;Outer Rim Territories;R-7
+DeGerrillion;Tamarin;Outer Rim Territories;N-19
+Dankayo;;Colonies;L-9
+Deko Neimoidia;Quellor;Colonies;N-11
+Dannamore;Saijo;Outer Rim Territories;J-20
+Del Zennis;Eucer;Mid Rim;R-7
+Danoor;Kathol;Outer Rim Territories;M-21
+Dela;Centrality;Outer Rim Territories;T-8
+Danoria;Nouane;Inner Rim;N-7
+Delacrix;Calaron;Outer Rim Territories;T-9
+Danos;Shadola;Outer Rim Territories;U-8
+Delantine;Varada;Outer Rim Territories;I-19
+Danteel;Emmo;Core Worlds;M-12
+Delari;Corva;Outer Rim Territories;P-4
+Dantooine;Raioballo;Outer Rim Territories;L-4
+Delassin;Calaron;Outer Rim Territories;T-9
+Danuta;Halla;Mid Rim;S-9
+Delcontr;Oriolan;Mid Rim;J-16
+Danzik;Dalonbian;Outer Rim Territories;M-3
+Delderaan;Noonian;Outer Rim Territories;N-6
+Dar'Or;Jospro;Outer Rim Territories;R-7
+Delemede;Rseik;Outer Rim Territories;N-20
+Darada;;Core Worlds;K-9
+Delephr;Carrion;Outer Rim Territories;J-4
+Darakin;;Core Worlds;M-11
+Delfii;Minos Cluster;Outer Rim Territories;M-20
+Daranc;Meram;Outer Rim Territories;O-4
+Dellalt;Tion Hegemony;Outer Rim Territories;T-6
+Dardanellia;;Inner Rim;N-14
+Delle;;Colonies;L-9
+Darek;Rachuk;Colonies;N-11
+Delmaas;Seswenna;Outer Rim Territories;M-18
+Darellia;;Core Worlds;L-10
+Delphania;Esuain;Mid Rim;Q-7
+Darepp;;Colonies;M-13
+Delphidian Cluster;;Mid Rim;I-15
+Dargulli;;Inner Rim;N-14
+Delphon;Javin (Anoat);Outer Rim Territories;K-18
+Darie;Likasha;Mid Rim;Q-14
+Delrakkin;Kallea;Outer Rim Territories;K-21
+Dark Nebula;Lothal;Outer Rim Territories;U-7
+Delrian;;Inner Rim;O-9
+Darkknell;Grumani;Outer Rim Territories;M-17
+Delriss;Dentari;Expansion Region;O-8
+Darkon;Chaama;Mid Rim;J-7
+Deltooine;Corporate Sector;Outer Rim Territories;S-3
+Darlon;Eucer;Mid Rim;R-7
+Deltron;;Inner Rim;O-10
+Darlyn Boda;Javin (Anoat);Outer Rim Territories;K-18
+Deluvia;Klina;Outer Rim Territories;S-13
+Darnaburny;Kanz;Outer Rim Territories;N-4
+Demar;Brak;Expansion Region;O-14
+Daro;Ojoster;Outer Rim Territories;N-6
+Demesel;Meram;Outer Rim Territories;P-4
+Daronak;Phelleem;Outer Rim Territories;S-7
+Demigue;Demetras;Outer Rim Territories;P-7
+Daroon;Harron;Expansion Region;O-11
+Demiloch;Lannik Space;Mid Rim;R-13
+Darsie;;Colonies;L-9
+Deminol;Juvex;Mid Rim;L-17
+Dartessex;;Inner Rim;N-10
+Demir;;Unknown Regions;G-6
+Daruvvia;Hapes Cluster;Inner Rim;O-9
+Demnadi;Far Xandil;Mid Rim;P-16
+Darvannis;Calaron;Outer Rim Territories;T-9
+Demonsgate;Kathol;Outer Rim Territories;M-21
+Darwikia;;Core Worlds;M-10
+Demophon;Demophon;Core Worlds;M-10
+Daslkehnt;Pelgrin;Outer Rim Territories;R-17
+Demos;Dustig;Mid Rim;N-16
+Dasoor;Agarix;Mid Rim;K-18
+Denarii Nebula;Gordian Reach;Outer Rim Territories;P-6
+Dassal;;Unknown Regions;H-7
+Denash;Ash Worlds (Batonn);Outer Rim Territories;T-7
+Datar;;Inner Rim;L-8
+Denbar;;Inner Rim;L-14
+Dathomir;Quelii;Outer Rim Territories;O-6
+Denbo;Tamarin;Outer Rim Territories;N-18
+Daupherm;Daupherm States;Core Worlds;K-12
+Dendada;Seswenna;Outer Rim Territories;M-18
+Davezra;Dustig;Mid Rim;N-16
+Dene Gois Cluster;Yminis;Outer Rim Territories;S-14
+Davirien;Corporate Sector;Outer Rim Territories;R-3
+Deneba;Maerdocian;Mid Rim;Q-13
+Davnar;Kanchen;Core Worlds;K-9
+Denebia;Senex;Mid Rim;L-18
+Dawinia;Hynestian;Colonies;J-13
+Denebrilla;Fei Hu;Mid Rim;P-13
+Daxam;Mayagil;Outer Rim Territories;N-18
+Deneeli;;Core Worlds;M-9
+Daxan Beta;Thesme;Outer Rim Territories;O-6
+Denevar;;Core Worlds;K-9
+Dayark;Kathol;Outer Rim Territories;M-21
+Dennaskar;Manda;Mid Rim;R-15
+Dbari;Churnis;Mid Rim;I-6
+Dennogra;Tharin;Outer Rim Territories;S-8
+Denon;Iseno;Inner Rim;N-13
+Didyma;;Wild Space;J-5
+Denova;Ojoster;Outer Rim Territories;N-7
+Dihneral;;Colonies;K-13
+Dentaal;;Core Worlds;K-13
+Dilbana;Baxel;Outer Rim Territories;U-12
+Dentamma Nebula;Varada;Outer Rim Territories;I-19
+Dilestri;Hevvrol;Mid Rim;O-15
+Dentaria;Dentari;Expansion Region;O-8
+Dilonexa;Centrality;Outer Rim Territories;U-8
+Denubba;Likasha;Mid Rim;Q-14
+Dimea;Dimean;Expansion Region;P-13
+Denudia;Grohl;Outer Rim Territories;R-15
+Din Nebula;Zuma (Moddell);Outer Rim Territories;H-16
+Denuhi;Greater Plooriod;Expansion Region;M-7
+Din Pulsar;Zuma (Moddell);Outer Rim Territories;H-16
+Denusia;;Inner Rim;M-13
+Dinlo;Thaere;Expansion Region;O-14
+Depatar;Cademimu;Outer Rim Territories;L-6
+Dinutu;Colundra;Outer Rim Territories;S-5
+Deppani;Bri'ahl;Outer Rim Territories;I-17
+Dinwa Prime;;Inner Rim;L-8
+Deralia;Tammuz;Outer Rim Territories;T-15
+Dinzo;Msst;Mid Rim;P-7
+Derango;Khuiumin;Outer Rim Territories;O-19
+Dioll;Juvex;Mid Rim;L-17
+Derella;;Core Worlds;M-10
+Diophos;Quiberon;Outer Rim Territories;S-15
+Derellium;Cronese Mandate;Outer Rim Territories;S-6
+Diorda;Perkell;Mid Rim;Q-7
+Derenzil;;Wild Space;S-18
+Dioya;;Unknown Regions;F-8
+Deretta;Tarabba;Outer Rim Territories;N-19
+Direllia;Nembus;Outer Rim Territories;P-4
+Derf;Sluis;Outer Rim Territories;M-19
+Dirha;;Hutt Space;S-9
+Derilyn;Elrood;Outer Rim Territories;M-19
+Distilon;Ash Worlds;Outer Rim Territories;S-7
+Deris-plata;Eucer;Mid Rim;R-7
+Dithanune;Bortele;Mid Rim;R-8
+Dermos;Belsmuth;Outer Rim Territories;O-6
+Divac;Nuiri;Outer Rim Territories;Q-6
+Derosha;;Wild Space;J-5
+Divora;Hapes Cluster;Inner Rim;O-9
+Derra;Mikaster;Expansion Region;N-15
+Dix'thaar;;Inner Rim;K-8
+Derricon;Spirva;Mid Rim;L-17
+Diyu;;Hutt Space;S-12
+Derso;Yminis;Outer Rim Territories;S-14
+Dizon Fray;;Outer Rim Territories;U-7
+Dersonn;Tammuz;Outer Rim Territories;T-14
+Djurmo;Strabin;Mid Rim;M-7
+Dervdis;;Core Worlds;L-9
+Dles;Tharin (Periphery);Outer Rim Territories;S-8
+Deryvia;;Inner Rim;L-14
+Dlor;Dononter;Mid Rim;I-16
+Desargorr;Allied Tion;Outer Rim Territories;S-6
+DNX-N1;;Wild Space;N-21
+Descopose Farmark;;Mid Rim;H-15
+Doan;Halthor;Outer Rim Territories;M-6
+Desevro;Tion Hegemony;Outer Rim Territories;S-6
+Doaskin;Bruanii;Mid Rim;K-18
+Desinta;Morshdine;Outer Rim Territories;O-5
+Dodz;Zoraster;Outer Rim Territories;U-13
+Desix;Suolriep;Outer Rim Territories;S-9
+Dohlban;Dohlbani;Mid Rim;R-13
+Desstious;Lambda;Mid Rim;P-16
+Dohnia;Semagi;Mid Rim;I-16
+Destreg;Bon'nyuw-Luq;Outer Rim Territories;N-18
+Dohu;Dohu;Mid Rim;K-7
+Devalok;Altier;Expansion Region;O-13
+Dol'har Hyde;Sanbra;Outer Rim Territories;O-17
+Devaron;Duluur;Colonies;M-13
+Doldur;Doldur;Mid Rim;P-15
+Devil's Asteroid;;Outer Rim Territories;O-2
+Doli;D'Astan;Outer Rim Territories;O-6
+Devon;Atrivis;Outer Rim Territories;L-5
+Dolis;Obtrexta;Outer Rim Territories;J-3
+Devros;Manda;Mid Rim;R-15
+Dolla;Videnda;Outer Rim Territories;L-18
+Devshi;;Inner Rim;J-8
+Dolomar;Dolomar;Core Worlds;K-9
+Dexus;;Colonies;L-9
+Dolsan;;Core Worlds;K-9
+Deylerax;Talcene;Mid Rim;R-8
+Dolstan;Kathol;Outer Rim Territories;M-21
+Deymasoll;;Colonies;J-13
+Dolva Prime;Semagi;Mid Rim;I-16
+Deysum;Trax;Mid Rim;Q-10
+Dom-Bradden;Lol;Outer Rim Territories;Q-18
+Dhandu;;Expansion Region;I-8
+Domancion;Suolriep;Outer Rim Territories;S-8
+Dhen-Moh;;Inner Rim;K-14
+Domgrin;Prefsbelt;Outer Rim Territories;K-6
+Di'tai'ni;Bothan;Mid Rim;R-14
+Dominus;Lothal (Dominus);Outer Rim Territories;U-7
+Di'wor;Morshdine;Outer Rim Territories;O-4
+Don I;Tapani;Colonies;L-13
+Diab;;Wild Space;J-6
+Don II;Tapani;Colonies;L-13
+Diado;Lifh;Mid Rim;R-8
+Dona Laza;Dona Laza;Expansion Region;P-9
+Diamal;;Core Worlds;L-13
+Donadus;Bamula;Inner Rim;J-13
+Dianth;;Wild Space;T-5
+Doneer'so;Fakir;Colonies;K-9
+Diatia Major;;Core Worlds;L-12
+Doniphon;Kwymar;Outer Rim Territories;P-4
+Dibrook;Albarrio;Outer Rim Territories;K-5
+Dononter Minor;Dononter;Mid Rim;I-16
+Dica;Tolemses;Expansion Region;P-11
+Donovia;Hali;Expansion Region;O-9
+Dontamo;Dantus;Outer Rim Territories;J-6
+Dreighton;Dantus;Outer Rim Territories;J-6
+Dooma;Dentari;Expansion Region;O-7
+Dreighton Nebula;Dantus;Outer Rim Territories;J-6
+Doornik-1142;Farlax;Core Worlds;K-10
+Dreivus;Oeiros;Expansion Region;P-10
+Doornik-207;Farlax;Core Worlds;K-10
+Dreizan;;Core Worlds;M-12
+Dor Nameth;Bright Jewel;Mid Rim;L-7
+Dremulae;;Deep Core;M-10
+Dorajan;Lannik Space;Mid Rim;Q-12
+Dresscol;Trax;Mid Rim;Q-10
+Dorande;Quiberon;Outer Rim Territories;T-15
+Dressel;Noolian;Mid Rim;Q-13
+Dorax;;Core Worlds;L-9
+Dressia;;Colonies;L-8
+Dorcin;Minos Cluster;Outer Rim Territories;M-20
+Dreve;;Inner Rim;N-7
+Dordolum;;Colonies;K-13
+Drexel;Lol;Outer Rim Territories;Q-18
+Doreen;Senex;Mid Rim;L-18
+Drexel Minor;Khuiumin;Outer Rim Territories;O-19
+Dorella;Tapani;Colonies;L-13
+Drez;Corva;Outer Rim Territories;P-4
+Dorellia;Tapani;Colonies;L-13
+Drezzi;Esstran (Sith Worlds);Outer Rim Territories;Q-5
+Dorenia;Mayagil;Outer Rim Territories;M-18
+Drgi;Tokamac;Expansion Region;O-13
+Dorin;Deadalis;Expansion Region;J-8
+Drift, The;Elrood;Outer Rim Territories;M-20
+Doris;Tapani;Colonies;L-13
+Drilbia;Brema;Outer Rim Territories;M-17
+Dorlo;Atravis;Outer Rim Territories;L-19
+Droecil;Boeus;Expansion Region;M-15
+Dorlon;;Colonies;M-9
+Drog;Corporate Sector;Outer Rim Territories;R-4
+Dornea;Lothal;Outer Rim Territories;U-7
+Drogheda;Teraab;Mid Rim;Q-11
+Dorriella;Wazta;Outer Rim Territories;I-17
+Dromondar Beta;;Unknown Regions;H-7
+Dorsis;Corellian;Core Worlds;M-11
+Drompani;Prefsbelt;Outer Rim Territories;J-6
+Dorvalla;Videnda;Outer Rim Territories;M-18
+Dromund Kaas;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Doshan;Drannik;Expansion Region;K-8
+Drong;Steniplis;Outer Rim Territories;L-18
+Dosuun;;Wild Space;H-20
+Drongar;;Outer Rim Territories;T-5
+Dotharian;;Hutt Space;S-12
+Dronseen;Thrasybule;Outer Rim Territories;P-6
+Dothnia;Hunnoverrs;Outer Rim Territories;S-17
+Drophun;;Colonies;L-13
+Douglas;Centrality;Outer Rim Territories;U-8
+Droxine;Esstran;Outer Rim Territories;Q-5
+Dowut;;Core Worlds;J-12
+Droxu;Bheriz;Outer Rim Territories;T-11
+Doxxen;Seitia;Outer Rim Territories;K-19
+Drualkiin;Kessel;Outer Rim Territories;T-10
+Dozoisia;Sevetta;Outer Rim Territories;S-15
+Druckenwell;Doldur;Mid Rim;P-15
+Dra;Wyl;Outer Rim Territories;R-4
+Drunost;Shelsha;Colonies;M-9
+Draay;Pelgrin;Outer Rim Territories;R-18
+Drup's Star;Saijo;Outer Rim Territories;J-20
+Draboon;Mandalore;Outer Rim Territories;O-7
+Drurish;Kuat;Core Worlds;M-10
+Drackmar;Quelii;Outer Rim Territories;O-6
+Druulgotha;Thesme;Outer Rim Territories;O-6
+Dractu;Lannik Space;Mid Rim;Q-13
+Dryorkeen Cluster;Parmic;Outer Rim Territories;P-18
+Drada;Halthor;Outer Rim Territories;L-6
+Du Hutta;;Hutt Space;S-11
+Draflago;Sertar;Outer Rim Territories;R-5
+Du Mai;Bryx;Mid Rim;R-8
+Dragon Void;Gomar;Inner Rim;K-14
+Dubloviann;;Inner Rim;M-8
+Dragonflower Nebula;Doldur;Mid Rim;P-15
+Dubraib;Cegul;Outer Rim Territories;M-20
+Dragos;Boeus;Expansion Region;M-15
+Dubrava;Albanin;Outer Rim Territories;T-13
+Drahgor;Colundra;Outer Rim Territories;S-4
+Dubrillion;Myto;Outer Rim Territories;K-3
+Draik;Alui;Mid Rim;O-17
+Dubrovia;Aldino;Mid Rim;J-17
+Dramassia;Juvex;Mid Rim;L-18
+Duhma;Kallea;Outer Rim Territories;K-20
+Drannik;Drannik;Expansion Region;K-8
+Duinarbulon;Cronese Mandate;Outer Rim Territories;S-6
+Draria;Lostar;Expansion Region;M-7
+Dulathia;Lantillian;Mid Rim;P-8
+Drash-So;Yminis;Outer Rim Territories;S-14
+Dulin;;Inner Rim;K-14
+Drashima;Majoor;Expansion Region;N-15
+Dulvoyinn;;Deep Core;K-12
+Draukyze;Thanium;Outer Rim Territories;R-6
+Dunari's Rest;Mayagil;Outer Rim Territories;N-18
+Dravian Starport;Tamarin;Outer Rim Territories;N-18
+Duneeden;Corusca;Core Worlds;K-9
+Dravin;Subterrel;Outer Rim Territories;L-20
+Dunnak;;Inner Rim;N-8
+Dravione;Allied Tion;Outer Rim Territories;S-6
+Dur Sabon;Morshdine;Outer Rim Territories;O-5
+Drayberia;Sertar;Outer Rim Territories;R-5
+Dura-Kahn;Bes Ber Bikade;Expansion Region;L-15
+Drazkel;Oriolan;Mid Rim;J-16
+Durace;;Unknown Regions;H-6
+Drearia;;Inner Rim;L-8
+Duran;;Core Worlds;K-9
+Dreena;Hapes Cluster;Inner Rim;O-9
+Durga;Marzoon;Mid Rim;I-16
+Dreffon;;Colonies;J-9
+Durgen's Star;Gordian Reach;Outer Rim Territories;P-6
+Durgeon;Galov;Outer Rim Territories;T-13
+Elbara;Elbaran;Mid Rim;J-17
+Durkteel;Kastolar;Mid Rim;Q-10
+Elbra;Airam;Outer Rim Territories;M-20
+Duro;Duro;Core Worlds;M-11
+Elcorth;Farlax;Core Worlds;K-10
+Durollia;Kalamith;Outer Rim Territories;P-5
+Elegasso;Irishi;Mid Rim;K-6
+Duron;Semagi;Mid Rim;I-16
+Elerion;Thanium;Outer Rim Territories;R-6
+Duroon;Corporate Sector;Outer Rim Territories;S-4
+Elessia;Vendusii;Mid Rim;P-16
+Durren;Meridian;Outer Rim Territories;R-7
+Elgamor;Maldrood;Mid Rim;R-7
+Dustig;Dustig;Mid Rim;N-16
+Elgit;;Hutt Space;T-10
+Dutar;;Core Worlds;L-10
+Eliad;Minos Cluster;Outer Rim Territories;M-20
+Duunir;Kibilini;Outer Rim Territories;Q-17
+Elien;;Inner Rim;J-14
+Duzay;Alui;Mid Rim;O-17
+Elin Roe;;Colonies;N-12
+Dwartii;Nouane;Inner Rim;N-8
+Elkeenar;;Wild Space;K-21
+Dweem;Calaron;Outer Rim Territories;T-9
+Elkkasinn;Phelleem;Outer Rim Territories;S-7
+Dwor;Steniplis;Outer Rim Territories;L-19
+Elliirad;Airam;Outer Rim Territories;L-20
+Dybbron;Nythlide;Inner Rim;L-15
+Elom;Sertar;Outer Rim Territories;R-5
+Dybrin;;Deep Core;L-12
+Elphrona;Bri'ahl;Outer Rim Territories;I-17
+Dyspeth;Varada;Outer Rim Territories;I-20
+Elriss;Onatos;Mid Rim;R-15
+Dytrew;Haserian;Mid Rim;Q-15
+Elrood;Elrood;Outer Rim Territories;M-20
+Dzass;Seswenna;Outer Rim Territories;M-17
+Elshandruu Pica;Quence;Outer Rim Territories;O-18
+Eadu;Bheriz;Outer Rim Territories;U-10
+Embaril;Allied Tion;Outer Rim Territories;S-6
+Ealor;Parmic;Outer Rim Territories;P-18
+Emberlene;Authala;Expansion Region;P-12
+Eamus;;Core Worlds;L-13
+Emmer;Nilgaard;Outer Rim Territories;S-5
+Ebaq;;Deep Core;M-11
+Emoh;Ploo;Expansion Region;N-7
+Ebenmal;Irnaj;Mid Rim;K-17
+Emorus;;Inner Rim;O-10
+Eberon;Mytaranor;Mid Rim;P-9
+Empartheca;Hook Nebula;Outer Rim Territories;O-18
+Ebiwaan;Sarin;Outer Rim Territories;P-18
+Empress Teta;Koros;Deep Core;L-10
+Ebra;Kesh;Mid Rim;L-6
+Emurria;;Colonies;L-9
+Ec Pand;Ado;Mid Rim;M-17
+Ena;Steniplis;Outer Rim Territories;L-19
+Echerta;Koradin;Outer Rim Territories;J-18
+Enaleh;;Colonies;L-13
+Echnos;Hadar;Mid Rim;L-17
+Enarc;Alui;Mid Rim;O-17
+Eckless;;Wild Space;J-3
+Encrust;Jubilar;Outer Rim Territories;T-7
+Eczar;Seswenna;Outer Rim Territories;M-18
+Endex;Velcar;Outer Rim Territories;J-5
+Edan;Hythrope;Expansion Region;M-15
+Endor;Zuma (Moddell);Outer Rim Territories;H-16
+Edatha;Vatha;Expansion Region;K-16
+Endor Gate;Zuma (Moddell);Outer Rim Territories;H-16
+Ediorung;Hapes Cluster;Inner Rim;O-9
+Endoraan;Clacis;Outer Rim Territories;K-4
+Edis;Farana*;Wild Space;S-3
+Endovan;Sarka;Mid Rim;Q-8
+Edonaaris;Thrasybule;Outer Rim Territories;P-6
+Endovar;(Terrabe);Mid Rim;H-10
+Edusa;Morshdine;Outer Rim Territories;O-5
+Endoviara;Dantus;Outer Rim Territories;J-6
+Eedoq;Tantra (Methall'has);Outer Rim Territories;M-19
+Endregaad;Indrexu;Outer Rim Territories;S-5
+Eeyyon;Halm;Mid Rim;J-16
+Endrias Minor;Tammuz;Outer Rim Territories;T-14
+Egaria;Svivreni;Outer Rim Territories;O-19
+Endrolia;;Core Worlds;K-10
+Egips;Tharin (Periphery);Outer Rim Territories;S-8
+Endymion;Kalamith;Outer Rim Territories;P-5
+Ehjenla;Kathol;Outer Rim Territories;M-21
+Enet;Brak;Expansion Region;O-14
+Eiattu;Ado;Mid Rim;L-17
+Enferm;Mezeg;Mid Rim;M-7
+Eibon;Cronese Mandate;Outer Rim Territories;S-6
+Engebo;Danjar;Outer Rim Territories;N-18
+Eidoloni;Eidoloni;Mid Rim;M-16
+Engira;Jospro;Outer Rim Territories;R-7
+Eilnia;;Inner Rim;N-9
+Enisca;;Colonies;M-13
+Eiloroseint;Tokamac;Expansion Region;N-13
+Ennth;Astal;Outer Rim Territories;Q-18
+Eiram;Tunka (Dalnan);Outer Rim Territories;I-19
+Enoth;Calamari;Outer Rim Territories;U-6
+Eirrauus;Quence;Outer Rim Territories;P-18
+Enrivi;Metatessu;Mid Rim;R-9
+Eislo;Eislomi;Inner Rim;O-8
+Enselon;;Core Worlds;L-12
+Ejolus;;Inner Rim;M-8
+Ensolica;;Core Worlds;K-10
+Ekibo;Trianii Space*;Wild Space;R-3
+Entana;Cademimu;Outer Rim Territories;L-6
+Ekuda;Cademimu;Outer Rim Territories;L-6
+Enthenium;Jjannex;Outer Rim Territories;K-19
+Elamposnia;Gordian Reach;Outer Rim Territories;Q-5
+Enthi;Manda;Mid Rim;R-14
+Elatha;Stensen;Outer Rim Territories;I-17
+Entiia;Maldrood;Mid Rim;R-7
+Entooine;Danjar;Outer Rim Territories;N-18
+Ession;Corporate Sector;Outer Rim Territories;S-4
+Entralla;Velcar;Outer Rim Territories;K-4
+Essowyn;Trax;Mid Rim;Q-10
+Entropian Hive;Elbaran;Mid Rim;J-17
+Estaph;Tapani;Colonies;L-13
+Entrus;Trax;Mid Rim;Q-10
+Estaria;Indrexu;Outer Rim Territories;S-5
+Entruvia;Halla;Mid Rim;R-8
+Esyram;Atravis;Outer Rim Territories;L-20
+Entuur;Urce Space;Mid Rim;L-6
+Etai;Druess;Mid Rim;O-15
+Eol Sha;Corva;Outer Rim Territories;P-3
+Ethav Major;Ethav Regions*;Wild Space;P-3
+Eos;Cadavine;Outer Rim Territories;P-17
+Ethrani;D'Astan (Valahari);Outer Rim Territories;N-5
+Ephemera;;Inner Rim;J-14
+Etorasp;Hakartha;Expansion Region;K-16
+Epica;Bes Ber Bikade;Expansion Region;L-15
+Etti;Corporate Sector;Outer Rim Territories;S-4
+Epidimi;Rolion;Outer Rim Territories;Q-7
+Euceron;Eucer;Mid Rim;Q-7
+Epikonia;Ojoster;Outer Rim Territories;N-7
+Eufornis Major;;Core Worlds;M-11
+Epo;Ciutric;Outer Rim Territories;N-5
+Eufornis Minor;Shadola;Outer Rim Territories;U-8
+Epsi Nadir;Epsi Collective;Expansion Region;M-15
+Eva-T;Quence;Outer Rim Territories;O-18
+Epsi Zenith;Epsi Collective;Expansion Region;M-15
+Evas;Belshar;Mid Rim;I-7
+Epsom;Quiberon;Outer Rim Territories;S-15
+Excarga;Herios;Outer Rim Territories;T-16
+Equanus;Veragi;Outer Rim Territories;K-3
+Exegol;;Unknown Regions;F-7
+Er'Kit;Noonian;Outer Rim Territories;M-6
+Exigar;Weneen;Outer Rim Territories;N-6
+Er'stacia;;Wild Space;V-9
+Exocron;Kathol;Outer Rim Territories;M-21
+Erai;Hangshan;Expansion Region;P-11
+Exodeen;;Colonies;M-12
+Erdo;Kriz;Outer Rim Territories;K-19
+Exodo;Meridian;Outer Rim Territories;R-7
+Erebus;;Colonies;N-13
+Extorin Major;Extorin;Expansion Region;J-15
+Eredenn;Tion Hegemony;Outer Rim Territories;S-6
+Extorin Minor;Extorin;Expansion Region;J-15
+Eredin;Astal;Outer Rim Territories;P-18
+Extrictarium Nebula;Ash Worlds;Outer Rim Territories;T-7
+Ereesus;Kanz;Outer Rim Territories;N-4
+Exu Prime;Tolonda;Outer Rim Territories;R-18
+Eremond;;Deep Core;L-10
+Eyar;;Inner Rim;O-10
+Eres;Esuain;Mid Rim;Q-7
+Eyo-Dajuritz;;Inner Rim;N-10
+Erhynradd;;Inner Rim;N-13
+Ezaraa;Spinward;Outer Rim Territories;M-2
+Eriadu;Seswenna;Outer Rim Territories;M-18
+Ezran;Onatos;Mid Rim;Q-15
+Erian;Churba;Mid Rim;P-15
+F'Dann;Dufilvian;Mid Rim;R-15
+Eridicon;Calamari;Outer Rim Territories;T-6
+F'tral;Calaron;Outer Rim Territories;T-9
+Erigorm;;Core Worlds;L-9
+F'tzner;Bartahn;Inner Rim;L-15
+Erilnar;Centrality;Outer Rim Territories;T-8
+Faarlsun;;Wild Space;T-4
+Eriscot;Haserian;Mid Rim;Q-14
+Fabrin;Circarpous;Expansion Region;O-12
+Ermi;Sertar;Outer Rim Territories;R-5
+Fadden;;Inner Rim;N-11
+Eroudac;Doldur;Mid Rim;P-15
+Fair Hollis;Karthakk;Outer Rim Territories;Q-17
+Errimin;Koradin;Outer Rim Territories;J-18
+Fait d'Fait;Venaarian;Mid Rim;O-7
+Ertegas;Javin (Anoat);Outer Rim Territories;K-18
+Faket;;Wild Space;G-15
+Ertrax;;Wild Space;N-21
+Fakir;Fakir;Colonies;K-9
+Erub;;Inner Rim;N-14
+Falang Minor;Thanium;Outer Rim Territories;R-6
+Erysthes;Corporate Sector;Outer Rim Territories;S-4
+Falasia;;Inner Rim;N-10
+Esaga;Esaga;Mid Rim;R-11
+Falaston;Kallea;Outer Rim Territories;K-21
+Escabar;;Expansion Region;I-8
+Faldos;Saijo;Outer Rim Territories;K-20
+Escalan;Cademimu;Outer Rim Territories;L-6
+Falko;Centrality;Outer Rim Territories;U-8
+Escander;Taldot;Mid Rim;Q-9
+Falleen;Doldur;Mid Rim;P-15
+Escarte;Keldrath;Outer Rim Territories;T-6
+Fallex;Belderone;Outer Rim Territories;R-6
+Eschaton;Far Xandil;Mid Rim;O-16
+Fallowan;Sujimis;Outer Rim Territories;P-19
+Esfandia;;Wild Space;I-6
+Fangol;Mortex;Outer Rim Territories;S-5
+Eshan;;Inner Rim;N-8
+Fanha;Seitia;Outer Rim Territories;K-19
+Esooma;Sprizen;Outer Rim Territories;N-5
+Faos Station;Belsmuth;Outer Rim Territories;P-6
+Espinar;;Core Worlds;K-9
+Far Dostany;M'shinni;Mid Rim;M-7
+Espirion;;Inner Rim;N-12
+Far Indosa;Gordian Reach;Outer Rim Territories;P-6
+Essebra;Airam;Outer Rim Territories;M-20
+Far Pando;;Hutt Space;S-13
+Esseles;Darpa;Core Worlds;L-9
+Fara's Belt;Rolion;Outer Rim Territories;Q-6
+Esseveya;Maldrood;Mid Rim;R-7
+Farana;Farana*;Wild Space;S-3
+Essien;Halthor;Outer Rim Territories;M-6
+Farbinda;;Inner Rim;N-14
+Farbog;Vorzyd;Outer Rim Territories;R-6
+Ferrelia;Hunnoverrs;Outer Rim Territories;R-16
+Farboon;Tantra;Outer Rim Territories;M-19
+Ferrhast;;Core Worlds;L-13
+Farfalla;Indra-su-Mar;Expansion Region;P-12
+Ferrix;Xappyh (Morlana);Outer Rim Territories;Q-3
+Farfax;Marzoon;Mid Rim;I-16
+Ferro;Illisurevimurasi;Outer Rim Territories;Q-4
+Farfeld;Jjannex;Outer Rim Territories;L-18
+Ferrok Pax;Ombakond;Expansion Region;P-12
+Farhava Beta;Tantra;Outer Rim Territories;M-19
+Ferros;Ojoster;Outer Rim Territories;N-7
+Farj;Varada;Outer Rim Territories;H-19
+Ferrous Aurora Nebula;Thesme;Outer Rim Territories;O-6
+Farnica;Hapes Cluster;Inner Rim;O-9
+Ferton;Al'Nasrl;Outer Rim Territories;T-13
+Faro;;Colonies;N-10
+Fest;Atrivis;Outer Rim Territories;L-5
+Farquar;Kurost;Mid Rim;Q-11
+Feswe Minor;Gordian Reach;Outer Rim Territories;P-5
+Farrfin;Farrfin;Core Worlds;K-9
+Feswe Prime;Gordian Reach;Outer Rim Territories;P-5
+Farseen;Msst;Mid Rim;P-7
+Fether;Corporate Sector;Outer Rim Territories;S-3
+Farsellah;Farstey;Expansion Region;O-8
+Fetilia;Maerdocian;Mid Rim;Q-12
+Farstey;Farstey;Expansion Region;O-8
+Fex;;Deep Core;L-12
+Farstine;Ryndellian;Mid Rim;P-17
+Fhost;;Wild Space;H-7
+Farstone;Juvex;Mid Rim;K-18
+Fial;Auril;Outer Rim Territories;S-6
+Farwell Station;Eucer;Mid Rim;R-7
+Fibuli;Trianii Space*;Wild Space;S-3
+Fasha;;Colonies;M-9
+Fikari;Thanium;Outer Rim Territories;R-6
+Fashinder Prime;Primtara;Mid Rim;P-15
+Fikzwaa;;Inner Rim;N-14
+Faz;Farlax;Core Worlds;K-10
+Filata;;Mid Rim;H-10
+Feather Nebula;Irnaj;Mid Rim;K-17
+Filby;;Core Worlds;L-9
+Febrini;Hapes Cluster;Inner Rim;O-9
+Fillithar;;Colonies;M-9
+Fedalle;;Core Worlds;M-10
+Filordis;Larrin;Inner Rim;N-8
+Feddasyr;Elus;Inner Rim;N-12
+Filve;Dufilvian;Mid Rim;R-15
+Federian;Stensen;Outer Rim Territories;I-17
+Fimster;;Inner Rim;L-14
+Fedje;Atrivis;Outer Rim Territories;L-5
+Findris;Haldeen;Colonies;M-9
+Fedovoi End;Croynar;Inner Rim;M-14
+Firrerre;Zuma (Sugai);Outer Rim Territories;H-16
+Feena;Gordian Reach;Outer Rim Territories;Q-5
+Firrhana;Ojoster;Outer Rim Territories;N-7
+Feenicks;Jjannex;Outer Rim Territories;K-19
+Firro;Farrfin;Core Worlds;K-9
+Feenix;D'Aelgoth;Mid Rim;K-17
+Fislan;Mortex;Outer Rim Territories;R-4
+Fef;Glythe;Mid Rim;J-7
+Fitca Prime;Urce Space;Mid Rim;L-6
+Fegorosk;Obtrexta;Outer Rim Territories;K-4
+Fiumar;Quanta;Core Worlds;M-12
+Fehern;Trax;Mid Rim;Q-10
+Five Points;Thanium;Outer Rim Territories;S-6
+Fekunda;Shadola;Outer Rim Territories;U-8
+Fiviune;Grumani;Outer Rim Territories;N-17
+Felacat;Grohl;Outer Rim Territories;R-15
+Fjor;Grohl;Outer Rim Territories;R-15
+Feldrona;Glythe;Mid Rim;J-7
+Flacharia;;Wild Space;H-6
+Feldwes;Gordian Reach;Outer Rim Territories;Q-6
+Flandor;;Inner Rim;N-13
+Feleantor;Halthor;Outer Rim Territories;L-6
+Flankers;Fakir;Colonies;K-9
+Felin;Spinward;Outer Rim Territories;M-2
+Flashpoint;Meerian;Outer Rim Territories;O-7
+Fellio;Cadavine;Outer Rim Territories;P-17
+Flax;Sumitra;Expansion Region;O-7
+Felne;Bon'nyuw-Luq;Outer Rim Territories;N-17
+Fleyars;Baroli;Expansion Region;N-14
+Felucia;Thanium;Outer Rim Territories;R-6
+Fligger;Kibilini;Outer Rim Territories;Q-17
+Fendry;Druess;Mid Rim;O-15
+Florn;Pakuuni;Outer Rim Territories;T-5
+Fenel;Demetras;Outer Rim Territories;O-7
+Florrum;Sertar;Outer Rim Territories;R-5
+Fengrine;Senex;Mid Rim;L-18
+Floubette;;Colonies;L-13
+Fenion;Rolion;Outer Rim Territories;P-7
+Fluwhaka;Mortex;Outer Rim Territories;R-5
+Fenn;Dufilvian;Mid Rim;R-15
+Flyntaria;D'Astan;Outer Rim Territories;O-6
+Fennesa;;Inner Rim;K-14
+Fnessal;;Inner Rim;K-14
+Fentersohn;;Expansion Region;I-9
+Fobaris;Parmel;Outer Rim Territories;O-18
+Fenves;Boeus;Expansion Region;L-15
+Fodro;Clacis;Outer Rim Territories;K-4
+Feraleech;Noolian;Mid Rim;Q-13
+Fodurant;Trans-Gascon;Mid Rim;P-8
+Fere;Quelii;Outer Rim Territories;O-6
+Foerost;;Core Worlds;L-10
+Ferijia;;Core Worlds;M-10
+Fokask;Klina;Outer Rim Territories;S-13
+Feris;Agarix;Mid Rim;K-17
+Folende;Tion Hegemony;Outer Rim Territories;S-5
+Fermic;Wazta;Outer Rim Territories;J-18
+Foless;;Colonies;M-13
+Ferona Vivaros;;Colonies;N-10
+Fondor;Tapani;Colonies;L-13
+Font-Alor;Garis;Outer Rim Territories;N-18
+Gabdor;;Expansion Region;H-14
+Foran Tutha;Cronese Mandate;Outer Rim Territories;S-6
+Gabredor;Myto;Outer Rim Territories;K-4
+Forbelea;;Unknown Regions;H-8
+Gacerian;Baroli;Expansion Region;N-15
+Fordon;Savareen;Outer Rim Territories;Q-16
+Gad;Brema;Outer Rim Territories;M-17
+Forlonis Minor;Tharin;Outer Rim Territories;S-8
+Gaddria;Oricho;Outer Rim Territories;M-5
+Formos;Kessel;Outer Rim Territories;T-10
+Gadon;Cronese Mandate;Outer Rim Territories;S-6
+Fornax;Glythe;Mid Rim;J-7
+Gaftikar;Kalamith;Outer Rim Territories;P-5
+Fornow;Pacanth Reach;Outer Rim Territories;H-16
+Gagrew Station;;Hutt Space;S-9
+Forntay;;Core Worlds;L-12
+Gailea;;Core Worlds;M-12
+Forome;Kessel;Outer Rim Territories;T-10
+Gaios;;Core Worlds;K-9
+Forrn;Xan;Mid Rim;Q-15
+Gairm;Venaarian;Mid Rim;O-7
+Forscan;Auril;Outer Rim Territories;R-7
+Gal Milnor;Seitia;Outer Rim Territories;K-19
+Forsen;Cassander;Outer Rim Territories;K-5
+Gala;Nuiri;Outer Rim Territories;Q-7
+Forvand;Corellian;Core Worlds;M-11
+Galaan;Corva;Outer Rim Territories;P-4
+Fostar Haven;Serathrace;Expansion Region;P-11
+Galagolos;;Colonies;J-9
+Fostin;Grumani;Outer Rim Territories;N-17
+Galand;Torranix;Core Worlds;K-10
+Foundry;;Colonies;N-10
+Galantos;Farlax;Core Worlds;K-10
+Foxar;;Wild Space;N-3
+Galara;Roche;Mid Rim;Q-8
+Fracni;;Inner Rim;J-8
+Galator;Belsmuth;Outer Rim Territories;O-6
+Fradian;Roche;Mid Rim;Q-8
+Galboron;Hertae;Mid Rim;Q-14
+Freda;Esaga;Mid Rim;Q-11
+Galdi;Brema (Reithcas);Outer Rim Territories;M-18
+Freerock;;Wild Space;H-13
+Galdria;Cronese Mandate;Outer Rim Territories;S-6
+Frego;;Core Worlds;L-13
+Galdronia;;Core Worlds;L-10
+Freliq;Calaron;Outer Rim Territories;U-9
+Galidraan;Thanium;Outer Rim Territories;R-6
+Fremond;;Inner Rim;N-14
+Galitan;Bormea;Core Worlds;L-9
+Frenos;Cadavine;Outer Rim Territories;P-17
+Galjaero;Tungra;Outer Rim Territories;K-18
+Fresia;Torranix;Core Worlds;K-10
+Gall;Cadavine;Outer Rim Territories;P-17
+Frewwil;;Expansion Region;I-14
+Gallapraxis;Hythrope;Expansion Region;M-16
+Freya;;Wild Space;S-18
+Galleefryn;Corporate Sector;Outer Rim Territories;S-3
+Frezno;Cademimu;Outer Rim Territories;M-6
+Gallimere;Thuris;Outer Rim Territories;P-19
+Friijillis;Dail;Outer Rim Territories;P-18
+Gallinore;Hapes Cluster;Inner Rim;O-9
+Frisal;Atrisian CW;Core Worlds;J-12
+Gallion;Grumani;Outer Rim Territories;N-17
+Frithia;Glythe;Mid Rim;K-7
+Gallios;Tragan Cluster;Outer Rim Territories;N-5
+Froffl;Churba;Mid Rim;P-15
+Galloa;D'Astan;Outer Rim Territories;O-5
+Fromiria;Mortex;Outer Rim Territories;R-5
+Gallshebbis Prime;Nilgaard;Outer Rim Territories;S-5
+Fromish;;Core Worlds;M-11
+Galltine;Thesme;Outer Rim Territories;O-6
+Frommon;;Colonies;M-9
+Gallus;Allied Tion;Outer Rim Territories;S-6
+Frong;Ojoster;Outer Rim Territories;N-7
+Galmerah;Jalor;Mid Rim;J-7
+Froswythe;;Colonies;M-13
+Galov;Galov;Outer Rim Territories;T-14
+Froz;Corellian;Core Worlds;M-11
+Galpos;Abrion;Outer Rim Territories;S-15
+Frunchettan;;Wild Space;I-6
+Galsol;Belderone;Outer Rim Territories;R-6
+Fryiaa;Dail;Outer Rim Territories;Q-18
+Galtea;Kathol;Outer Rim Territories;M-21
+Fuacha;Galov;Outer Rim Territories;T-14
+Galtea Binary;Kathol;Outer Rim Territories;M-21
+Fusai;Zuma (Fusai);Outer Rim Territories;H-16
+Galvoni;;Core Worlds;K-9
+Fwatna;Subterrel;Outer Rim Territories;K-20
+Galzez;Dustig;Mid Rim;M-17
+Fwiis;;Inner Rim;M-13
+Gam Tim'nisi;Tungra;Outer Rim Territories;K-18
+Fwillsving;Calaron;Outer Rim Territories;T-10
+Gama;;Core Worlds;L-12
+Fyodos;Tammuz;Outer Rim Territories;U-14
+Gamerong;Nijune;Outer Rim Territories;N-4
+Fyrth;;Inner Rim;J-8
+Gammalin;Vish;Mid Rim;N-16
+Fytoun;Brak;Expansion Region;O-14
+Gamor;Chaykin;Expansion Region;O-14
+G'haris;Perinn;Outer Rim Territories;J-4
+Gamorr;Galov;Outer Rim Territories;T-14
+G'rho;;Wild Space;G-16
+Gan Moradir;Xan;Mid Rim;Q-15
+G'Tep'Noi;Croynar;Inner Rim;N-14
+Ganath;;Hutt Space;R-12
+G'wenee;Weneen;Outer Rim Territories;N-6
+Gand;Shadola;Outer Rim Territories;T-8
+Gaalt;Meram;Outer Rim Territories;O-4
+Gandalla;Boeus;Expansion Region;M-15
+Gaaten;Garis;Outer Rim Territories;N-17
+Gandan;Oricho;Outer Rim Territories;M-6
+Gandeal;;Core Worlds;M-12
+Gedi;Arkanis;Outer Rim Territories;R-16
+Geedon;Sumitra;Expansion Region;N-7
+Gandeid;Trailing Grant;Expansion Region;J-15
+Gefthaine;Mandalore;Outer Rim Territories;O-7
+Gandle Ott;Kathol;Outer Rim Territories;M-21
+Geillia;Keldrath;Outer Rim Territories;T-6
+Gandolo;Lahara;Outer Rim Territories;M-5
+Geister;Iskin;Mid Rim;O-16
+Gandrossi;Perinn;Outer Rim Territories;J-4
+Gelda;Carrion;Outer Rim Territories;J-4
+Gandrun;;Colonies;J-13
+Geldoll;Kossa;Expansion Region;O-11
+Gangxi Station;;Wild Space;I-15
+Gelemeade;Kordu;Mid Rim;L-7
+Gania;Tapani;Colonies;L-13
+Gelgelar;Elrood;Outer Rim Territories;M-20
+Ganlihk;Dantus;Outer Rim Territories;J-6
+Gellefon;Savareen;Outer Rim Territories;Q-16
+Gannaria;Trilon;Outer Rim Territories;H-15
+Gelviddis Cluster;;Inner Rim;N-9
+Gannymeda;;Inner Rim;M-8
+Gem, The;;Unknown Regions;G-14
+Ganoidi;Brema;Outer Rim Territories;M-17
+Genassa;M'shinni;Mid Rim;M-7
+Gansett;Manda;Mid Rim;R-15
+Gendius;Gendius;Mid Rim;J-17
+Gansevor;Tammuz;Outer Rim Territories;T-14
+Gendoraan;;Core Worlds;M-10
+Ganthel;Bormea;Core Worlds;L-9
+Gendrah-Narvin;;Inner Rim;N-13
+Gantho;;Inner Rim;N-12
+Generis;Atrivis;Outer Rim Territories;L-5
+Gantonnerre;;Inner Rim;N-8
+Genesia;Brak;Expansion Region;O-14
+Ganzik;Maldrood;Mid Rim;R-7
+Genetia;;Expansion Region;I-14
+Garban;Abrion;Outer Rim Territories;S-15
+Genhu;Tharin (Periphery);Outer Rim Territories;S-8
+Garcornia;Ado;Mid Rim;M-17
+Genian;Trax;Mid Rim;P-10
+Gardaji Rift;(Gardaji);Outer Rim Territories;M-1
+Geniseria;Jurzan;Expansion Region;M-15
+Garel;Lothal;Outer Rim Territories;U-7
+Genon;;Inner Rim;N-13
+Garen;Thuldin's Grant;Expansion Region;J-15
+Genosha;;Outer Rim Territories;I-20
+Garfin;Immeria;Expansion Region;O-14
+Geonosis;Arkanis;Outer Rim Territories;R-16
+Gargolyn;;Wild Space;I-8
+Gepparin;Shelsha;Colonies;M-9
+Gargon;Mandalore;Outer Rim Territories;O-7
+Geptish;Yushan;Mid Rim;K-17
+Garia;Brak;Expansion Region;O-14
+Geran;Calaron;Outer Rim Territories;T-9
+Garis;Tamarin;Outer Rim Territories;N-18
+Gerhalt;Altier;Expansion Region;O-13
+Garn;Cadma;Outer Rim Territories;T-8
+Geridard;Doldur;Mid Rim;P-15
+Garnib;Bozhnee;Outer Rim Territories;L-18
+Gerinia;Trans-Vulta;Mid Rim;N-7
+Garobi;Tapani;Colonies;L-13
+Geris;Trans-Vulta;Mid Rim;O-7
+Garollia;Baroli;Expansion Region;N-15
+Geroon;;Unknown Regions;I-8
+Garos;Msst;Mid Rim;P-7
+Gerrard;;Core Worlds;K-12
+Garqi;Cassander (Tadrin);Outer Rim Territories;K-5
+Gerrenthum;Javin (Anoat);Outer Rim Territories;K-18
+Garr'lst;;Inner Rim;O-8
+Gerres Gule;Primtara;Mid Rim;P-15
+Garrthinius;Steniplis;Outer Rim Territories;M-18
+Gerrigon;Masla;Mid Rim;J-17
+Garwillia;;Core Worlds;M-10
+Gertafuu;;Wild Space;S-18
+Gascon;Trans-Gascon;Mid Rim;P-8
+Gerzob;Hunnoverrs;Outer Rim Territories;R-18
+Gastrula;Rayter;Outer Rim Territories;J-19
+Gesaral Beta;Gordian Reach;Outer Rim Territories;P-6
+Gatalenta;;Core Worlds;M-10
+Gesaril;Minos Cluster;Outer Rim Territories;M-20
+Gathus;Tynquay;Outer Rim Territories;Q-4
+Geska Prime;Lifh;Mid Rim;Q-8
+Gattering;Noolian;Mid Rim;Q-13
+Gestrex;Calaron;Outer Rim Territories;T-9
+Gaulus;Gaulus;Outer Rim Territories;S-17
+Gestron;Tennuutta;Mid Rim;Q-7
+Gaurick;Corporate Sector;Outer Rim Territories;S-4
+Gevarno Cluster;Brema;Outer Rim Territories;M-17
+Gavana;Belasco;Expansion Region;O-11
+Ggy-ynt;Esuain;Mid Rim;Q-7
+Gavens;Tregillis;Expansion Region;M-15
+GH-531;;Unknown Regions;I-5
+Gavos;Kastolar;Mid Rim;Q-10
+Ghaina;;Core Worlds;K-9
+Gavriza;Prackla;Expansion Region;O-8
+Ghalla;Airam;Outer Rim Territories;L-20
+Gavryn;Romintine;Mid Rim;Q-8
+Gheia;Albarrio;Outer Rim Territories;K-5
+Gaxxa;;Inner Rim;N-10
+Gherillia;Bes Ber Bikade;Expansion Region;L-15
+Gazian;Truum;Mid Rim;P-8
+Ghishi;Daimar;Mid Rim;Q-16
+Gazzari;Grumani;Outer Rim Territories;M-17
+Ghita;Atravis;Outer Rim Territories;L-19
+Gazzari Minor;Garis;Outer Rim Territories;N-17
+Ghoba;Chitarghar;Expansion Region;K-15
+Gbu;Keldrath;Outer Rim Territories;T-6
+Gholondreine;Chitarghar;Expansion Region;K-15
+Geal;Gendius;Mid Rim;K-17
+Ghonoath;Croynar;Inner Rim;M-14
+Ghorman;Sern;Colonies;L-13
+Gonmore;Fath;Outer Rim Territories;K-6
+Ghorn;Tharin (Karstaxon);Outer Rim Territories;S-8
+Gontzol;;Colonies;L-13
+Ghost Moon;Wornal;Mid Rim;K-16
+Goorla;Corellian;Core Worlds;M-11
+Ghost Nebula;Ghost Nebula;Expansion Region;P-10
+Goratak;Vensensor;Expansion Region;K-16
+Ghothia;Stensen;Outer Rim Territories;I-16
+Gorbah;Atravis;Outer Rim Territories;L-19
+Gibad;Abrion;Outer Rim Territories;S-15
+Gorgaria;Karthakk;Outer Rim Territories;Q-17
+Gibbela;Atrivis;Outer Rim Territories;L-5
+Gorm;Meerian;Outer Rim Territories;O-6
+Gibraal;Itopol;Expansion Region;K-15
+Gorma;Majoor;Expansion Region;N-15
+Giddea;Merthian;Expansion Region;N-13
+Gormen;Nuiri;Outer Rim Territories;Q-7
+Giermos;;Colonies;L-8
+Gorno;Arkanis;Outer Rim Territories;R-17
+Gigor;Tynquay;Outer Rim Territories;R-4
+Gorobei;;Inner Rim;M-8
+Giju;Herglic Space;Colonies;L-13
+Goroth;Trans-Nebular;Mid Rim;R-16
+Gilatter;Churnis;Mid Rim;I-7
+Gorse;;Inner Rim;O-10
+Gilliana;Tapani;Colonies;L-13
+Gorsh;;Wild Space;O-3
+Gilvaanen;;Inner Rim;L-8
+Gortus;Kanz;Outer Rim Territories;N-4
+Ginn Jump;;Core Worlds;L-10
+Gorvinia;Thusa;Mid Rim;O-7
+Giryulan;;Wild Space;U-6
+Gos Hutta;;Hutt Space;S-11
+Gizer;Lantillian;Mid Rim;P-8
+Gosfambling;Lifh;Mid Rim;R-8
+Glade;Gordian Reach;Outer Rim Territories;P-5
+Gosho;Parmel;Outer Rim Territories;O-18
+Glakka;Wyl;Outer Rim Territories;R-4
+Goshyn;Tolonda;Outer Rim Territories;Q-18
+Glassferra;;Inner Rim;N-9
+Gotar;;Wild Space;U-9
+Glastis;Chiss Space*;Unknown Regions;F-8
+Gotida;;Inner Rim;O-10
+Glavis;;Core Worlds;M-11
+Gotoma;Farlax;Core Worlds;K-10
+Glee Anselm;Jalor;Mid Rim;J-7
+Gottlegoob;;Wild Space;O-20
+Gligger;Ash Worlds;Outer Rim Territories;S-7
+Govia;Corellian;Core Worlds;M-11
+Glite-Ven;Aparo;Outer Rim Territories;R-3
+Gowdawl;;Inner Rim;M-14
+Glithnos;;Core Worlds;M-10
+Gozgo;;Hutt Space;S-9
+Glom Tho;Hevvrol;Mid Rim;O-15
+Gra Ploven;;Colonies;N-12
+Gloon;Kessel;Outer Rim Territories;T-10
+Graador;Graador;Mid Rim;I-17
+Glottal;Baxel;Outer Rim Territories;U-11
+Graal'diin;Spadja;Outer Rim Territories;R-6
+Glova;Tarabba;Outer Rim Territories;M-19
+Graddus Rex;;Inner Rim;L-14
+Gmar Askilon;Krenhner;Inner Rim;L-14
+Gradilis Rift;;Wild Space;I-5
+Gnithia;Jospro;Outer Rim Territories;R-7
+Grakouine;Onatos;Mid Rim;R-15
+Goa;Bes Ber Bikade;Expansion Region;L-15
+Gralack;Kwymar;Outer Rim Territories;P-4
+Gobindi;Noonian;Outer Rim Territories;M-6
+Graland;Corellian;Core Worlds;M-11
+Gobreton;Barma;Colonies;M-9
+Grand Tharkand;;Inner Rim;O-9
+Godo;Quence;Outer Rim Territories;O-18
+Grandak;Cronese Mandate;Outer Rim Territories;S-6
+Godsheart, The;;Hutt Space;T-11
+Grandeel;Tynna;Expansion Region;N-14
+Goelitz;M'shinni;Mid Rim;M-7
+Grandine;;Colonies;M-9
+Goff;Airam;Outer Rim Territories;L-20
+Grange;Kurost;Mid Rim;Q-11
+Goibniu;Videnda;Outer Rim Territories;L-18
+Granna;;Core Worlds;K-10
+Golatha;Dalicron;Outer Rim Territories;K-19
+Granus;;Inner Rim;M-14
+Golatha Nebula;Dalicron;Outer Rim Territories;K-19
+Grast;;Inner Rim;J-14
+Golden Nyss;Fellwe;Expansion Region;L-8
+Grathus;Jospro;Outer Rim Territories;R-7
+Golh;Videnda;Outer Rim Territories;L-18
+Grava;Kallea;Outer Rim Territories;K-20
+Goliath Mal;;Colonies;N-10
+Gravan;;Inner Rim;O-8
+Golkus;;Colonies;K-9
+Gravane;Klina;Outer Rim Territories;S-13
+Golrath;Sanbra;Outer Rim Territories;O-17
+Gravdinia;;Colonies;N-10
+Golus Pheyar;Tion Hegemony;Outer Rim Territories;T-6
+Gravlex Med;Raioballo;Outer Rim Territories;L-4
+Golus Station;Vilonis;Mid Rim;O-16
+Great Aglamerti;Charra;Expansion Region;P-14
+Goluud Minor;;Core Worlds;L-10
+Great Forveen Nebula;Churnis;Mid Rim;J-6
+Goluud Prime;;Deep Core;L-10
+Great Zilk;Irishi;Mid Rim;K-6
+Gom;Tregillis;Expansion Region;L-15
+Greater Marianas;Sevetta;Outer Rim Territories;S-15
+Gon Tiek;Atravis;Outer Rim Territories;L-19
+Gree;Veragi (Gree Enclave);Outer Rim Territories;L-2
+Gonda;Bon'nyuw-Luq;Outer Rim Territories;N-18
+Gree Baaker;Atrivis;Outer Rim Territories;L-5
+Gondagali;Lahara;Outer Rim Territories;M-5
+Greeb-Streebling Cluster;Bozhnee;Outer Rim Territories;L-18
+Greeve;Grumani;Outer Rim Territories;N-17
+Hakara;Corva;Outer Rim Territories;P-3
+Gregonia;Dimean;Expansion Region;P-13
+Hakartha;Hakartha;Expansion Region;K-16
+Grehollo;Manoe;Mid Rim;K-7
+Hakassi;;Deep Core;M-11
+Grella;Tapani;Colonies;L-13
+Hakotei;D'Astan;Outer Rim Territories;O-6
+Greyman's Planet;Wazta;Outer Rim Territories;J-18
+Halais;;Colonies;N-10
+Grimdock;Axion;Expansion Region;P-10
+Halanit;;Colonies;N-11
+Grimwald;Truum;Mid Rim;P-8
+Halbara;Elrood;Outer Rim Territories;M-20
+Griq;;Unknown Regions;H-7
+Halcyon;;Colonies;K-13
+Grizal;Hadar;Mid Rim;L-17
+Haldeen;Haldeen;Colonies;M-9
+Grizmallt;;Core Worlds;L-9
+Hali;Hali;Expansion Region;O-9
+Gromas;Perkell;Mid Rim;Q-7
+Hallion;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Groth;;Hutt Space;S-11
+Hallitron;Jalor;Mid Rim;J-7
+Grumwall;Illisurevimurasi;Outer Rim Territories;Q-4
+Halloways;;Inner Rim;O-9
+Gruvia;Hilo;Expansion Region;P-13
+Hallrin;Surron;Expansion Region;O-13
+Gryphon;;Inner Rim;N-9
+Halm;Halm;Mid Rim;J-16
+Guagenia;Guagenian;Inner Rim;J-14
+Halmad;Quelii;Outer Rim Territories;N-6
+Guat'a;Torch Nebula;Outer Rim Territories;P-19
+Halowan;Fakir;Colonies;K-9
+Guavian Drift;Meram;Outer Rim Territories;P-4
+Halpat;;Core Worlds;K-9
+GUHL-J03870;Trilon;Outer Rim Territories;H-15
+Halthor;Halthor;Outer Rim Territories;L-6
+Guiteica;Kadok Regions*;Wild Space;J-4
+Haluria;Vendusii;Mid Rim;P-16
+Gulf of Tatooine;Arkanis;Outer Rim Territories;R-16
+Halyard;Bes Ber Bikade;Expansion Region;L-15
+Gulhadar;;Inner Rim;L-8
+Handooine;Phelleem;Outer Rim Territories;S-7
+Gulma;;Wild Space;P-3
+Haneli;Arc d'Stot;Expansion Region;K-15
+Gultanna;Va di Gult;Mid Rim;K-8
+Hanna;;Inner Rim;M-8
+Gulvitch;Gordian Reach;Outer Rim Territories;Q-6
+Hanod;Corva;Outer Rim Territories;P-3
+Gundravia;Hadar;Mid Rim;L-17
+Hanofar;;Colonies;L-13
+Gunthar;Kriz;Outer Rim Territories;J-18
+Hapes;Hapes Cluster;Inner Rim;O-9
+Gurrisalia;Relgim;Outer Rim Territories;L-5
+Hapor;;Inner Rim;O-8
+Gutretee;Javin (Anoat);Outer Rim Territories;K-18
+Hapuntep;Ado;Mid Rim;M-17
+Guudria;;Wild Space;R-19
+Har Binande;Har Worlds;Expansion Region;J-16
+Guuko;Weneen;Outer Rim Territories;N-6
+Harbin-re;;Inner Rim;N-13
+Gwar;;Mid Rim;H-15
+Harda;Phelleem;Outer Rim Territories;S-7
+Gwongdeen;;Colonies;J-9
+Hardex;Jubilar;Outer Rim Territories;T-7
+Gwori;Clacis;Outer Rim Territories;K-4
+Hargeeva;Jurzan;Expansion Region;M-15
+Gymelo;Bakura;Outer Rim Territories;G-16
+Harix;;Colonies;K-9
+Gyndine;Circarpous;Expansion Region;O-12
+Harko Station;D'Astan;Outer Rim Territories;N-5
+Gyndorath;;Unknown Regions;G-11
+Harkrova;;Inner Rim;N-9
+Gyosha;;Core Worlds;K-12
+Harlequin Station;Garis;Outer Rim Territories;N-17
+H'Grathi Nebulae;Thrasybule;Outer Rim Territories;P-6
+Harloen;Belsmuth;Outer Rim Territories;O-6
+H'ken;Corva;Outer Rim Territories;P-4
+Harloff Minor;;Core Worlds;L-9
+H'nemthe;Mayagil;Outer Rim Territories;M-18
+Harpori;Druess;Mid Rim;O-15
+H'ratth;;Inner Rim;N-10
+Harrandarr;Bosph;Outer Rim Territories;Q-3
+H'relac;Aparo;Outer Rim Territories;R-3
+Harridan;Dantus;Outer Rim Territories;J-6
+Haariden;;Inner Rim;O-9
+Harrin;Harrin;Inner Rim;L-15
+Haaridin;Kwymar;Outer Rim Territories;P-4
+Harrod's Planet;Oplovis;Outer Rim Territories;M-5
+Haashimut;Ash Worlds;Outer Rim Territories;S-7
+Harswee;Mandalore;Outer Rim Territories;O-7
+Habassa;Herdessa;Mid Rim;Q-16
+Hartaga;Drannik;Expansion Region;K-8
+Had Abbadon;;Deep Core;L-10
+Harterra;Hapes Cluster;Inner Rim;O-9
+Hadi;Kalamith;Outer Rim Territories;P-5
+Haruun Kal;Dustig;Mid Rim;M-17
+Hadlress;;Inner Rim;M-14
+Hasaq;Askarian;Expansion Region;P-12
+Hadros;Prefsbelt;Outer Rim Territories;J-6
+Haseria;Haserian;Mid Rim;P-15
+Hafernia;;Inner Rim;J-8
+Hasiki;;Inner Rim;O-8
+Haffrin;Esstran;Outer Rim Territories;Q-4
+Hassaria;Wazta;Outer Rim Territories;I-17
+Hagar Secundus;Brak;Expansion Region;O-14
+Hasskyn;Minos Cluster;Outer Rim Territories;M-20
+Haidoral Prime;Kastolar;Mid Rim;R-10
+Hast;;Wild Space;U-6
+Haileap;Tunka (Dalnan);Outer Rim Territories;I-19
+Hathrox;Halla;Mid Rim;R-10
+Haurgab;Spirva;Mid Rim;L-16
+Hijarna;Orus;Inner Rim;M-8
+Havel Prime;;Inner Rim;L-8
+Hijo;Hijoian Space;Expansion Region;J-8
+Haven;Minos Cluster;Outer Rim Territories;M-20
+Hikil;Grohl;Outer Rim Territories;R-16
+Haverling;Albarrio;Outer Rim Territories;K-5
+Hillindor;Echo;Inner Rim;M-13
+Havricus;;Colonies;N-12
+Hilo;Hilo;Expansion Region;O-13
+Hazun;Astal;Outer Rim Territories;P-17
+Hinakuu;Calamari;Outer Rim Territories;U-6
+Hazzard;Lahara;Outer Rim Territories;M-5
+Hinari;Thesme;Outer Rim Territories;O-6
+Heap Nine;Boeus;Expansion Region;M-15
+Hinda;Airam;Outer Rim Territories;L-20
+Hebekrr;Ojoster;Outer Rim Territories;N-7
+Hindasar;Corpheli;Expansion Region;M-8
+Heffrin;Arkanis;Outer Rim Territories;R-17
+Hindle;;Core Worlds;M-12
+Hefi;Abrion;Outer Rim Territories;S-15
+Hino;;Colonies;N-10
+Hei;Thrasybule;Outer Rim Territories;P-6
+Hintis;Parmel;Outer Rim Territories;O-18
+Heliconia;;Core Worlds;L-10
+Hintivan;Corva;Outer Rim Territories;Q-3
+Helikoprion;Nilgaard;Outer Rim Territories;S-5
+Hiorin;Ash Worlds;Outer Rim Territories;T-6
+Helix;Meridian;Outer Rim Territories;R-6
+Hirsi;Elbaran;Mid Rim;J-17
+Helleguth;;Inner Rim;N-13
+Hishyim;Abrion;Outer Rim Territories;S-15
+Hellenah;Xan;Mid Rim;Q-15
+Hismaul;Karthakk;Outer Rim Territories;Q-16
+Hellhoop, The;Hocatar;Expansion Region;P-12
+Hisseen;Yucrales;Mid Rim;R-15
+Hellios;Tapani;Colonies;L-13
+Hissrich;Spadja;Outer Rim Territories;R-6
+Helmaxa;;Inner Rim;M-14
+Hitaka;Cademimu;Outer Rim Territories;M-6
+Helska;Dalonbian;Outer Rim Territories;L-2
+Hivebase-1;Minos Cluster;Outer Rim Territories;M-20
+Hemei;;Core Worlds;M-12
+Hjaff;;Colonies;J-13
+Hendanyn;;Colonies;M-13
+Hleua;Eucer;Mid Rim;Q-7
+Hendrix;Iska;Mid Rim;J-16
+Hodi;;Core Worlds;M-10
+Hensara;Rachuk;Colonies;N-11
+Hofsgut;Hewett;Mid Rim;M-7
+Heptalia;;Inner Rim;M-14
+Hok;;Colonies;M-9
+Heptooine;Grumani;Outer Rim Territories;N-17
+Holador;Herios;Outer Rim Territories;T-16
+Herakal;Ghost Nebula;Expansion Region;P-10
+Holageus;Charra;Expansion Region;P-14
+Herdessa;Herdessa;Mid Rim;Q-16
+Holess;Manda;Mid Rim;R-14
+Herego;;Colonies;M-9
+Hollastin;;Hutt Space;S-12
+Herios;Herios;Outer Rim Territories;T-16
+Hologram Fun World;Phelleem;Outer Rim Territories;S-7
+Heriston;Atravis;Outer Rim Territories;L-19
+Holpern;Arkanis;Outer Rim Territories;R-16
+Hermos;Spadja;Outer Rim Territories;R-5
+Homana;Strabin;Mid Rim;M-6
+Hero Twins;Relgim;Outer Rim Territories;L-4
+Homon;Homon;Mid Rim;M-7
+Herrik;Dantus;Outer Rim Territories;J-6
+Honoghr;Kessel;Outer Rim Territories;T-10
+Herstell;;Colonies;N-12
+Hoogon;Dantus;Outer Rim Territories;J-6
+Herzob;;Colonies;N-12
+Hope Station;Haserian;Mid Rim;Q-14
+Hesperys Station;Tunka (Dalnan);Outer Rim Territories;I-19
+Horain;;Inner Rim;L-14
+Hestria;Senex;Mid Rim;L-18
+Horizon Base;Veragi;Outer Rim Territories;K-3
+Heterkus;Tharin;Outer Rim Territories;S-8
+Horn Station;Lahara;Outer Rim Territories;M-5
+Hethar;Atrivis;Outer Rim Territories;L-5
+Horob;Vardoss;Expansion Region;I-8
+Hetnagaro;Andirma;Expansion Region;L-15
+Horos;Lambda;Mid Rim;Q-15
+Hettitite;Dalonbian;Outer Rim Territories;M-2
+Horox;Lahara;Outer Rim Territories;M-5
+Hettsk;Belsmuth;Outer Rim Territories;P-6
+Horska;;Colonies;J-9
+Hetzal;Savareen;Outer Rim Territories;Q-16
+Horthav;Kuat;Core Worlds;M-10
+Heva;Sevetta;Outer Rim Territories;S-16
+Hortolo;Trans-Vulta;Mid Rim;O-7
+Hevurion;;Inner Rim;L-8
+Horuz;Atrivis;Outer Rim Territories;L-5
+Hewett;Hewett;Mid Rim;M-6
+Hosko;;Hutt Space;S-11
+Hewl;Eidoloni;Mid Rim;M-16
+Hosnian Prime;Hosnian;Core Worlds;M-12
+Hexus;D'Astan;Outer Rim Territories;O-5
+Hosrel;Centrality;Outer Rim Territories;U-8
+Hibrath;;Unknown Regions;G-7
+Hoszh Iszhir;Uoti;Core Worlds;K-9
+Hidden Tegoor;Albanin;Outer Rim Territories;T-12
+Hoth;Javin (Anoat);Outer Rim Territories;K-18
+Hiffis;Jjannex;Outer Rim Territories;L-18
+Houche;Zuma (Sugai);Outer Rim Territories;H-16
+High Chunah;Javin;Outer Rim Territories;K-18
+Hovan;Senex;Mid Rim;L-18
+Hiit;Corporate Sector;Outer Rim Territories;S-3
+Hoven;;Inner Rim;O-8
+Hijado;Thesme;Outer Rim Territories;O-6
+Hovun;Sepan;Expansion Region;P-13
+Hoxim;;Unknown Regions;G-9
+Ifron;Thuris;Outer Rim Territories;P-18
+Hoylin;Fei Hu;Mid Rim;P-13
+Ihopek;Mayagil;Outer Rim Territories;N-18
+Hradreek;Graador;Mid Rim;I-17
+Ikari;;Wild Space;H-14
+Hraki;Vorzyd;Outer Rim Territories;R-6
+Ikkrukk;Ryndellian;Mid Rim;P-17
+Hrasskis;Kossa;Expansion Region;O-11
+Ikon;Majoor;Expansion Region;N-15
+Hreeshi;Kalamith;Outer Rim Territories;P-5
+Iktotch;Narvath;Expansion Region;O-14
+Hrel;Relgim;Outer Rim Territories;L-5
+Ilamna;Eucer;Mid Rim;Q-7
+Hrill;Yminis;Outer Rim Territories;S-15
+Iliabath;Mortex;Outer Rim Territories;R-4
+Hrthging;Mandalore;Outer Rim Territories;O-7
+Ilimardon;Nicandra;Mid Rim;L-7
+Hudalla;Stensen;Outer Rim Territories;I-17
+Illarreen;Herios;Outer Rim Territories;T-16
+Huk;;Wild Space;J-4
+Illmuth;Corellian;Core Worlds;M-11
+Huldamun;Arkanis;Outer Rim Territories;R-17
+Illodia;Illodia;Core Worlds;K-13
+Hull's Star;Farana*;Wild Space;S-3
+Illoud;Hali;Expansion Region;O-9
+Huloon;;Hutt Space;S-11
+Iloh;;Inner Rim;N-9
+Humbarine;Humbarine;Core Worlds;M-10
+Ilos;;Hutt Space;R-10
+Hurd's Moon;Bortele;Mid Rim;R-8
+Ilos Minor;;Hutt Space;R-10
+Hurikane;;Wild Space;V-9
+Ilthan;;Core Worlds;M-11
+Huro;Ciutric;Outer Rim Territories;N-5
+Ilum;;Unknown Regions;G-7
+Hurrim;Danjar;Outer Rim Territories;N-18
+Imberlin;Imberlin;Expansion Region;P-14
+Huru;Mieru'kar;Outer Rim Territories;N-4
+Imdaar;Dantus;Outer Rim Territories;J-6
+Hutlar;Senex;Mid Rim;L-17
+Imena;Varada;Outer Rim Territories;H-19
+Huulia;;Colonies;N-12
+Imerria;Immeria;Expansion Region;O-14
+Huvveck;Juris;Outer Rim Territories;O-17
+Immalia;Immalia;Expansion Region;K-8
+Huwaw;Lahara;Outer Rim Territories;M-5
+Immeldia;Ash Worlds;Outer Rim Territories;T-7
+Hyabb;Krenher;Core Worlds;K-9
+Imram;Lannik Space;Mid Rim;R-13
+Hyborea;Semagi;Mid Rim;I-16
+Imroosia;;Inner Rim;N-9
+Hyder;Tarabba;Outer Rim Territories;M-19
+Imvur;Hertae;Mid Rim;Q-14
+Hydra;Aparo (Catarlo);Outer Rim Territories;R-3
+Imynusoph;Kallea;Outer Rim Territories;J-21
+Hydraxia;;Inner Rim;M-13
+Inamorata, The;Bheriz;Outer Rim Territories;U-10
+Hyell;Vilonis;Mid Rim;O-16
+Inat Prime;Quiberon;Outer Rim Territories;S-15
+Hylaia;;Inner Rim;O-9
+Indellian;Javin (Yarith);Outer Rim Territories;K-18
+Hylanth;Meram;Outer Rim Territories;O-4
+Indoumodo;;Wild Space;S-18
+Hylobi;Taldot;Mid Rim;Q-8
+Indu San;Rolion;Outer Rim Territories;Q-7
+Hynah;Kalamith;Outer Rim Territories;P-5
+Indupar;Ado;Mid Rim;M-17
+Hynestia;Hynestian;Colonies;J-13
+Ingae;Rseik;Outer Rim Territories;N-20
+Hyperkarn;Grohl;Outer Rim Territories;R-16
+Ingo;Bortele;Mid Rim;R-8
+Hypori;Ferra;Outer Rim Territories;S-16
+Injopan;Kessel;Outer Rim Territories;T-10
+Hypotria;Bortele;Mid Rim;S-8
+Innton;Sluis;Outer Rim Territories;M-18
+Hyrol Preen Beta;Portmoak;Outer Rim Territories;P-18
+Insk;;Wild Space;P-3
+Hysalria;Sluis;Outer Rim Territories;M-19
+Insta;Majoor;Expansion Region;N-15
+Hythrope;Hythrope;Expansion Region;M-15
+Intran;Brak;Expansion Region;O-14
+I'vorcia Prime;Mieru'kar;Outer Rim Territories;O-4
+Intuci;Abrion;Outer Rim Territories;S-15
+Iakar;Rseik;Outer Rim Territories;N-20
+Inusagi;Vilonis;Mid Rim;O-16
+Ianane;;Wild Space;I-10
+Inysh;;Core Worlds;J-12
+Iast;Aldino;Mid Rim;J-17
+Iokath;;Unknown Regions;D-7
+Ibaar;Jubilar;Outer Rim Territories;T-8
+Iol;;Unknown Regions;I-10
+Ibanjji;Mieru'kar;Outer Rim Territories;N-4
+Ione;Javin (Anoat);Outer Rim Territories;K-18
+Ibbe;Subterrel;Outer Rim Territories;L-20
+Iope;;Deep Core;L-10
+Iceni;Corporate Sector;Outer Rim Territories;R-4
+Iotra;Suolriep (Iotran Expanse);Outer Rim Territories;S-8
+Ichalin Station;Hijoian Space;Expansion Region;J-8
+Ipellrilla;Glythe;Mid Rim;K-7
+Ichtor;Sombure;Mid Rim;K-16
+Iphar;;Inner Rim;L-14
+Icindra;Calamari;Outer Rim Territories;U-6
+Iphigin;;Core Worlds;L-13
+Idaflor;Sarin;Outer Rim Territories;O-18
+Ipsidon;Corthenia;Mid Rim;K-7
+Idolia;Halthor;Outer Rim Territories;M-6
+Irff;Couronne;Expansion Region;P-10
+Iego;Ash Worlds;Outer Rim Territories;T-7
+Iridia;Glythe;Mid Rim;J-7
+Ifmix;;Colonies;M-9
+Iridium;Atrivis;Outer Rim Territories;L-5
+Iridonia;Glythe;Mid Rim;J-7
+Jaga's Cluster;Esstran;Outer Rim Territories;Q-5
+Irith;;Hutt Space;S-11
+Jagomir;Esstran;Outer Rim Territories;Q-5
+Irkalla;;Unknown Regions;G-13
+Jaguada;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Irmenu;Belsmuth;Outer Rim Territories;O-6
+Jahilid;;Wild Space;L-21
+Irudiru;Wyl;Outer Rim Territories;S-4
+Jakelia;Mandalore;Outer Rim Territories;O-7
+Iscera;Dalchon;Outer Rim Territories;R-17
+Jakku;;Inner Rim;I-13
+Iscno;;Core Worlds;K-12
+Jalarren;Senex;Mid Rim;L-18
+Isde Naha;Javin (Yarith);Outer Rim Territories;K-18
+Jalin;;Core Worlds;M-11
+Isen;D'Astan;Outer Rim Territories;N-5
+Jalindi;Gordian Reach;Outer Rim Territories;P-6
+Iseno;Iseno;Inner Rim;N-13
+Jaloria;Jalor;Mid Rim;J-7
+Ishanna;Circarpous;Expansion Region;O-12
+Jalucaz;Subterrel;Outer Rim Territories;L-20
+Ishbix;Agarix;Mid Rim;K-17
+Jaminere;Allied Tion;Outer Rim Territories;S-6
+Ishram Nebula;Seitia;Outer Rim Territories;J-20
+Jamiri;Myto;Outer Rim Territories;K-4
+Isht;;Core Worlds;L-13
+Jamiron;Chiss Space*;Unknown Regions;F-8
+Isiring;Cassander (Tendrannan);Outer Rim Territories;L-5
+Janako;;Inner Rim;N-11
+Iska;Iska;Mid Rim;K-17
+Janara;;Inner Rim;L-14
+Iskallon;;Wild Space;H-14
+Janaus;Thrasybule;Outer Rim Territories;P-6
+Iskalon;Trans-Nebular;Mid Rim;R-16
+Jandolhoon;Bosph;Outer Rim Territories;Q-3
+Iskin;Iskin;Mid Rim;O-16
+Jandoon;Corva;Outer Rim Territories;P-4
+Isobi;;Inner Rim;M-8
+Jandur;;Inner Rim;J-14
+Isolt;Sujimis;Outer Rim Territories;P-19
+JanFathal;Fath;Outer Rim Territories;K-6
+Ison;Javin (Anoat);Outer Rim Territories;K-18
+Jangelle;Kathol;Outer Rim Territories;M-21
+Issagra;Corporate Sector;Outer Rim Territories;S-4
+Janguine;Halthor;Outer Rim Territories;L-6
+Issor;Arkanis;Outer Rim Territories;R-17
+Janilis;Cronese Mandate;Outer Rim Territories;S-6
+Istic;Teraab;Mid Rim;Q-11
+Jankok;Bozhnee;Outer Rim Territories;L-18
+Italbos;Halori;Mid Rim;Q-7
+Janodral Mizar;Indrexu;Outer Rim Territories;S-5
+Itani;;Inner Rim;N-14
+Jante;Esaga;Mid Rim;Q-11
+Itani Nebula;;Inner Rim;N-14
+Japai;Yushan;Mid Rim;K-17
+Itapi Prime;;Core Worlds;L-9
+Japeal;Kanz;Outer Rim Territories;N-4
+Ithica;;Inner Rim;K-14
+Jappe;Tapani;Colonies;L-13
+Ithor;Ottega;Mid Rim;M-6
+Jarbanov;Serathrace;Expansion Region;P-11
+Ithori;Ado;Mid Rim;M-17
+Jardeen;Trans-Jardeen;Expansion Region;K-16
+Ithull;Airon;Inner Rim;O-10
+Jaresh;Corva;Outer Rim Territories;P-4
+Iti;Tammuz;Outer Rim Territories;T-14
+Jargridia;Sprizen;Outer Rim Territories;N-5
+Ivarujar;Vensensor;Expansion Region;K-16
+Jarnollen;Bright Jewel;Mid Rim;L-7
+Ivatch;Kathol;Outer Rim Territories;M-21
+Jarsatt;Hakartha;Expansion Region;L-16
+Ivera;;Core Worlds;L-12
+Jarvanam;Astal;Outer Rim Territories;P-17
+Ivexia;Tennuutta;Mid Rim;Q-7
+Jastro;;Core Worlds;M-10
+Ividal;Ividal;Mid Rim;P-14
+Jatir;;Colonies;L-9
+Ivis;;Inner Rim;N-10
+Javarica;Tynquay;Outer Rim Territories;Q-4
+Ixilix;Japrael;Inner Rim;O-9
+Javin;Javin;Outer Rim Territories;K-18
+Ixtlar;Ixtlar;Core Worlds;L-10
+Javis;Tapani;Colonies;L-13
+Ixzinia;Agarix;Mid Rim;K-17
+Jaxus;;Core Worlds;M-10
+Iyred;Kibilini;Outer Rim Territories;Q-17
+Jaymir;;Mid Rim;I-16
+Iyuta;Fakir;Colonies;K-9
+Jazbina;Lostar;Expansion Region;M-8
+J'doytzin;Maldrood;Mid Rim;R-7
+Jebble;Ojoster;Outer Rim Territories;N-7
+J't'p'tan;Farlax;Core Worlds;K-10
+Jedd;;Wild Space;I-14
+Ja-bess;Tragan Cluster;Outer Rim Territories;N-5
+Jedha;(Terrabe);Mid Rim;H-10
+Jaatovi;;Inner Rim;N-14
+Jekara;Bryx;Mid Rim;R-7
+Jabiim;Phelleem;Outer Rim Territories;S-7
+Jelucan;Kwymar;Outer Rim Territories;Q-4
+Jabone;Tennuutta;Mid Rim;Q-7
+Jendar;Nembus;Outer Rim Territories;P-4
+Jabor;Ado;Mid Rim;M-17
+Jendiria;Maldrood;Mid Rim;R-7
+Jaciprus;;Core Worlds;M-11
+Jendorn;Farstey;Expansion Region;O-8
+Jaelen;Irishi;Mid Rim;K-6
+Jenenma;;Inner Rim;M-13
+Jaemus;Obtrexta;Outer Rim Territories;K-4
+Jenoport;;Colonies;M-9
+Jafan;Chommell;Mid Rim;O-16
+Jentares;Mieru'kar;Outer Rim Territories;N-3
+Jeosyn;Weneen;Outer Rim Territories;N-6
+Junction;Thesme;Outer Rim Territories;O-5
+Jereth;Bozhnee;Outer Rim Territories;L-18
+Junkfort Station;Tharin;Outer Rim Territories;T-8
+Jerijador;Calaron;Outer Rim Territories;T-9
+Junobia;Keldrath;Outer Rim Territories;T-6
+Jermac;Portmoak;Outer Rim Territories;P-18
+Juntar;Emmo;Core Worlds;M-12
+Jerne;Kanz;Outer Rim Territories;N-4
+Jurio;Corva;Outer Rim Territories;P-4
+Jero;Teraab;Mid Rim;Q-11
+Jurzan;Jurzan;Expansion Region;M-15
+Jerrilek;;Deep Core;L-10
+Jurzuu;Suolriep;Outer Rim Territories;S-8
+Jerrist;Corporate Sector;Outer Rim Territories;S-4
+Jussafet;Weneen;Outer Rim Territories;N-6
+Jestan;Corpheli;Expansion Region;M-7
+Jutrand;Grumani;Outer Rim Territories;M-17
+Jevelet;;Core Worlds;K-10
+Juvex;Juvex;Mid Rim;L-18
+Jexeria;Tharin;Outer Rim Territories;T-8
+Juzzia;;Inner Rim;N-8
+Jeyell;Roche;Mid Rim;Q-8
+Jweab;Locris;Expansion Region;O-8
+Jhantoria;Allied Tion;Outer Rim Territories;S-6
+K'ath;Juvex;Mid Rim;L-18
+Jhensrus;Trax;Mid Rim;Q-10
+k'Farri;Hapes Cluster;Inner Rim;O-9
+Jhosh;Albarrio;Outer Rim Territories;K-5
+K'taktaxka;;Inner Rim;J-14
+Jiaan;Almak;Mid Rim;J-17
+Ka'Dedus;Tharin (Periphery);Outer Rim Territories;S-8
+Jidlor;Jidlor Marches;Mid Rim;J-16
+Kaa;;Colonies;N-10
+Jillsaaria;Minos Cluster;Outer Rim Territories;M-20
+Kaal;Yushan;Mid Rim;K-17
+Jilrua;;Hutt Space;R-12
+Kabaira;Bajic;Outer Rim Territories;P-17
+Jinda;Tapani;Colonies;L-13
+Kabal;Mayagil;Outer Rim Territories;N-18
+Jindau Station;;Inner Rim;L-15
+Kabieroun;Nijune;Outer Rim Territories;O-4
+Jinet;Brak;Expansion Region;O-14
+Kaboryth Cluster;Thaere;Expansion Region;O-14
+Jiran;Dantus;Outer Rim Territories;J-6
+Kabray;Corweillian;Mid Rim;P-15
+Jiroch;Yushan;Mid Rim;K-17
+Kadavo;;Wild Space;S-4
+Jiruus;Rolion;Outer Rim Territories;P-7
+Kaddak;Tammuz;Outer Rim Territories;T-14
+Jjannex;Jjannex;Outer Rim Territories;L-19
+Kaderin;Wazta;Outer Rim Territories;J-18
+Jmin;Masla;Mid Rim;J-16
+Kadril;Thanium;Outer Rim Territories;R-6
+Jocal;Ghost Nebula;Expansion Region;P-10
+Kaelen;;Inner Rim;M-9
+Jodaka;Hapes Cluster;Inner Rim;O-9
+Kaellin;Corbett;Mid Rim;I-17
+Jofoger;Tharin (Periphery);Outer Rim Territories;S-8
+Kafane;;Hutt Space;S-9
+Joh'Cire;Alui;Mid Rim;N-17
+Kaifo;;Colonies;N-11
+Johria;;Core Worlds;M-11
+Kaikielius;;Core Worlds;L-10
+Joiol;Orus;Inner Rim;M-8
+Kail;Corporate Sector;Outer Rim Territories;R-3
+Jolia;Eucer;Mid Rim;Q-7
+Kailion;Kailion;Expansion Region;O-13
+Jolynria;Atravis;Outer Rim Territories;L-20
+Kailor;;Core Worlds;L-10
+Jomark;Jospro;Outer Rim Territories;R-7
+Kaisa;Corva;Outer Rim Territories;P-3
+Jondora;Ojoster (Taris);Outer Rim Territories;N-7
+Kajim;Locris;Expansion Region;O-8
+Jonsior;;Core Worlds;L-10
+Kakra;;Wild Space;I-14
+Joodrudda;;Wild Space;S-4
+Kal'Shebbol;Kathol;Outer Rim Territories;M-21
+Joralla;Mektrun;Mid Rim;L-17
+Kalaan;Churnis;Mid Rim;J-7
+Joran Station;Rolion;Outer Rim Territories;P-7
+Kalab;Sluis;Outer Rim Territories;M-19
+Jorgan;D'Astan;Outer Rim Territories;O-5
+Kalandis;Pallis;Inner Rim;N-14
+Joruna;Farlax;Core Worlds;K-10
+Kalarassi;;Inner Rim;K-8
+Jostaar;Kibilini;Outer Rim Territories;Q-17
+Kalarba;Hevvrol;Mid Rim;P-15
+Jovan;Gordian Reach;Outer Rim Territories;P-6
+Kalastar;;Outer Rim Territories;I-20
+Jovaria;Hapes Cluster;Inner Rim;O-9
+Kaldar Trinary;Chopani;Outer Rim Territories;M-4
+Jubalene;Grumani;Outer Rim Territories;N-17
+Kalee;;Wild Space;J-4
+Jubilar;Jubilar;Outer Rim Territories;T-7
+Kalgo;Senex;Mid Rim;L-18
+Judakann;Torch Nebula;Outer Rim Territories;P-18
+Kalidorn;;Wild Space;O-20
+Juinkwy;;Inner Rim;J-8
+Kaliida Nebula;Juris;Outer Rim Territories;O-17
+Julio;Marcol;Inner Rim;L-8
+Kalinda;Vilonis;Mid Rim;O-16
+Julsujod;Tolonda;Outer Rim Territories;Q-17
+Kalishik;Gordian Reach;Outer Rim Territories;Q-6
+Juma;Dalchon;Outer Rim Territories;R-17
+Kaliska;Sombure;Mid Rim;K-17
+Jumeria;;Core Worlds;M-10
+Kalist;;Deep Core;K-12
+Jumus;Corellian;Core Worlds;M-11
+Kalki Nebula;Cassander (Tendrannan);Outer Rim Territories;L-5
+Junction;Vorc;Mid Rim;J-7
+Kalkovak;Bortele;Mid Rim;S-8
+Kalla;Corporate Sector;Outer Rim Territories;S-4
+Karvathia;Tokamac;Expansion Region;N-13
+Kallakea;Authala;Expansion Region;P-12
+Karvoss;Parmorak;Core Worlds;M-12
+Kaller;Cassander;Outer Rim Territories;K-5
+Kashir;Vardoss;Expansion Region;J-8
+Kallidah;Subterrel;Outer Rim Territories;L-20
+Kashoon;Colundra;Outer Rim Territories;S-5
+Kallistas;Parmel;Outer Rim Territories;O-18
+Kashyyyk;Mytaranor;Mid Rim;P-9
+Kaloom;Noonian;Outer Rim Territories;M-6
+Kasiol;Pelgrin;Outer Rim Territories;R-18
+Kalsunor;Esstran (Sith Worlds);Outer Rim Territories;R-4
+Kaski;Calaron;Outer Rim Territories;U-8
+Kalzeron;Bri'ahl;Outer Rim Territories;I-17
+Kaspas;Hevvrol;Mid Rim;O-15
+Kamar;;Wild Space;S-3
+Kassido;Juvex;Mid Rim;L-17
+Kamasto;Grumani;Outer Rim Territories;M-17
+Katalia;Thesme;Outer Rim Territories;O-5
+Kamdon;Calamari;Outer Rim Territories;U-7
+Katalla;Kastolar;Mid Rim;R-10
+Kamgeddon;Harron;Expansion Region;O-12
+Katanos;Xan;Mid Rim;Q-15
+Kamil;;Wild Space;J-6
+Katarr;Vensori;Mid Rim;O-8
+Kammia;;Wild Space;G-16
+Katchan;Kallea;Outer Rim Territories;K-20
+Kamori;;Core Worlds;M-11
+Kath;Dustig;Mid Rim;M-17
+Kamparas;Dolomar;Core Worlds;K-9
+Kathol;Kathol;Outer Rim Territories;M-21
+Kampe;;Deep Core;L-11
+Kathol Rift;Kathol;Outer Rim Territories;M-21
+Kamper;Tapani;Colonies;L-13
+Katraasii;Belsmuth;Outer Rim Territories;O-6
+Kamur;Senex;Mid Rim;L-18
+Kattada;;Colonies;M-10
+Kanaver;Tion Hegemony;Outer Rim Territories;S-5
+Kaump;Bruanii;Mid Rim;K-17
+Kankalo;Esuain;Mid Rim;P-7
+Kauron;Meram;Outer Rim Territories;O-4
+Kant;Bothan;Mid Rim;R-14
+Kavith;Corva;Outer Rim Territories;P-4
+Kanzi;;Colonies;N-12
+Kayri;;Expansion Region;I-15
+Kaon;Tion Hegemony;Outer Rim Territories;S-6
+Kayuk;Sepan;Expansion Region;P-13
+Kar'a'katok;;Core Worlds;K-9
+Kayven;;Inner Rim;M-14
+Kara-bin;Tharin;Outer Rim Territories;T-8
+Kazarak;Sertar (Mahrusha);Outer Rim Territories;S-5
+Karalle;Albanin;Outer Rim Territories;T-13
+Kazlin;Suolriep;Outer Rim Territories;S-8
+Karambola;Al'Nasrl;Outer Rim Territories;T-13
+Kebolar;Lahara;Outer Rim Territories;M-5
+Karatha;Tregillis;Expansion Region;L-15
+Kebro;Bormea;Core Worlds;L-9
+Karavis;Obtrexta;Outer Rim Territories;K-4
+Kedorzha;Senex;Mid Rim;L-18
+Karaxis;;Wild Space;I-7
+Kedra;;Inner Rim;L-14
+Karazak;Sujimis;Outer Rim Territories;P-19
+Keeara Major;Koros;Deep Core;K-10
+Kardava;Sevastol;Mid Rim;P-14
+Keedad;Auril;Outer Rim Territories;R-7
+Kardoa;Atrivis;Outer Rim Territories;L-5
+Kegan;Calaron;Outer Rim Territories;T-9
+Kardura;Juvex;Mid Rim;L-17
+Keitum;Ariarch;Mid Rim;J-6
+Kareas;Prefsbelt;Outer Rim Territories;K-6
+Kejim;Sertar;Outer Rim Territories;R-5
+Karee;Nuon e Safyd;Expansion Region;P-12
+Kelada;Duluur;Colonies;M-13
+Karfeddion;Senex;Mid Rim;L-18
+Kelarea;Tynna;Expansion Region;N-14
+Karga;Dustig;Mid Rim;N-16
+Keldimar;Tharin;Outer Rim Territories;S-7
+Karideph;Minos Cluster;Outer Rim Territories;M-20
+Keldooine;;Hutt Space;R-10
+Kariek;;Wild Space;I-6
+Keller's Void;;Inner Rim;L-15
+Karinda;Wazta;Outer Rim Territories;J-18
+Kellgar;Mieru'kar;Outer Rim Territories;O-3
+Karka;Clacis;Outer Rim Territories;K-4
+Kellis;Terr'skiar;Mid Rim;P-10
+Karkaris;Nilgaard;Outer Rim Territories;S-5
+Kellux;Seitia;Outer Rim Territories;J-20
+Karken;;Inner Rim;L-8
+Kelrodo-Ai;Steniplis;Outer Rim Territories;L-18
+Karlinus;Chommell;Mid Rim;O-16
+Keltos;Irnaj;Mid Rim;K-17
+Karltonia;;Core Worlds;K-13
+Keltria;;Core Worlds;L-9
+Karnac;Cadma;Outer Rim Territories;T-8
+Kem Stor Ai;Tennuutta;Mid Rim;Q-7
+Karnak Alpha;;Core Worlds;M-10
+Kemal Station;Arkanis;Outer Rim Territories;R-16
+Karnst;Tharin (Karstaxon);Outer Rim Territories;S-8
+Kemix;Yminis;Outer Rim Territories;S-14
+Karoon;Shadola;Outer Rim Territories;U-8
+Kemla;Dantus;Outer Rim Territories;K-6
+Karra;Rayter;Outer Rim Territories;J-19
+Kenari;Perkell;Mid Rim;Q-7
+Karsten's World;Gordian Reach;Outer Rim Territories;Q-6
+Kendamar;Lol;Outer Rim Territories;Q-18
+Karthon;Zuma (Sugai);Outer Rim Territories;H-16
+Kennerla;Minos Cluster;Outer Rim Territories;M-20
+Karthrexia;Kriz;Outer Rim Territories;K-19
+Kenosha;Tynna;Expansion Region;N-14
+Kartoosh;Narrant;Mid Rim;I-16
+Keptik;Carrion;Outer Rim Territories;J-4
+Keral;Corellian;Core Worlds;M-11
+Kiffex;Kiffu;Inner Rim;L-14
+Kerensik;Botor Enclave;Core Worlds;K-12
+Kiilimaar;Svivreni;Outer Rim Territories;O-19
+Keresia;Demetras;Outer Rim Territories;P-7
+Kijimi;Bryx;Mid Rim;R-8
+Kerest;Sluis;Outer Rim Territories;M-19
+Kile;Jospro;Outer Rim Territories;S-7
+Kerev Doi;Circarpous;Expansion Region;O-12
+Kilia;;Wild Space;I-8
+Kergans;;Inner Rim;M-14
+Kiliea;Atrisian CW;Core Worlds;J-12
+Kerig'En;Brema;Outer Rim Territories;M-17
+Killaniri;Wornal;Mid Rim;K-17
+Kerkoidia;Kira;Expansion Region;N-15
+Killisu;Ado;Mid Rim;M-17
+Keros;Thrasybule;Outer Rim Territories;P-6
+Killof;Cegul;Outer Rim Territories;L-20
+Kerroc;Sarin;Outer Rim Territories;O-18
+Killun Station;Pakuuni;Outer Rim Territories;T-6
+Kes;;Core Worlds;L-9
+Kilmauls;Vorzyd;Outer Rim Territories;R-6
+Kesh;;Wild Space;U-10
+Kilner;Cor'ric;Outer Rim Territories;P-18
+Keshi;Bheriz;Outer Rim Territories;U-10
+Kilotowa;Corbett;Mid Rim;I-17
+Keskin;Koradin;Outer Rim Territories;J-18
+Kilstra;Jidlor Marches;Mid Rim;I-16
+Kesmere;Raioballo;Outer Rim Territories;L-4
+Kimanan;Orus;Inner Rim;M-8
+Kesmere Minor;Raioballo;Outer Rim Territories;L-4
+Kimm Aurek;Juvex;Mid Rim;L-18
+Kessar;Grumani;Outer Rim Territories;N-17
+Kimm Besh;Juvex;Mid Rim;L-18
+Kessel;Kessel;Outer Rim Territories;T-10
+Kimm Cresh;Juvex;Mid Rim;L-18
+Kessur;Dimean;Expansion Region;P-13
+Kindlabethia;Braxant;Outer Rim Territories;J-3
+Kestavel;;Colonies;K-9
+Kindosorn;Lol;Outer Rim Territories;Q-18
+Kestel;Mortex;Outer Rim Territories;R-5
+King's Galquek;Meridian;Outer Rim Territories;R-7
+Kestos Minor;Kwymar;Outer Rim Territories;Q-4
+Kinooine;;Wild Space;J-21
+Ket;Hapes Cluster;Inner Rim;O-9
+Kinoss;Chiss Space*;Unknown Regions;E-8
+Ketal;;Inner Rim;L-14
+Kinrah;Onatos;Mid Rim;R-15
+Ketaris;Oplovis;Outer Rim Territories;L-5
+Kintan;;Hutt Space;S-9
+Keteeria;Venaarian;Mid Rim;O-7
+Kintarr;;Colonies;L-13
+Kethmandi;Hangshan;Expansion Region;P-11
+Kintoni;Ash Worlds;Outer Rim Territories;S-6
+Ketz;;Colonies;K-13
+Kinun Depot;Pelgrin;Outer Rim Territories;R-18
+Ketzali;Lannik Wilds;Mid Rim;R-13
+Kinyen;Bes Ber Bikade;Expansion Region;L-15
+Kevan;Jalor;Mid Rim;J-7
+Kip;Chorlian;Outer Rim Territories;S-4
+Kexeeria;;Colonies;M-12
+Kir;Corporate Sector;Outer Rim Territories;S-3
+Keyorin;Belderone;Outer Rim Territories;R-6
+Kira;Kira;Expansion Region;N-16
+Khadaji Singularity;Corridan;Core Worlds;J-10
+Kirdo;Tamarin;Outer Rim Territories;N-19
+Khar Delba;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Kiribi;;Colonies;L-9
+Kharmort's Miasma;;Unknown Regions;H-9
+Kirima;Elbaran;Mid Rim;J-17
+Kharzet;Mortex;Outer Rim Territories;R-4
+Kirkeide Station;Ojoster;Outer Rim Territories;N-7
+Kheedar;Khuiumin;Outer Rim Territories;O-18
+Kirna;;Colonies;N-10
+Khemerion;Belasco;Expansion Region;P-11
+Kiros;Ehosiq;Expansion Region;L-8
+Kho Nai;Kalamith;Outer Rim Territories;P-5
+Kirtania;Nembus;Outer Rim Territories;P-4
+Khoan;Phelleem;Outer Rim Territories;S-7
+Kirtarkin;Javin (Anoat);Outer Rim Territories;K-18
+Khofar;Lahara;Outer Rim Territories;M-5
+Kishpaugh;Iskin;Mid Rim;O-16
+Kholes;Elbaran;Mid Rim;J-17
+Kismaano;Cronese Mandate;Outer Rim Territories;S-6
+Khomm;;Deep Core;L-12
+Kiszo;Lol;Outer Rim Territories;Q-18
+Khomr;Corellian;Core Worlds;M-11
+Kitaros Nebula;Prefsbelt;Outer Rim Territories;K-5
+Khonji;Prefsbelt;Outer Rim Territories;J-5
+Kitel Phard;Atrisian CW;Core Worlds;J-12
+Khorm;Halori;Mid Rim;P-8
+Kiva;Venaarian;Mid Rim;O-7
+Khorya;;Hutt Space;S-9
+Kizan;;Inner Rim;N-8
+Khramboa;;Core Worlds;M-9
+Kktkt;Farlax;Core Worlds;K-10
+Khubeaie;Arkanis;Outer Rim Territories;R-17
+Klaatu;Airam;Outer Rim Territories;L-20
+Khuiumin;Khuiumin;Outer Rim Territories;O-18
+Klasse Ephemora;;Unknown Regions;F-9
+Khuteb;Thanium;Outer Rim Territories;S-5
+Klathos;Chorlian;Outer Rim Territories;S-4
+Kiamurr;Likasha;Mid Rim;Q-15
+Klatooine;;Hutt Space;S-9
+Kidiet Olgo;;Core Worlds;L-9
+Klaymor;Druess;Mid Rim;O-15
+Kidir;Kuat;Core Worlds;M-10
+Kleeva;;Hutt Space;R-11
+Kidriff;Lostar;Expansion Region;M-8
+Klepthia;Tynna;Expansion Region;N-14
+Kidron;Elrood;Outer Rim Territories;M-20
+Kler'terria;;Core Worlds;K-12
+Kli'aar;Gordian Reach;Outer Rim Territories;P-5
+Kor Nasirii;;Hutt Space;S-10
+Klonoid;Phelleem;Outer Rim Territories;S-7
+Kor Nijiladii;;Hutt Space;S-10
+Kloodavia;;Core Worlds;K-13
+Kor Oktanivii;;Hutt Space;S-11
+Kloper;;Inner Rim;N-9
+Kor Qunaalac;;Hutt Space;S-11
+Kluistar;;Colonies;M-8
+Kor Trinivii;;Hutt Space;S-11
+Klynan;Klina;Outer Rim Territories;S-13
+Kor Usilic;;Hutt Space;S-11
+Klytonia;Bheriz;Outer Rim Territories;U-11
+Kor Utoradii;;Hutt Space;S-11
+Klytus;;Wild Space;H-15
+Kor Vanderijar;;Hutt Space;S-11
+Knolstee;Corporate Sector;Outer Rim Territories;R-3
+Kor Vosadii;;Hutt Space;S-10
+Knooda;Askarian;Expansion Region;O-12
+Kor-Lahvan;Corosi;Outer Rim Territories;N-6
+Knores;Senex;Mid Rim;L-17
+Korad;Elrood;Outer Rim Territories;M-19
+Knot Holes;Hapes Cluster;Inner Rim;O-9
+Korbin;;Inner Rim;J-14
+Ko-Longava;Hocatar;Expansion Region;P-12
+Korbori;;Colonies;N-12
+Koaan;;Inner Rim;N-8
+Korda;;Inner Rim;O-8
+Koba;Narrant;Mid Rim;J-16
+Kordoku;Terr'skiar;Mid Rim;P-10
+Kobal's World;Koradin;Outer Rim Territories;I-18
+Kordu;Kordu;Mid Rim;L-7
+Kobaria;Emmo;Core Worlds;M-12
+Korev;Zaric;Inner Rim;N-9
+Kobbahn;Dantus;Outer Rim Territories;J-6
+Korfanus;;Core Worlds;L-10
+Koboh;Varada;Outer Rim Territories;H-19
+Korfo;;Core Worlds;M-9
+Koboth;;Outer Rim Territories;R-3
+Korlings;Kwymar;Outer Rim Territories;P-4
+Koda Space Station;Wazta;Outer Rim Territories;I-18
+Kormoran;Wyl;Outer Rim Territories;R-4
+Kodai;Belderone;Outer Rim Territories;R-6
+Korphir;Gordian Reach;Outer Rim Territories;Q-6
+Koensayr;;Colonies;N-12
+Korrilan;Daalang;Mid Rim;Q-12
+Kogan;Veragi;Outer Rim Territories;L-3
+Korriz;Esstran (Sith Worlds);Outer Rim Territories;R-4
+Koiogra;Grohl;Outer Rim Territories;R-16
+Korrus;Clacis;Outer Rim Territories;K-4
+Kojash;Farlax;Core Worlds;K-10
+Korseg;Grohl;Outer Rim Territories;R-16
+Kokash;Kokash;Core Worlds;J-10
+Kortatka;Croynar;Inner Rim;M-14
+Koke Frost;;Wild Space;H-7
+Korteen;Kibilini;Outer Rim Territories;Q-17
+Kol Atorn;Kanz;Outer Rim Territories;N-4
+Koru Neimoidia;Quellor;Colonies;N-11
+Kol Huro;Kanz;Outer Rim Territories;N-4
+Korvaii;Kordu;Mid Rim;L-7
+Kol Iben;Arkanis;Outer Rim Territories;R-16
+Koshaga;;Wild Space;I-7
+Kolaador;Dalchon;Outer Rim Territories;R-17
+Koshi;Sevastol;Mid Rim;Q-14
+Kolanda Station;Yminis;Outer Rim Territories;S-14
+Kossa Prime;Kossa (Kossa Prime);Expansion Region;O-11
+Kolatill;Kathol;Outer Rim Territories;M-21
+Kostra;Romintine;Mid Rim;Q-8
+Koler;;Deep Core;L-12
+Kotab;;Inner Rim;N-10
+Kolkur;Indrexu;Outer Rim Territories;S-5
+Kothlis;Bothan;Mid Rim;R-14
+Kolos;Paqwepori;Mid Rim;P-15
+Kovor;Koradin;Outer Rim Territories;I-18
+Koltine;;Wild Space;L-21
+Kowak;Sevetta;Outer Rim Territories;S-16
+Komnor;Suolriep;Outer Rim Territories;S-8
+Kragis;Citlik;Expansion Region;O-15
+Kondoraan;Saijo;Outer Rim Territories;K-20
+Krake's Planet;Demetras;Outer Rim Territories;P-7
+Konkiv;Cadma;Outer Rim Territories;T-8
+Kral'to;Demetras;Outer Rim Territories;O-7
+Konos;;Colonies;N-10
+Krann;Brevost;Expansion Region;O-15
+Kooda;Herglic Space;Colonies;K-13
+Krant;Bothan;Mid Rim;R-14
+Koolach;;Inner Rim;O-10
+Kravos;Gordian Reach;Outer Rim Territories;P-6
+Kooriva;;Inner Rim;M-14
+Krayiss;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Koovis;;Inner Rim;L-8
+Kreeling;Chommell;Mid Rim;O-16
+Koozebane;Calaron;Outer Rim Territories;T-9
+Krenhner;Krenhner;Inner Rim;L-14
+Kor Anjiliac;;Hutt Space;S-11
+Krevas;Antemeridian;Outer Rim Territories;R-7
+Kor Bareesh;;Hutt Space;S-11
+Kriekaal;;Wild Space;J-14
+Kor Besadii;;Hutt Space;S-10
+Kril'Dor;Outer Jalor;Mid Rim;I-7
+Kor Desilijic;;Hutt Space;S-11
+Krinemonen;Calamari;Outer Rim Territories;U-6
+Kor Gejalli;;Hutt Space;S-11
+Krintrino;;Colonies;M-10
+Kor Gorensla;;Hutt Space;S-10
+Kriselist;Wornal;Mid Rim;K-16
+Kor Hestilic;;Hutt Space;S-10
+Krmar;Tolonda;Outer Rim Territories;R-17
+Kor Hunamma;;Hutt Space;S-11
+Krnay;Vilonis;Mid Rim;O-16
+Kor Jiramma;;Hutt Space;S-11
+Kro Var;;Unknown Regions;H-8
+Kroctar;Shataum;Inner Rim;N-7
+Ladarra;Gordian Reach;Outer Rim Territories;P-5
+Kromus;Esuain;Mid Rim;P-7
+Ladro;;Colonies;J-13
+Kronk;Auril;Outer Rim Territories;R-6
+Laecor;Kallea;Outer Rim Territories;K-21
+Krownest;Mandalore;Outer Rim Territories;O-7
+Laerdocia;Dalonbian;Outer Rim Territories;L-3
+Krozurbia;Shadola;Outer Rim Territories;U-8
+Laertos;;Inner Rim;L-14
+Krugan;;Inner Rim;K-15
+Lafete;Tunka;Outer Rim Territories;I-18
+Kruskan;Colundra;Outer Rim Territories;S-5
+Lafra;Wyl;Outer Rim Territories;R-4
+Kryger;Ado;Mid Rim;M-17
+Lah'mu;Raioballo;Outer Rim Territories;L-3
+Krykas;Spirva;Mid Rim;L-16
+Lahag Erli;Cantons of Lahag;Expansion Region;J-15
+Krykis;Duluur;Colonies;M-13
+Lahn;Noonian;Outer Rim Territories;M-6
+Krylon;Gordian Reach;Outer Rim Territories;P-5
+Lahsbane;Onatos;Mid Rim;R-15
+Krystar;Manda;Mid Rim;R-14
+Laim;Rayter;Outer Rim Territories;J-19
+Ksiczzic;Yucrales;Mid Rim;Q-15
+Lakra;;Wild Space;I-6
+Ktath'atn;Chopani;Outer Rim Territories;M-4
+Lali;;Core Worlds;L-13
+Ktil;Ktilac Regions;Inner Rim;N-9
+Lalmy'ash;Hapes Cluster;Inner Rim;O-9
+Kuar;Koros;Deep Core;K-10
+Laman;;Colonies;L-13
+Kuat;Kuat;Core Worlds;M-10
+Lamaredd;;Wild Space;S-18
+Kubindi;Calaron;Outer Rim Territories;T-9
+Lambaria;;Colonies;M-13
+Kudo;Corvair;Inner Rim;K-14
+Lamman;;Core Worlds;M-11
+Kuliquo;;Inner Rim;L-14
+Lamuir;Tapani;Colonies;L-13
+Kullgroon;Authala;Expansion Region;P-12
+Lamus;Sertar;Outer Rim Territories;R-5
+Kumru;Javin;Outer Rim Territories;K-18
+Lan Barell;Hook Nebula;Outer Rim Territories;O-18
+Kuna's Eye;Zuma (Moddell);Outer Rim Territories;H-16
+Landor;Thesme;Outer Rim Territories;O-6
+Kuna's Fist;Zuma (Moddell);Outer Rim Territories;H-16
+Langhesa;Meram;Outer Rim Territories;P-4
+Kuna's Horn;Zuma (Moddell);Outer Rim Territories;H-16
+Langoona;;Hutt Space;S-10
+Kuna's Tail;Zuma (Moddell);Outer Rim Territories;H-16
+Langsha-Raang;Tamarin;Outer Rim Territories;N-18
+Kuna's Tooth;Zuma (Moddell);Outer Rim Territories;H-16
+Langston;Kira;Expansion Region;N-15
+Kundu Minor;Steniplis;Outer Rim Territories;M-19
+Lanjer;Rseik;Outer Rim Territories;N-19
+Kupoh;Dohlbani;Mid Rim;R-13
+Lankashiir;;Colonies;N-11
+Kur Minor;;Wild Space;I-8
+Lannik;Lannik Space;Mid Rim;R-13
+Kur Nebula;Elrood;Outer Rim Territories;M-20
+Lanos;Tandon;Mid Rim;Q-14
+Kuras;Elrood;Outer Rim Territories;M-19
+Lansend;;Inner Rim;N-12
+Kuratooine;;Wild Space;J-5
+Lansono;;Core Worlds;L-12
+Kuratow;Brevost;Expansion Region;O-15
+Lant;Tharin (Periphery);Outer Rim Territories;S-8
+Kurdavvia;;Core Worlds;M-11
+Lanteeb;Bri'ahl;Outer Rim Territories;I-17
+Kurluvion;Weneen;Outer Rim Territories;N-6
+Lanthe;Var Hagen;Mid Rim;M-16
+Kurost;Kurost;Mid Rim;Q-11
+Lanthrym;Elrood;Outer Rim Territories;M-20
+Kursid;Esstran (Sith Worlds);Outer Rim Territories;Q-5
+Lantillies;Lantillian;Mid Rim;P-8
+Kushibah;Gordian Reach;Outer Rim Territories;P-5
+Lanz Carpo;;Core Worlds;M-11
+Kutag;Farlax;Core Worlds;K-10
+Lapez;Esstran;Outer Rim Territories;Q-5
+Kuthic;Tharin;Outer Rim Territories;S-8
+Laramus;Parmic;Outer Rim Territories;P-18
+Kvabja;Uoti;Core Worlds;K-9
+Laria;Rseik;Outer Rim Territories;N-19
+Kwannot;Alderath;Mid Rim;L-6
+Las Lagon;;Inner Rim;M-13
+Kwapi;;Wild Space;R-3
+Lasan;;Wild Space;P-20
+Kwenn;Kastolar;Mid Rim;R-10
+Lastelle;Tapani;Colonies;L-13
+Kwevron;Clacis;Outer Rim Territories;K-4
+Lasten;;Core Worlds;L-13
+Kwookrrr;Mytaranor;Mid Rim;P-9
+Lateron;Talcene;Mid Rim;Q-8
+KyLessia;Bes Ber Bikade;Expansion Region;L-15
+Latoma;Brak;Expansion Region;O-14
+Kynachi;;Wild Space;J-5
+Latza;Spirva;Mid Rim;K-17
+Kyoloria;Xappyh;Outer Rim Territories;Q-3
+Lau;Meerian;Outer Rim Territories;O-6
+Kyrouac;;Inner Rim;K-14
+Laud;Brak;Expansion Region;O-14
+Kyrska;Hevvrol;Mid Rim;P-15
+Lavisar;Strabin;Mid Rim;M-7
+Kyryll's World;Phelleem;Outer Rim Territories;S-7
+Lazerian;Kira;Expansion Region;N-15
+Laakonis;Glythe;Mid Rim;J-7
+Leafar;Greater Plooriod;Expansion Region;M-7
+Laakteen Depot;;Colonies;L-13
+Lechra;Lixal;Inner Rim;M-14
+Laboi;Suolriep;Outer Rim Territories;S-8
+Ledalau;;Core Worlds;L-12
+Ledeve;;Expansion Region;I-7
+Little Capella;Gordian Reach;Outer Rim Territories;Q-6
+Lekua;Centrality;Outer Rim Territories;T-8
+Little Kessel;Kessel;Outer Rim Territories;T-10
+Lelmra;Churba;Mid Rim;P-14
+Little Petrovi;Yushan;Mid Rim;K-17
+Lemmi;Hapes Cluster;Inner Rim;O-9
+Little Talhovi;Juvex;Mid Rim;K-18
+Lenahra;Velcar;Outer Rim Territories;J-5
+Liul;Demetras;Outer Rim Territories;P-7
+Lengil;Bes Ber Bikade;Expansion Region;L-15
+Livien;Tion Hegemony;Outer Rim Territories;S-5
+Lenico;Cademimu;Outer Rim Territories;L-6
+Livno;;Wild Space;J-21
+Lenniera;;Core Worlds;M-10
+Livorno;Belderone;Outer Rim Territories;R-6
+Lenthalis;Spirva;Mid Rim;L-17
+Llanic;Karthakk;Outer Rim Territories;Q-16
+Leonit;Cyrillian Protectorate;Expansion Region;O-12
+Llewebum;Rolion;Outer Rim Territories;Q-7
+Leoxo;Rayter;Outer Rim Territories;J-19
+Llon Nebulae;Itopol;Expansion Region;K-15
+Lequabis;;Expansion Region;I-14
+Llorkan;;Inner Rim;N-10
+Lerct;Prackla;Expansion Region;O-8
+Lo'Uran;Aparo;Outer Rim Territories;R-3
+Leresen;Lannik Wilds;Mid Rim;R-13
+Loac;Hocatar;Expansion Region;P-12
+Leria Kerlsil;;Core Worlds;M-10
+Lobaoc;Mieru'kar;Outer Rim Territories;N-3
+Leritor;Yucrales;Mid Rim;Q-15
+Lobaq Station;Rolion;Outer Rim Territories;Q-7
+Lespectus;;Core Worlds;M-10
+Loce;;Wild Space;S-4
+Lessa;Mytaranor;Mid Rim;P-9
+Lockest;Palamut;Expansion Region;N-13
+Lesser Sloo Gas Cloud;Sloo;Mid Rim;P-14
+Loedorvia;Weemell;Core Worlds;K-12
+Lesser Tontakoh;Klina;Outer Rim Territories;S-13
+Lofquar;Chommell;Mid Rim;O-17
+Lessuris;Pelgrin;Outer Rim Territories;R-17
+Logal Ri;Chaama;Mid Rim;J-7
+Lesu;Dail;Outer Rim Territories;Q-18
+Lohopa;Boeus;Expansion Region;M-15
+Letaki;Steniplis;Outer Rim Territories;L-19
+Loit;Cegul;Outer Rim Territories;M-20
+Letev;Tapani;Colonies;L-13
+Loj;;Colonies;M-9
+Lettow;;Core Worlds;M-11
+Loken;Bryx;Mid Rim;R-7
+Levian;;Inner Rim;N-8
+Lokondo;Braxant;Outer Rim Territories;J-3
+Lew'el;;Wild Space;J-3
+Lokori;Karthakk;Outer Rim Territories;Q-16
+Lexas Prime;Kessel;Outer Rim Territories;U-10
+Lokud;Chopani;Outer Rim Territories;L-3
+Lexrul;Trax;Mid Rim;Q-10
+Lol;Lol;Outer Rim Territories;Q-18
+Lexus;Thrasybule;Outer Rim Territories;P-6
+Lola Sayu;Belderone;Outer Rim Territories;R-6
+Leyaki;Tregillis;Expansion Region;M-15
+Lolet;Haserian;Mid Rim;Q-14
+Leyoye;Elochar;Mid Rim;R-9
+Loletia;Ojoster;Outer Rim Territories;N-7
+LFA-509;Thaere;Expansion Region;P-14
+Lolnar;;Core Worlds;M-11
+Lhosa;;Inner Rim;N-8
+Lomabu;Aida;Mid Rim;Q-13
+Li-Toran;;Inner Rim;M-13
+Lonania;Kossa;Expansion Region;O-11
+Lialic;;Deep Core;K-12
+Lonatro;Veragi (Gree Enclave);Outer Rim Territories;L-3
+Lianna;Allied Tion;Outer Rim Territories;S-6
+Londor;Londori;Mid Rim;J-7
+Liaq;;Core Worlds;M-11
+Lonera;;Inner Rim;O-12
+Licha In;Veragi (Gree Enclave);Outer Rim Territories;L-2
+Long Shadow;Kallea;Outer Rim Territories;K-21
+Ligna;Corva;Outer Rim Territories;P-4
+Longwind;Trax;Mid Rim;Q-10
+Liinade;Ciutric;Outer Rim Territories;N-5
+Lonjair Prime;Danjar;Outer Rim Territories;M-19
+Liintaar;Gaulus;Outer Rim Territories;R-17
+Lonnaw;Droma;Mid Rim;K-6
+Likasha;Likasha;Mid Rim;Q-14
+Lontar;;Colonies;J-9
+Linasals;Mikaster;Expansion Region;N-15
+Loovria;Juvex;Mid Rim;L-18
+Linuri;Doldur;Mid Rim;P-15
+Loped;;Inner Rim;O-9
+Lioaoi;Lioaoin Space*;Unknown Regions;E-7
+Lopor Station;Spirva;Mid Rim;K-17
+Liok;Ciutric;Outer Rim Territories;N-5
+Loposi;Dustig;Mid Rim;M-17
+Lipsec;Koradin;Outer Rim Territories;I-18
+Lorahns;Sloo;Mid Rim;P-14
+Lira San;;Wild Space;O-20
+Lorahns Cavity;Sloo;Mid Rim;P-14
+Lirra;Baxel;Outer Rim Territories;U-12
+Lorardia;D'Astan;Outer Rim Territories;O-6
+Lisal;Sarka;Mid Rim;Q-8
+Lorattick Nebula;Esstran;Outer Rim Territories;Q-5
+Liskan;Ojoster;Outer Rim Territories;N-7
+Loratus;Sanbra;Outer Rim Territories;O-17
+Lissam;Rayter;Outer Rim Territories;J-18
+Lorell;;Inner Rim;O-9
+Listehol;Kwymar;Outer Rim Territories;Q-4
+Lorenz;Tapani;Colonies;L-13
+Listoria;Tapani;Colonies;L-13
+Loreth;Saijo;Outer Rim Territories;K-20
+Little Atullus;Anthos;Inner Rim;N-8
+Loretto;;Core Worlds;M-11
+Lorimax;Fakir;Colonies;K-9
+Lythia;Suolriep;Outer Rim Territories;S-8
+Lorista;Glythe;Mid Rim;J-7
+Lythos;Corporate Sector;Outer Rim Territories;S-3
+Lorn;Dalchon;Outer Rim Territories;R-17
+M'Bardi;Kalamith;Outer Rim Territories;P-5
+Loronar;;Colonies;M-12
+M'dweshuu Nova;;Hutt Space;S-9
+Lorpfan;Tynquay;Outer Rim Territories;R-4
+M'haeli;Majoor;Expansion Region;N-15
+Lorrad;Allied Tion;Outer Rim Territories;S-6
+M'Hanna;;Hutt Space;T-11
+Lorrd;Kanz;Outer Rim Territories;N-4
+M132L4;;Inner Rim;K-8
+Lorta;Gendius;Mid Rim;J-17
+M2934738;Tragan Cluster;Outer Rim Territories;N-5
+Lost Clusters;;Wild Space;I-20
+M4-78;;Inner Rim;O-9
+Lost Murvey;;Wild Space;H-6
+Ma'alkerr;Rago;Mid Rim;I-7
+Lost Souls;Cademimu;Outer Rim Territories;L-6
+Ma'ar Shaddam;Rseik;Outer Rim Territories;N-20
+Lota;Brak;Expansion Region;O-14
+Maarka;Perkell;Mid Rim;Q-7
+Loth;;Inner Rim;J-8
+Maateen;;Inner Rim;O-10
+Lothal;Lothal;Outer Rim Territories;U-7
+Maccent;Phelleem;Outer Rim Territories;S-7
+Lotho Minor;Wazta;Outer Rim Territories;I-17
+Mackar;Hewett;Mid Rim;M-6
+Lotide;Mortex;Outer Rim Territories;S-5
+Madurs;Maldrood;Mid Rim;R-7
+Lovetus;;Core Worlds;L-9
+Maelstrom Nebula;Relgim;Outer Rim Territories;K-5
+Lovola;Hapes Cluster;Inner Rim;O-9
+Maerdocia;Maerdocian;Mid Rim;Q-13
+Low'n;Romintine;Mid Rim;Q-8
+Magagran;Halthor;Outer Rim Territories;L-6
+Lower Flora Cloud;;Inner Rim;I-14
+Magar's World;Stensen;Outer Rim Territories;H-17
+Lowick;Calaron;Outer Rim Territories;U-9
+Magataran Maelstrom;;Inner Rim;N-7
+Lowik;Cadavine;Outer Rim Territories;P-17
+Magaveene;Prefsbelt;Outer Rim Territories;K-6
+Lozash;Bes Ber Bikade;Expansion Region;L-15
+Magmar;;Core Worlds;M-10
+Lubang Minor;Illisurevimurasi;Outer Rim Territories;Q-4
+Magna;;Wild Space;G-14
+Lucazec;Nuiri;Outer Rim Territories;Q-6
+Magnus Horn;Talcene;Mid Rim;Q-8
+Lucrenn;Skine;Outer Rim Territories;Q-19
+Magravia;Karthakk;Outer Rim Territories;Q-17
+Lucrusia;Seswenna;Outer Rim Territories;M-18
+Maher;;Unknown Regions;G-7
+Luduria;;Colonies;M-12
+Mahranee;Taldot;Mid Rim;P-8
+Luj;Tamarin;Outer Rim Territories;N-19
+Maicombe;Corthenia;Mid Rim;K-7
+Lujo;;Core Worlds;L-12
+Maill;Cadavine;Outer Rim Territories;P-17
+Luminous Magnificence;;Wild Space;H-14
+Mairenhelm;Dona Laza;Expansion Region;P-9
+Lupal;;Wild Space;G-20
+Maires;Hapes Cluster;Inner Rim;O-9
+Lupani;Tapani;Colonies;L-13
+Mairne;Kathol;Outer Rim Territories;M-21
+Luprora;;Unknown Regions;G-7
+Majilop;Lol;Outer Rim Territories;Q-18
+Luptoom;Seswenna;Outer Rim Territories;M-18
+Majoor;Majoor;Expansion Region;N-15
+Lur;Aparo;Outer Rim Territories;R-4
+Majoros;;Inner Rim;O-8
+Lurania;;Colonies;N-10
+Makeb;Aida;Mid Rim;Q-13
+Luristan;;Inner Rim;M-14
+Makem Te;Nilgaard;Outer Rim Territories;S-5
+Lurr;Rayter;Outer Rim Territories;J-19
+Makksre;Uoti;Core Worlds;K-9
+Lusaanda;Meram;Outer Rim Territories;O-4
+Mako-Ta;Noonian;Outer Rim Territories;M-6
+Lusdu;Alderaan;Core Worlds;M-10
+Makthierse;Cegul;Outer Rim Territories;L-20
+Lusk;Tapani;Colonies;L-13
+Malachor;Chorlian;Outer Rim Territories;S-4
+Lust;;Wild Space;J-20
+Maladi;Maladi;Expansion Region;O-12
+Lutrillia;Javin (Yarith);Outer Rim Territories;J-18
+Malador;Juvex;Mid Rim;L-17
+Luudria;Dalchon;Outer Rim Territories;R-17
+Malaga Cluster;Steniplis;Outer Rim Territories;L-19
+Luuhar;Hapes Cluster;Inner Rim;O-9
+Malagarr;;Wild Space;V-8
+Luuq;Luuq;Mid Rim;L-7
+Malano;;Colonies;N-10
+Luxiar;Bon'nyuw-Luq;Outer Rim Territories;N-18
+Malanose;Veragi (Gree Enclave);Outer Rim Territories;K-2
+Luzalite;;Core Worlds;L-9
+Malari;Churnis;Mid Rim;I-6
+Lwhekk;Ssi-ruuvi Space*;Unknown Regions;C-16
+Malastare;Dustig;Mid Rim;N-16
+Lybeya;Bajic;Outer Rim Territories;P-18
+Malathon;Ghost Nebula;Expansion Region;P-10
+Lyjdaa;Kwymar;Outer Rim Territories;Q-4
+Maldo Kreis;Arkanis;Outer Rim Territories;R-16
+Lynos;Mortex;Outer Rim Territories;R-4
+Maldovea;Brema;Outer Rim Territories;M-17
+Lynx;Tapani;Colonies;L-13
+Maldra;Shadola;Outer Rim Territories;U-8
+Lyran;Quiberon;Outer Rim Territories;S-15
+Maldroth;Grumani;Outer Rim Territories;N-17
+Lysatra;;Wild Space;I-8
+Maleinator;Great Agash;Expansion Region;K-15
+Malenko;Eidoloni;Mid Rim;L-16
+Mareg;;Wild Space;I-20
+Malian;;Expansion Region;I-14
+Marfa;;Core Worlds;M-10
+Malicar;Mieru'kar;Outer Rim Territories;N-4
+Maridun;Rolion;Outer Rim Territories;Q-6
+Malkii;Mortex;Outer Rim Territories;S-5
+Markbee's Star;Atrivis;Outer Rim Territories;L-5
+Mall'ordian;Corporate Sector;Outer Rim Territories;R-3
+Markez;Tiala;Mid Rim;K-7
+Malloran;Garis;Outer Rim Territories;N-18
+Markon;;Core Worlds;L-9
+Malo;Sluis;Outer Rim Territories;M-19
+Marleyvane;Tharin;Outer Rim Territories;T-8
+Malpassia;;Core Worlds;L-10
+Marmoth;Albarrio;Outer Rim Territories;K-4
+Malpaz;Wazta;Outer Rim Territories;I-17
+Marngar;;Core Worlds;M-10
+Malrev;Thrasybule;Outer Rim Territories;P-6
+Maro Della;Mektrun;Mid Rim;L-17
+Malsuum;;Inner Rim;L-14
+Marotan;;Inner Rim;O-9
+Maltha Obex;Mieru'kar;Outer Rim Territories;O-3
+Marquarra;Prefsbelt;Outer Rim Territories;J-5
+Maltheen Divide;Trax;Mid Rim;Q-10
+Marquinn;;Inner Rim;K-8
+Malthor;Tandon;Mid Rim;Q-14
+Marranis;Esstran;Outer Rim Territories;P-5
+Maltorian;Lifh;Mid Rim;R-8
+Marrovia;Gordian Reach;Outer Rim Territories;P-5
+Maltorra;;Core Worlds;M-12
+Martaus;;Inner Rim;N-8
+Malus;Gaulus;Outer Rim Territories;S-17
+Martle Station;Indrexu;Outer Rim Territories;S-5
+Mamendin;Farrfin;Core Worlds;K-9
+Maryo;Corporate Sector;Outer Rim Territories;S-4
+Mamkoda;Cassander;Outer Rim Territories;L-5
+Maryx Minor;Sujimis;Outer Rim Territories;O-19
+Manaan;;Inner Rim;O-11
+Marzoon;Marzoon;Mid Rim;I-16
+Manakron;Tashtor;Mid Rim;I-16
+Masgen;Churnis;Mid Rim;I-7
+Manali;Imberlin;Expansion Region;P-14
+Masposhani;Taldot;Mid Rim;Q-9
+Manari;Brevost;Expansion Region;O-15
+Massiff Nebula;;Core Worlds;K-9
+Manaxia;;Core Worlds;M-10
+Massoss;;Unknown Regions;G-8
+Manda;Manda;Mid Rim;R-15
+Masterra;Hertae;Mid Rim;Q-14
+Mandalore;Mandalore;Outer Rim Territories;O-7
+Matabre;Eucer;Mid Rim;Q-7
+Mandell;Bothan;Mid Rim;R-14
+Matacorn;Lambda;Mid Rim;P-15
+Mandellia;Nuiri;Outer Rim Territories;Q-7
+Mataou;Javin (Anoat);Outer Rim Territories;K-18
+Mandrine;Kessel;Outer Rim Territories;T-10
+Matarri;;Inner Rim;N-8
+Manella;;Core Worlds;M-9
+Mathas;;Inner Rim;J-14
+Manforgon;Senex;Mid Rim;L-17
+Matra;Corporate Sector;Outer Rim Territories;S-4
+Mangan;;Colonies;J-9
+Matterhelm;;Inner Rim;N-9
+Mangez;Brak;Expansion Region;O-14
+Mattri;;Inner Rim;O-10
+Mannius;;Wild Space;I-14
+Mauk;Metatessu;Mid Rim;R-9
+Mannova;Gordian Reach;Outer Rim Territories;Q-5
+Maun Digitalis;;Colonies;L-8
+Manoe;Manoe;Mid Rim;K-7
+Mauphin;;Core Worlds;K-12
+Manpha;Seitia;Outer Rim Territories;K-20
+Mavinia;;Inner Rim;N-13
+Manress;;Inner Rim;N-9
+Mavva;Aparo;Outer Rim Territories;R-3
+Mantan;Calamari;Outer Rim Territories;U-6
+Maw Cluster;Kessel;Outer Rim Territories;T-10
+Mantarran;;Inner Rim;L-14
+Mawan;;Core Worlds;M-11
+Mantessa;Orus;Inner Rim;M-8
+Maxca;Brak;Expansion Region;O-14
+Mantilorr;Suolriep;Outer Rim Territories;S-10
+Maxet;Tragan Cluster;Outer Rim Territories;N-5
+Mantooine;Atrivis;Outer Rim Territories;L-5
+Maxilia;Vulcusion;Expansion Region;L-16
+Manwess;Kilbanis;Colonies;N-9
+Maya Kovel;Zuma (Moddell);Outer Rim Territories;H-16
+Maphus Tria;Cadma;Outer Rim Territories;T-8
+Mayagil;Mayagil;Outer Rim Territories;M-18
+Mapuzo;Hollan;Mid Rim;M-7
+Mayvitch;Immalia;Expansion Region;L-8
+Marais, The;Hatawa;Core Worlds;J-10
+Mazhar;Spadja;Outer Rim Territories;R-6
+Maraken;Oktos;Mid Rim;R-12
+Mazuma;Nuiri;Outer Rim Territories;Q-6
+Maramere;Karthakk;Outer Rim Territories;Q-17
+Mearalis;Bri'ahl;Outer Rim Territories;I-17
+Marasai;Marasa Nebula;Inner Rim;O-10
+Meastrinnar;;Inner Rim;K-8
+Marasaln;Outer Jalor;Mid Rim;I-7
+Mechis;;Inner Rim;L-14
+Marca;Meerian;Outer Rim Territories;N-6
+Medepiest;Lambda;Mid Rim;P-15
+Marcadia;;Inner Rim;N-14
+Media;Corporate Sector;Outer Rim Territories;S-4
+Marcelan Prime;;Wild Space;J-5
+Medoslea;;Inner Rim;O-8
+Marcol Void;Kathol;Outer Rim Territories;M-21
+Medth;Ado;Mid Rim;M-17
+Mardona;;Inner Rim;N-13
+Meedis Minor;Tandon;Mid Rim;Q-13
+Mefti;;Colonies;L-8
+Metharg;Hook Nebula;Outer Rim Territories;O-17
+Megalox Beta;Bes Ber Bikade;Expansion Region;L-15
+Metharian Nebula;Tantra;Outer Rim Territories;M-19
+Megaria;;Inner Rim;M-8
+Metlok;Nouane;Inner Rim;N-8
+Meglumine;;Inner Rim;J-8
+Mev;Javin (Anoat);Outer Rim Territories;K-18
+Mek va Uil;Surron;Expansion Region;O-13
+Mexeluine;Javin (Anoat);Outer Rim Territories;K-18
+Mek-Sha;Belderone;Outer Rim Territories;R-6
+Mezeg;Mezeg;Mid Rim;N-7
+Mek'tradi;Baroli;Expansion Region;N-14
+Mhalanduin;Oktos;Mid Rim;R-12
+Mektrun Cluster;Mektrun;Mid Rim;L-17
+Mhatma;;Mid Rim;I-16
+Melagawni;Likasha;Mid Rim;Q-15
+Mhettghar;Atravis;Outer Rim Territories;L-19
+Melahna;;Core Worlds;K-9
+Midani;Thuris;Outer Rim Territories;P-18
+Melasaton;Jjannex;Outer Rim Territories;L-18
+Midarr;Mulgard;Mid Rim;N-16
+Melchior;Zeemacht Cluster;Inner Rim;N-8
+Midgor;Croynar;Inner Rim;M-14
+Meldazar;Immalia;Expansion Region;K-8
+Miekos;Cegul;Outer Rim Territories;L-20
+Melida/Daan;Cadavine;Outer Rim Territories;P-17
+Miele Nova;;Core Worlds;L-9
+Meligin;Ehosiq;Expansion Region;L-8
+Miglar;Morshdine;Outer Rim Territories;O-4
+Melinz;;Core Worlds;L-9
+Mijos;Javin (Anoat);Outer Rim Territories;K-18
+Melldia;Esstran;Outer Rim Territories;Q-4
+Mika;Arkanis;Outer Rim Territories;R-17
+Melm;Wyl;Outer Rim Territories;S-4
+Mikaster;Mikaster;Expansion Region;N-15
+Melnea's World;Arkanis;Outer Rim Territories;R-16
+Mikkia;Greater Plooriod;Expansion Region;M-7
+Melus;Nicandra;Mid Rim;L-7
+Miko;Esaga;Mid Rim;Q-11
+Mendacia;Fei Hu;Mid Rim;P-13
+Mil Velay;;Inner Rim;M-8
+Mendavi;Ferra;Outer Rim Territories;S-16
+Mila;Brak;Expansion Region;O-14
+Mendenbatt;Mortex;Outer Rim Territories;R-5
+Milagro;Chaykin;Expansion Region;O-14
+Mendicat;;Wild Space;I-8
+Milarian;Trans-Nebular;Mid Rim;R-16
+Mengal;Gordian Reach;Outer Rim Territories;Q-6
+Mileva;Maldrood;Mid Rim;R-7
+Mengjini;Bright Jewel;Mid Rim;L-7
+Millinar;Hapes Cluster;Inner Rim;O-9
+Mennar-Daye;Thesme;Outer Rim Territories;O-6
+Milvayne;;Inner Rim;L-8
+Mentanar Vosk;Nijune;Outer Rim Territories;O-4
+Mima;D'Aelgoth;Mid Rim;L-17
+Menthusa;;Colonies;M-9
+Mina-Rau;D'Astan;Outer Rim Territories;O-6
+Meor Ain;Jubilar;Outer Rim Territories;T-7
+Minashee;Cassander (Tadrin);Outer Rim Territories;K-5
+Mepha'as Prime;Belsmuth;Outer Rim Territories;O-6
+Minavar;Bheriz;Outer Rim Territories;U-10
+Mephitis;;Colonies;J-13
+Mindabaal;Faultheen;Inner Rim;J-13
+Mephout;Mephout Dominion*;Wild Space;H-20
+Mindemir;;Colonies;N-10
+Merakai;;Core Worlds;K-9
+Mindor;;Inner Rim;M-8
+Meria;;Mid Rim;H-15
+Minfar;;Inner Rim;I-13
+Meridian;Meridian;Outer Rim Territories;R-7
+Minkring;Shelsha;Colonies;M-9
+Merikon;Fath;Outer Rim Territories;K-6
+Minntaa;Nilgaard;Outer Rim Territories;S-5
+Merisee;Elrood;Outer Rim Territories;M-19
+Minntooine;Calamari;Outer Rim Territories;T-6
+Merj;Thesme;Outer Rim Territories;O-6
+Minoth;Masla;Mid Rim;J-17
+Merokia;Koradin;Outer Rim Territories;J-18
+Mirak Major;;Inner Rim;M-14
+Merren;Chaykin;Expansion Region;O-14
+Mircapala;;Wild Space;S-3
+Merson;;Inner Rim;O-10
+Mirial;Illisurevimurasi;Outer Rim Territories;Q-4
+Merthia;Merthian;Expansion Region;N-13
+Miriatin;Var Hagen;Mid Rim;M-16
+Meruud;Narrant;Mid Rim;I-16
+Mirit;;Colonies;K-9
+Mes Cavoli;Venaarian;Mid Rim;O-7
+Mirnic;Seswenna;Outer Rim Territories;M-18
+Meserian;Nijune;Outer Rim Territories;O-4
+Miro;Fath;Outer Rim Territories;K-6
+Meshakia;Likasha;Mid Rim;Q-14
+Mirran;Morobe;Colonies;N-11
+Messert;Mytaranor;Mid Rim;Q-10
+Mirrin Prime;Kalamith (Mirrin);Outer Rim Territories;P-5
+Messia;;Core Worlds;M-11
+Mirshaf;;Core Worlds;L-9
+Mestare;;Deep Core;L-12
+Mirshilan;Dalchon;Outer Rim Territories;R-17
+Mestra;Minos Cluster;Outer Rim Territories;M-20
+Mis-Tenek;Manda;Mid Rim;S-15
+Mestun;Thrasybule;Outer Rim Territories;P-6
+Misnor;Meram;Outer Rim Territories;O-4
+Mesula;Eidoloni;Mid Rim;M-16
+Mistar;Tragan Cluster;Outer Rim Territories;N-5
+Metagos;Cadma;Outer Rim Territories;T-8
+Mitek-Por;;Inner Rim;M-8
+Metalorn;Talcene;Mid Rim;R-8
+Mittoblade;;Inner Rim;K-8
+Metellos;Corusca;Core Worlds;K-10
+Miv'rah;Gaulus;Outer Rim Territories;R-17
+Mizra;;Inner Rim;O-8
+Morogia;;Core Worlds;M-10
+Miztoc;Irnaj;Mid Rim;K-17
+Morseer;Quelii;Outer Rim Territories;O-6
+Mobetta;Airam;Outer Rim Territories;M-20
+Morton;Majoor;Expansion Region;N-15
+Modus;Hapes Cluster;Inner Rim;O-9
+Morturia;Relgim;Outer Rim Territories;L-4
+Moer;Hewett;Mid Rim;M-7
+Morvogodine;Calaron;Outer Rim Territories;T-9
+Mogoshyn;Gordian Reach;Outer Rim Territories;P-5
+Moseum;Thesme;Outer Rim Territories;O-6
+Mohsenia;Meridian;Outer Rim Territories;R-6
+Moshaw;Seswenna;Outer Rim Territories;M-18
+Mokivj;Pacanth Reach;Outer Rim Territories;G-16
+Moskk;Albarrio;Outer Rim Territories;K-5
+Mokk;;Inner Rim;N-10
+Mossak;Thanium;Outer Rim Territories;R-6
+Mol'leaj;Thaere;Expansion Region;O-14
+Motexx;;Colonies;M-13
+Molavar;Abrion;Outer Rim Territories;S-15
+Mourushia;Barsa;Mid Rim;J-6
+Moldour;Lothal;Outer Rim Territories;U-7
+Movris;Noonian;Outer Rim Territories;M-6
+Mollo Tanka;Corellian;Core Worlds;M-11
+Mowgle;Demophon;Core Worlds;M-10
+Molos;Stensen;Outer Rim Territories;I-17
+Mrinzebon;Sombure;Mid Rim;K-16
+Moloskia;Mbandamonte;Expansion Region;N-15
+Mrisst;Fakir;Colonies;K-9
+Moltok;Atrivis;Outer Rim Territories;L-5
+Mrlsst;Tapani;Colonies;L-13
+Momansi;Brevost;Expansion Region;O-15
+Msst;Msst;Mid Rim;P-7
+Mon Cala;Calamari;Outer Rim Territories;U-6
+Mugaar;Bruanii;Mid Rim;K-18
+Mon Gazza;Lambda;Mid Rim;Q-16
+Mulatan;;Hutt Space;S-10
+Mon Torri;Msst;Mid Rim;P-7
+Muldore;;Core Worlds;J-9
+Monadin;Kuat;Core Worlds;M-10
+Mulita;;Wild Space;H-19
+Monastery;Haserian;Mid Rim;Q-14
+Mullan;Keldrath;Outer Rim Territories;T-6
+Mondress;Mondress;Expansion Region;J-7
+Mulvar;Obtrexta;Outer Rim Territories;K-3
+Monhudle;Cassander (Tadrin);Outer Rim Territories;K-5
+Munlali Mafir;;Unknown Regions;G-5
+Monic;Trianii Space*;Wild Space;R-3
+Munt Ontdal;Fei Hu;Mid Rim;Q-13
+Monnoc;Rseik;Outer Rim Territories;N-19
+Munto Codru;Pakuuni;Outer Rim Territories;T-6
+Monor;Doldur;Mid Rim;P-15
+Muntro;Mayagil;Outer Rim Territories;N-18
+Monsua Nebula;Zuma (Moddell);Outer Rim Territories;H-16
+Muntuur;Sloo;Mid Rim;P-14
+Monta;Daimar;Mid Rim;Q-16
+Mupin;Rocantor;Expansion Region;L-15
+Montalsia;Corellian;Core Worlds;M-11
+Muqular;Montitian Grant;Expansion Region;J-15
+Montitia;Montitian Grant;Expansion Region;J-15
+Murakam;;Deep Core;M-11
+Montross;Truum;Mid Rim;P-8
+Murgo;;Wild Space;I-7
+Moobia;Kastolar;Mid Rim;R-10
+Murk;Zuma (Moddell);Outer Rim Territories;H-16
+Moog Mot;Tharin;Outer Rim Territories;S-8
+Murkhana;Auril;Outer Rim Territories;S-6
+Mooga;Perkell;Mid Rim;Q-7
+Murninkam;Corva;Outer Rim Territories;O-3
+Moonflower Nebula;;Wild Space;U-16
+Musca;Merthian;Expansion Region;N-14
+Moonus Mandel;Bothan;Mid Rim;R-14
+Muskree;Colundra;Outer Rim Territories;S-5
+Moorja;;Inner Rim;L-15
+Musson;Karthakk;Outer Rim Territories;Q-16
+Moorjhone;Jospro;Outer Rim Territories;R-7
+Mussubir;Senex;Mid Rim;L-17
+Mooshie Cluster;Videnda;Outer Rim Territories;L-18
+Mustafar;Atravis;Outer Rim Territories;L-19
+Moraband;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Muunilinst;Obtrexta;Outer Rim Territories;K-4
+Morado;Hune;Mid Rim;Q-11
+Muuria;;Inner Rim;M-13
+Moraga;Oricho;Outer Rim Territories;M-5
+Muzara;Trestis;Expansion Region;K-8
+Morak;;Wild Space;H-18
+Muzzli;Citlik;Expansion Region;O-15
+Moralan;;Hutt Space;T-10
+Mycroft;Fakir;Colonies;K-9
+Morath Nebula;Hatawa;Core Worlds;J-10
+Mydasos;Dalicron;Outer Rim Territories;K-19
+Moravia;Lambda;Mid Rim;Q-16
+Mygeeto;Albarrio;Outer Rim Territories;K-5
+Moraysi;Skine (Moraysian);Outer Rim Territories;P-18
+Mykapo;Ash Worlds;Outer Rim Territories;T-7
+Mordagon;Authala;Expansion Region;P-12
+Mylok;Airam;Outer Rim Territories;L-20
+Mordal;Illisurevimurasi;Outer Rim Territories;Q-4
+Mynock 7 Station;Mayagil;Outer Rim Territories;M-18
+Mordis;Lambda;Mid Rim;P-16
+Mynos;Dalchon;Outer Rim Territories;R-17
+Morellia;Morellian CW*;Wild Space;S-3
+Myomar;Deadalis;Expansion Region;J-7
+Morgania;Yminis;Outer Rim Territories;S-14
+Myrenia;;Core Worlds;L-9
+Morishim;Albarrio;Outer Rim Territories;K-5
+Myrkr;;Inner Rim;N-7
+Morning's Bell;Farlax;Core Worlds;K-10
+Mytar;Dufilvian;Mid Rim;Q-15
+Moro;Rago;Mid Rim;I-7
+Mytaranor;Mytaranor;Mid Rim;P-10
+Mytus;;Wild Space;S-3
+Narkina;Abrion;Outer Rim Territories;S-15
+MZX32905;Kanz;Outer Rim Territories;N-4
+Narq;;Colonies;N-11
+N'dian;Spadja;Outer Rim Territories;R-6
+Narragader;Kibilini;Outer Rim Territories;Q-17
+N'ildwab;Tynquay;Outer Rim Territories;Q-4
+Narrant;Narrant;Mid Rim;J-17
+N'zoth;Farlax;Core Worlds;K-10
+Nars;Senex;Mid Rim;L-17
+Naalol;Spirva;Mid Rim;L-17
+Narth;Mayagil;Outer Rim Territories;N-18
+Naator;Var Hagen;Mid Rim;M-16
+Narvath;Narvath;Expansion Region;O-14
+Naboo;Chommell;Mid Rim;O-17
+Natalon;Piryn Shar;Expansion Region;K-16
+Nacon;;Deep Core;L-10
+Nath Goordi;Tennuutta;Mid Rim;Q-7
+Nacronis;Hollan;Mid Rim;M-7
+Nathas;Questal;Core Worlds;J-12
+Nadaav;;Inner Rim;M-8
+Nathema;Chorlian;Outer Rim Territories;S-4
+Nadhe;Rolion;Outer Rim Territories;Q-6
+Natinati;;Wild Space;S-4
+Nadiem;Baxel;Outer Rim Territories;U-11
+Nativum;Halla;Mid Rim;R-9
+Nadiri;Bormea;Core Worlds;L-9
+Nauton;Taldot;Mid Rim;Q-9
+Nag Ubdur;Demetras;Outer Rim Territories;P-7
+Nazzri;Lantillian;Mid Rim;P-9
+Nagoa;;Wild Space;O-3
+NCW-781;;Wild Space;H-18
+Nahsu Minor;Ktilac Regions;Inner Rim;N-9
+Nea Dajanam;Sern;Colonies;L-13
+Najan-Rovi;Brema;Outer Rim Territories;M-17
+Near Indosa;Gordian Reach;Outer Rim Territories;P-6
+Najarka;Rayter;Outer Rim Territories;J-19
+Near Pando;;Hutt Space;S-14
+Najiba;Arkanis;Outer Rim Territories;R-17
+Neary;Calaron;Outer Rim Territories;T-9
+Nak Shimor;;Colonies;M-9
+Nebula Forso;Meram;Outer Rim Territories;P-4
+Nakadia;Tregillis;Expansion Region;M-15
+Necr'ygor;Chommell;Mid Rim;O-16
+Nakrikal Singularity;Grumani;Outer Rim Territories;N-17
+Necropolis;Zuma (Sugai);Outer Rim Territories;H-16
+Nal Hutta;;Hutt Space;S-12
+Nedij;Samix;Outer Rim Territories;Q-19
+Nal Kapok;Taldot;Mid Rim;Q-9
+Needan;;Wild Space;I-20
+Naldar;Phelleem;Outer Rim Territories;S-7
+Neelabi;Kibilini;Outer Rim Territories;Q-17
+Nalrith;Rseik;Outer Rim Territories;N-20
+Neelanon;Senex;Mid Rim;L-17
+Nalyd;Tharin;Outer Rim Territories;S-7
+Neelgaimon;Xappyh;Outer Rim Territories;Q-3
+Nam Chorios;Meridian;Outer Rim Territories;R-6
+Nefitifi;Wazta;Outer Rim Territories;J-18
+Nam Priax;Nilgaard;Outer Rim Territories;S-5
+Nefri;Ciutric;Outer Rim Territories;N-5
+Nam'ta;Atrivis;Outer Rim Territories;L-5
+Neijaia;Majoor;Expansion Region;N-15
+Namadii;Churnis;Mid Rim;I-6
+Neimoidia;Quellor;Colonies;M-10
+Nameel;Mytaranor;Mid Rim;Q-10
+Neka;Raioballo;Outer Rim Territories;L-4
+Namore;;Colonies;L-13
+Nela-Ray;Kalamith;Outer Rim Territories;P-5
+Namzor;Esuain;Mid Rim;P-7
+Nelfrus;Elrood;Outer Rim Territories;M-20
+Nanta-Ri;Farlax;Core Worlds;K-10
+Nelgenam;Tashtor;Mid Rim;I-16
+Nantama;Senex;Mid Rim;L-17
+Nella;Tapani;Colonies;L-13
+Nanth'ri;Kurost;Mid Rim;Q-12
+Nellac Kram;Bon'nyuw-Luq;Outer Rim Territories;N-18
+Nantoon;;Colonies;M-13
+Nelvaan;Savareen;Outer Rim Territories;Q-16
+Nantuker;Hapes Cluster;Inner Rim;O-9
+Nelvana Gas Cluster;Iskin;Mid Rim;O-16
+Naos;;Wild Space;S-18
+Nentan;Glythe;Mid Rim;K-7
+Naplousea;Tynquay;Outer Rim Territories;R-4
+Nenyezh;Halori;Mid Rim;P-7
+Naporar;Chiss Space*;Unknown Regions;F-8
+Neoli;;Wild Space;O-20
+Naps Fral Cluster;Ferra;Outer Rim Territories;S-16
+Neona;Tapani;Colonies;L-13
+Nar Bo Sholla;;Hutt Space;R-10
+Nephryn;Prackla;Expansion Region;O-8
+Nar Chunna;;Hutt Space;S-10
+Nepotis;Calaron;Outer Rim Territories;T-9
+Nar Haaska;;Hutt Space;T-11
+Nepoy;Senex;Mid Rim;L-17
+Nar Kaaga;;Hutt Space;S-13
+Neral;Corellian;Core Worlds;M-11
+Nar Kanji;Suolriep;Outer Rim Territories;S-9
+Neree;Suolriep;Outer Rim Territories;S-9
+Nar Kreeta;;Hutt Space;S-10
+Nerria;Suolriep;Outer Rim Territories;S-9
+Nara;;Colonies;L-9
+Nerrif;Vilonis;Mid Rim;O-16
+Naraka;Phelleem;Outer Rim Territories;S-7
+Neshei;Neshei;Expansion Region;J-8
+Naran-Shiv;Tacuni;Expansion Region;O-15
+Neshtab;Quohag;Inner Rim;K-8
+Naratar;Wornal;Mid Rim;K-16
+Neskar;Tashtor;Mid Rim;I-16
+Narg;Rayter;Outer Rim Territories;J-19
+Nessem;Lostar;Expansion Region;M-8
+Narigus;Belsmuth;Outer Rim Territories;O-6
+Netalych;;Inner Rim;N-14
+Netolio;Tapani;Colonies;L-13
+Nimgorrhea;Yminis;Outer Rim Territories;S-14
+Nettehi;Paataatus Hiveborn*;Unknown Regions;F-9
+Nimia;;Hutt Space;S-9
+Neutra;Oeiros;Expansion Region;P-10
+Ningoth;Karthakk;Outer Rim Territories;Q-16
+Neuvia;;Colonies;L-9
+Ninn;Corporate Sector;Outer Rim Territories;R-3
+Nevarro;Dalicron;Outer Rim Territories;K-20
+Ninzam;Ryndellian;Mid Rim;P-17
+New Agamar;Sprizen;Outer Rim Territories;N-5
+Niorven;Lambda;Mid Rim;P-16
+New Alderaan;Ash Worlds;Outer Rim Territories;T-6
+Niran;Tunka;Outer Rim Territories;I-18
+New Apsolon;Terr'skiar;Mid Rim;P-10
+Nirauan;;Wild Space;I-5
+New Ator;Arkanis;Outer Rim Territories;R-16
+Niraya;;Inner Rim;N-9
+New Bakstre;Cassander (Tendrannan);Outer Rim Territories;K-5
+Nirellia;Oktos;Mid Rim;Q-11
+New Balosar;Arc d'Stot;Expansion Region;K-15
+Niro;Circarpous;Expansion Region;O-12
+New Bornalex;Belsmuth;Outer Rim Territories;O-6
+Nishmar;;Wild Space;G-15
+New Brampis;;Inner Rim;M-13
+Nishr;Hunnoverrs;Outer Rim Territories;R-17
+New Brigia;Farlax;Core Worlds;K-10
+Nista;Tapani;Colonies;L-13
+New Canistel;Demetras;Outer Rim Territories;P-7
+Nithorni;;Colonies;K-8
+New Cov;Churba;Mid Rim;P-14
+Nivek;Citlik;Expansion Region;O-14
+New Cylimba;D'Aelgoth;Mid Rim;L-17
+Nixor;Eclorar;Mid Rim;Q-12
+New Drev'starn;Thesme;Outer Rim Territories;O-6
+Nixus;Parmic;Outer Rim Territories;P-18
+New Heurkea;Calamari;Outer Rim Territories;U-6
+Nkllon;Alchenaut;Expansion Region;L-16
+New Holgha;Ciutric;Outer Rim Territories;N-5
+No-ad;Bryx;Mid Rim;R-7
+New Holstice;Maldrood;Mid Rim;R-7
+Noaxson;Oricho;Outer Rim Territories;M-6
+New Javis;Tapani;Colonies;L-13
+Nocto;Airam;Outer Rim Territories;L-20
+New Parsh;Perinn;Outer Rim Territories;J-4
+Noctralis;Ehosiq;Expansion Region;L-8
+New Plympto;Corellian;Core Worlds;M-11
+Noctu;;Colonies;J-13
+New Polokia;;Inner Rim;M-13
+Nodgra;Airam;Outer Rim Territories;L-20
+New Raithal;Annecy;Expansion Region;P-9
+Noe'ha'on;Piryn Shar;Expansion Region;K-16
+New Ralltiir;Lantillian;Mid Rim;P-8
+Nojic;Nojic;Expansion Region;O-9
+New Shella;Tapani;Colonies;L-13
+Nolar;;Inner Rim;N-8
+New Valis;Bri'ahl;Outer Rim Territories;I-17
+Nomaria;Suolriep;Outer Rim Territories;S-8
+Nexator;;Inner Rim;O-10
+Nomlis;Vilonis;Mid Rim;O-16
+Nexer;Prackla;Expansion Region;O-8
+Noola;Relgim;Outer Rim Territories;L-5
+Nexus Ortai;Hertae;Mid Rim;Q-14
+Nooli;Noolian;Mid Rim;Q-13
+Nez Peron;D'Astan;Outer Rim Territories;O-5
+Noomis Riga;Yminis;Outer Rim Territories;S-14
+Nezni;Mayagil;Outer Rim Territories;N-18
+Noonar;Noonian;Outer Rim Territories;M-6
+Nfolgai;Esstran (Sith Worlds);Outer Rim Territories;R-4
+Noopiths, The;Bozhnee;Outer Rim Territories;L-18
+Nharqis'l;Veragi;Outer Rim Territories;K-2
+Noori;Noori;Expansion Region;O-10
+Niamos;Vorzyd;Outer Rim Territories;R-6
+Nooroyo;Cadavine;Outer Rim Territories;P-17
+Nibiru;Zuma (Kakani);Outer Rim Territories;H-16
+Nopachi;;Core Worlds;M-10
+Nicandra;Nicandra;Mid Rim;M-7
+Nopces;Bormea;Core Worlds;L-9
+Nichen;Morshdine;Outer Rim Territories;N-4
+Nopsin;;Mid Rim;I-15
+Nicht Ka;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Noquivzor;;Colonies;K-9
+Niele;;Colonies;K-13
+Nora;Belshar;Mid Rim;J-7
+Nierport;;Colonies;L-8
+Norah;;Inner Rim;L-14
+Nieuth;Wyloff;Colonies;L-8
+Norat;Farlax;Core Worlds;K-10
+Nigel;Kira;Expansion Region;N-16
+Norclune;;Colonies;L-8
+Nightsend;Phelleem;Outer Rim Territories;S-7
+Nord;Kanz;Outer Rim Territories;N-4
+Nightside;Sertar;Outer Rim Territories;R-5
+Nordis Prime;Tashtor;Mid Rim;J-16
+Niian;Thaere;Expansion Region;O-14
+Nordra;;Inner Rim;N-14
+Nijune;Nijune;Outer Rim Territories;N-5
+Noremac;Kanz;Outer Rim Territories;N-4
+Nilash;Grumani;Outer Rim Territories;M-17
+Noris;Chiss Space*;Unknown Regions;F-8
+Nilg;Alderath;Mid Rim;L-7
+Norisyn;Svivreni;Outer Rim Territories;O-19
+Nilgaria;Masla;Mid Rim;J-16
+Norkronia;;Core Worlds;K-10
+Nim Drovis;Meridian;Outer Rim Territories;R-7
+Norne;;Core Worlds;K-10
+Nimat;Tharin;Outer Rim Territories;T-8
+Norsid;Rseik;Outer Rim Territories;N-19
+Nimba;;Wild Space;T-17
+Norulac;;Inner Rim;O-9
+Nimban;;Hutt Space;S-10
+Norval;Calaron;Outer Rim Territories;T-9
+Noryath;Nuiri;Outer Rim Territories;Q-6
+Obus;;Wild Space;I-4
+Noryokon;;Inner Rim;K-8
+Ocahont;Alui;Mid Rim;N-17
+Nosken;Prefsbelt;Outer Rim Territories;J-6
+Ochotl;Airam;Outer Rim Territories;L-20
+Notak;Doldur;Mid Rim;P-15
+Ocktai;Kriz;Outer Rim Territories;K-19
+Nothoiin;Javin (Anoat);Outer Rim Territories;K-18
+Ocsin;Corporate Sector;Outer Rim Territories;S-3
+Notonia;Illisurevimurasi;Outer Rim Territories;Q-4
+Octavia;Nicandra;Mid Rim;M-7
+Nouane;Nouane;Inner Rim;N-8
+Octero;Portmoak;Outer Rim Territories;P-18
+Noult;;Core Worlds;L-12
+Odacer-Faustin;Esstran (Sith Worlds);Outer Rim Territories;Q-5
+Nova Garon;Rayter;Outer Rim Territories;J-19
+Odessen;;Wild Space;G-13
+Novar;Lostar;Expansion Region;M-8
+Odik;;Deep Core;K-11
+Novi;Hapes Cluster;Inner Rim;O-9
+Odona;Tolonda;Outer Rim Territories;Q-17
+Novka;Manda;Mid Rim;R-14
+Odos;Meridian;Outer Rim Territories;R-7
+Novoil Cluster;;Colonies;N-12
+Odryn;Noonian;Outer Rim Territories;N-7
+Novolek Beacon;Tharin (Periphery);Outer Rim Territories;S-8
+Odynnia Gavo;Bryx;Mid Rim;R-7
+Novor;Tharin (Periphery);Outer Rim Territories;S-8
+Oetchi;Bon'nyuw-Luq;Outer Rim Territories;N-17
+Nuala;Trans-Gascon;Mid Rim;P-7
+Öetrago;Mayagil;Outer Rim Territories;M-18
+Nubia;Corellian;Core Worlds;M-11
+Off-Canau;;Colonies;N-12
+Nuja;Axion;Expansion Region;P-10
+Ogden Minor;Maerdocian;Mid Rim;Q-12
+Nulan;Hook Nebula;Outer Rim Territories;O-18
+Ogem;D'Aelgoth;Mid Rim;L-17
+Null;Trans-Vulta;Mid Rim;N-7
+Oggustus Nebula;Kira;Expansion Region;N-15
+Numatra;;Core Worlds;L-12
+Ogoth Tiir;Atravis;Outer Rim Territories;L-19
+Numidian Prime;Bright Jewel;Mid Rim;L-7
+Ohratuu;Piryn Shar;Expansion Region;K-16
+Nummunr;Ash Worlds;Outer Rim Territories;S-7
+OHS1782-03;Ash Worlds;Outer Rim Territories;T-7
+Nunce;;Core Worlds;L-13
+OHS2132-04;Ash Worlds;Outer Rim Territories;T-7
+Nuralee;Tyus;Mid Rim;N-16
+OHS3842-03;Ash Worlds;Outer Rim Territories;T-7
+Nurasenti;Abrion;Outer Rim Territories;S-15
+OHS4140-02;Ash Worlds;Outer Rim Territories;T-7
+Nuswatta;Cronese Mandate;Outer Rim Territories;S-6
+Ojom;;Deep Core;M-11
+Nuvar;Dustig;Mid Rim;N-17
+Okator;Eucer;Mid Rim;Q-7
+Nux;Endocray;Mid Rim;R-14
+Oko E;Wazta;Outer Rim Territories;J-18
+Nwarcol;Tharin (Periphery);Outer Rim Territories;S-8
+Oktaro;Lannik Space;Mid Rim;R-13
+Nyara;;Inner Rim;L-8
+Oktos Nebula;;Hutt Space;R-12
+Nyarikan Nebula;Msst;Mid Rim;P-7
+Okyaab;Ojoster;Outer Rim Territories;N-7
+Nyasko;Phelleem (Colunda);Outer Rim Territories;S-7
+Olabria;Seitia;Outer Rim Territories;J-20
+Nyemari;Meridian;Outer Rim Territories;R-6
+Olanji;Hapes Cluster;Inner Rim;O-9
+Nymalia;Eidoloni;Mid Rim;M-17
+Old Barag;Epsi Collective;Expansion Region;M-15
+Nyny;Ash Worlds;Outer Rim Territories;T-7
+Old Mankoo;Quess;Mid Rim;N-17
+Nyonpur;Daimar;Mid Rim;Q-16
+Olega;Esuain;Mid Rim;P-7
+Nyriaan;Trans-Vulta;Mid Rim;N-7
+Oligtaz;;Core Worlds;L-12
+Nyssa;Tapani;Colonies;L-13
+Oliu;Jubilar;Outer Rim Territories;T-7
+Nysza;Dalchon;Outer Rim Territories;R-17
+Olkrastrus;Numesira;Mid Rim;Q-9
+O'reen;;Unknown Regions;H-13
+Omaka;Dalchon;Outer Rim Territories;R-17
+Oaka Prime;;Inner Rim;J-8
+Omar;;Colonies;K-13
+Oanne;Bon'nyuw-Luq;Outer Rim Territories;N-17
+Omereth;Albanin;Outer Rim Territories;U-13
+Oba Diah;Kessel;Outer Rim Territories;T-10
+Omiddelon;Halla;Mid Rim;S-9
+Obana;Arkanis;Outer Rim Territories;R-16
+Omman;Tion Hegemony;Outer Rim Territories;S-6
+Obas;Andirma;Expansion Region;L-15
+Omman Minor;Kibilini;Outer Rim Territories;Q-17
+Obelia;Tapani;Colonies;L-13
+Omonoth;;Inner Rim;M-8
+Oben;;Wild Space;J-4
+Ompersan;Prefsbelt;Outer Rim Territories;K-5
+Obica;Grumani;Outer Rim Territories;M-17
+Omphalos;Venaarian;Mid Rim;O-7
+Obinipor;Demetras;Outer Rim Territories;P-7
+Omwat;Garis;Outer Rim Territories;N-18
+Obran Cluster;Videnda;Outer Rim Territories;L-18
+Onadax;Minos Cluster;Outer Rim Territories;M-20
+Obredaan;Irishi;Mid Rim;K-6
+Onatos;Onatos;Mid Rim;R-15
+Obroa-skai;;Inner Rim;N-8
+Ondara;Lantillian;Mid Rim;P-8
+Obsidia;;Unknown Regions;G-7
+Onderia;;Inner Rim;M-13
+Obulette;Tapani;Colonies;L-13
+Onderon;Japrael;Inner Rim;O-9
+Obumubo;;Core Worlds;L-13
+Ondo;;Colonies;N-12
+Ondos;;Core Worlds;K-10
+Ord Lithone;;Inner Rim;L-8
+Ongary;Ividal;Mid Rim;P-14
+Ord Lonesome;Albanin;Outer Rim Territories;T-12
+Ongella;;Inner Rim;N-10
+Ord Mantell;Bright Jewel;Mid Rim;L-7
+Onod;Irnaj;Mid Rim;K-17
+Ord Marsax;Belderone;Outer Rim Territories;R-6
+Ontotho;Nembus;Outer Rim Territories;P-4
+Ord Mynock;Prefsbelt;Outer Rim Territories;K-6
+Ookbat;Kastolar;Mid Rim;Q-10
+Ord Namurt;Tharin;Outer Rim Territories;S-8
+Ool;Chiss Space*;Unknown Regions;E-8
+Ord Ortag;;Hutt Space;S-13
+Oolex Pulsar;Sumitra;Expansion Region;N-7
+Ord Pardron;Dufilvian;Mid Rim;R-15
+Oolidi;Hythrope;Expansion Region;M-16
+Ord Pentala;;Inner Rim;K-14
+Ooloponi;Bes Ber Bikade;Expansion Region;L-15
+Ord Radama;Esstran;Outer Rim Territories;Q-5
+Oon;Lothal;Outer Rim Territories;U-7
+Ord Sabaok;;Core Worlds;J-13
+Oon Tien;Kathol;Outer Rim Territories;M-21
+Ord Sedra;Clacis;Outer Rim Territories;K-4
+Ooo-sek;Daimar;Mid Rim;Q-16
+Ord Segra;Dufilvian;Mid Rim;Q-15
+Ooo-temiuk;Arkanis;Outer Rim Territories;R-16
+Ord Sigatt;Noonian;Outer Rim Territories;N-6
+Oor;Cronese Mandate;Outer Rim Territories;S-6
+Ord Simres;Brema;Outer Rim Territories;M-17
+Oordo;Strabin;Mid Rim;M-7
+Ord Tellarom;Suolriep;Outer Rim Territories;S-8
+Oorn Tchis;Lahara;Outer Rim Territories;M-5
+Ord Tessebok;Irishi;Mid Rim;K-6
+Oosalon;Baxel;Outer Rim Territories;U-12
+Ord Thabl;Elochar;Mid Rim;R-9
+Ootoo Prime;Tungra;Outer Rim Territories;K-18
+Ord Thoden;Dynali;Outer Rim Territories;J-4
+Ootoola;Morshdine;Outer Rim Territories;O-5
+Ord Tiddell;Tennuutta;Mid Rim;Q-7
+Oovo;Tharin;Outer Rim Territories;S-8
+Ord Torrenze;Sertar;Outer Rim Territories;S-5
+Oovri;Tungra;Outer Rim Territories;K-18
+Ord Traga;Tragan Cluster;Outer Rim Territories;N-5
+Opari;Dustig;Mid Rim;N-16
+Ord Trasi;Relgim;Outer Rim Territories;L-4
+Opatajji;Alsaka;Core Worlds;L-9
+Ord Varee;Belshar;Mid Rim;J-7
+Open Sea;Centrality;Outer Rim Territories;U-8
+Ord Vaug;Rocantor;Expansion Region;L-15
+Ophideraan;;Colonies;K-13
+Ord Vaxal;Callia;Inner Rim;N-13
+Opiteihr;Var Hagen;Mid Rim;M-16
+Ord Wylan;Oktos;Mid Rim;R-12
+Opitha Tren;;Mid Rim;J-15
+Ord Yndar;Esaga;Mid Rim;Q-11
+Oplovis;Oplovis;Outer Rim Territories;M-5
+Ord Zat;Jospro;Outer Rim Territories;S-7
+Opop Hibbedit;Sevastol;Mid Rim;Q-14
+Ord Zeuol;Vilonis;Mid Rim;O-16
+OR-Kappa-2722;Lahara;Outer Rim Territories;M-5
+Ord Zynthar;Lambda;Mid Rim;P-16
+Oracaia;Dantus;Outer Rim Territories;J-6
+Ordnandell;Kastolar;Mid Rim;R-10
+Oranessan;Grumani;Outer Rim Territories;M-17
+Ordo;Mandalore;Outer Rim Territories;O-7
+Orax;Subterrel;Outer Rim Territories;L-20
+Ordo Eris;Chorlian;Outer Rim Territories;S-4
+Orchis;;Inner Rim;N-8
+Ordo Moon;Bortele;Mid Rim;R-8
+Ord Adinorr;Meridian;Outer Rim Territories;R-7
+Ordo Tera;Belasco;Expansion Region;P-11
+Ord Antalaha;;Colonies;L-8
+Oreenda Fayeet;;Colonies;L-13
+Ord Biniir;Relgim;Outer Rim Territories;L-5
+Orelon;Hapes Cluster;Inner Rim;O-9
+Ord Bueri;Nilgaard;Outer Rim Territories;S-5
+Orgri, The;Jubilar;Outer Rim Territories;T-7
+Ord Canfre;Cassander;Outer Rim Territories;K-5
+Oricho;Oricho;Outer Rim Territories;M-6
+Ord Cantrell;Fath;Outer Rim Territories;K-6
+Oricon;Corva;Outer Rim Territories;P-3
+Ord Celbus;Karthakk;Outer Rim Territories;Q-16
+Oridol Cluster;Rolion;Outer Rim Territories;P-7
+Ord Cestus;D'Astan;Outer Rim Territories;O-6
+Orimanther;Quelii;Outer Rim Territories;O-6
+Ord Dalet;Sertar;Outer Rim Territories;R-5
+Orinackra;;Wild Space;J-3
+Ord Dorlass;Iskin;Mid Rim;O-16
+Orinca;Tunka;Outer Rim Territories;I-19
+Ord Dycoll;Lannik Wilds;Mid Rim;R-13
+Orinda;Irishi;Mid Rim;K-6
+Ord Fanthal;Ojoster;Outer Rim Territories;O-7
+Oriolanis;Oriolan;Mid Rim;J-16
+Ord Gimmel;Ado;Mid Rim;M-17
+Orion;Tion Hegemony;Outer Rim Territories;T-6
+Ord Grovner;Khuiumin;Outer Rim Territories;O-18
+Orish;Brema;Outer Rim Territories;M-17
+Ord Gustald;Mytaranor;Mid Rim;Q-9
+Oristrom;;Unknown Regions;I-5
+Ord Hout;Brema;Outer Rim Territories;M-17
+Orixon Nebula;Phelleem;Outer Rim Territories;S-7
+Ord Ibanna;Brema;Outer Rim Territories;M-17
+Orkellia;Haserian;Mid Rim;Q-15
+Ord Ivarn;Hakartha;Expansion Region;L-16
+Orko;Videnda;Outer Rim Territories;L-18
+Ord Jannak;Kastolar;Mid Rim;R-10
+Orleon;Talcene;Mid Rim;Q-8
+Ord Janon;Spinward;Outer Rim Territories;N-2
+Orma;Brak;Expansion Region;O-14
+Ord Klina;Klina;Outer Rim Territories;S-13
+Orn Kios;Javin (Yarith);Outer Rim Territories;K-18
+Ornfra;Chiss Space*;Unknown Regions;F-8
+Oyokal;Chiss Space*;Unknown Regions;E-8
+Oro Sankeria;Tharin;Outer Rim Territories;S-7
+Oznek;Cademimu;Outer Rim Territories;M-6
+Orocco;Ottega;Mid Rim;M-7
+Ozri;Far Xandil;Mid Rim;P-16
+Orondia;;Hutt Space;S-11
+Ozu;Javin (Anoat);Outer Rim Territories;K-18
+Orooturoo;Farlax;Core Worlds;K-10
+P'frorin;Bheriz;Outer Rim Territories;U-10
+Orowat;Myto;Outer Rim Territories;K-4
+Pa Tho;;Inner Rim;K-14
+Orra;D'Astan;Outer Rim Territories;O-5
+Pa'hir'al;Urce Space;Mid Rim;L-7
+Orranana;Cadma;Outer Rim Territories;T-8
+Paarin Minor;Cademimu;Outer Rim Territories;M-6
+Orrik;Dalicron;Outer Rim Territories;K-19
+Pabu;Chopani;Outer Rim Territories;L-3
+Orroman;;Wild Space;I-14
+Pacara;;Mid Rim;J-15
+Orron;Corporate Sector;Outer Rim Territories;S-4
+Padua;;Core Worlds;M-12
+Orryxia;Seswenna;Outer Rim Territories;M-18
+Paecia;Quelii;Outer Rim Territories;O-6
+Orsis;Haserian;Mid Rim;Q-15
+Pagodon;Pelgrin;Outer Rim Territories;R-18
+Orthellin;Binarran Cloud;Colonies;M-9
+Paig;Drannik;Expansion Region;K-8
+Orto;Sluis;Outer Rim Territories;M-19
+Paigu;Vorzyd;Outer Rim Territories;R-6
+Orto Norwe;Trans-Vulta;Mid Rim;N-7
+Paklan;Nuiri;Outer Rim Territories;Q-6
+Oru;Veragi;Outer Rim Territories;L-3
+Paklarn;Abaar;Mid Rim;K-7
+Orvax;Savareen;Outer Rim Territories;R-17
+Pako Ramoon;Rayter;Outer Rim Territories;J-19
+Osadia;;Core Worlds;K-10
+Pakrik;Kanchen;Core Worlds;K-9
+Osara;;Inner Rim;K-8
+Pakuuni;Pakuuni;Outer Rim Territories;T-6
+Oseon;Centrality;Outer Rim Territories;T-8
+Pal Goral;Mortex;Outer Rim Territories;R-4
+Oshetti;Aparo;Outer Rim Territories;R-3
+Palagosal;Arkanis;Outer Rim Territories;R-17
+Oshira;Vilonis;Mid Rim;O-16
+Palanhi;Fakir;Colonies;K-9
+Oshora;Tolonda;Outer Rim Territories;Q-17
+Palawa;;Core Worlds;L-10
+Osirrag;Elrood;Outer Rim Territories;M-20
+Palek;Cyrillian Protectorate;Expansion Region;O-12
+Osisis Station;Regani;Inner Rim;M-8
+Pallaxides;Ojoster;Outer Rim Territories;N-7
+Osk-Trill;;Core Worlds;M-10
+Palliduva;;Wild Space;U-12
+Oslumpex;Corporate Sector;Outer Rim Territories;S-4
+Palmatian;Baronos;Colonies;M-9
+Osmani;Senex;Mid Rim;L-18
+Pam'ba;;Mid Rim;H-15
+Ossel;Bozhnee;Outer Rim Territories;L-18
+Pamaradia;;Colonies;L-8
+Osseriton;;Unknown Regions;G-9
+Pamarthe;Mayagil;Outer Rim Territories;N-18
+Ossi;Mezeg;Mid Rim;N-7
+Pamina Prime;;Inner Rim;M-8
+Ossiathora;Juvex;Mid Rim;L-17
+Pammant;Calamari;Outer Rim Territories;U-6
+Ossiathora;;Inner Rim;J-8
+Pamorjal;Immerian Outback;Expansion Region;N-14
+Osskorn;Tyan;Mid Rim;L-6
+Panatha;Pacanth Reach;Outer Rim Territories;H-16
+Osssorck Nebulae;;Core Worlds;J-12
+Pandem Nai;Thrasybule;Outer Rim Territories;P-6
+Ossus;Auril;Outer Rim Territories;R-6
+Pandori;Sarin;Outer Rim Territories;O-18
+Ostega;Grohl;Outer Rim Territories;R-15
+Panela;;Core Worlds;M-12
+Ostor;Koradin;Outer Rim Territories;I-18
+Pangarees, The;Airam;Outer Rim Territories;L-20
+Ota;Mytaranor;Mid Rim;Q-10
+Panisia;Halthor;Outer Rim Territories;L-6
+Otavon;Hollan;Mid Rim;M-7
+Panna;Cronese Mandate;Outer Rim Territories;S-6
+Oteroa;Corthenia;Mid Rim;K-7
+Pansha;;Core Worlds;K-12
+Otomok;Prefsbelt;Outer Rim Territories;K-6
+Pantolomin;Dolomar;Core Worlds;K-9
+Otor's Hub;Ojoster;Outer Rim Territories;N-7
+Pantora;Sujimis;Outer Rim Territories;P-19
+Otranto;Nembus;Outer Rim Territories;P-4
+Pantrosian Eye;Endocray;Mid Rim;R-14
+Ottabesk;;Deep Core;M-11
+Paonid;;Inner Rim;O-8
+Ottethan;Halthor;Outer Rim Territories;M-6
+Paqualis;;Inner Rim;L-8
+Ottinger;Perinn;Outer Rim Territories;J-4
+Paqwepor Major;Paqwepori;Mid Rim;P-15
+Otunia;Bosph;Outer Rim Territories;Q-3
+Parabaw Station;Jospro;Outer Rim Territories;S-7
+Oulanne;;Inner Rim;L-14
+Parada;Hadar;Mid Rim;L-17
+Outer Mebarius;;Inner Rim;N-10
+Paradise;Airam;Outer Rim Territories;M-20
+Outland Station;Baxel;Outer Rim Territories;T-12
+Paradise Station;Gendius;Mid Rim;J-17
+Ova;Quelii;Outer Rim Territories;O-6
+Paramatan;Senex;Mid Rim;L-17
+Ovanis;Pacanth Reach;Outer Rim Territories;G-16
+Parau;Great Agash;Expansion Region;K-15
+Ovise;Zuma (Moddell);Outer Rim Territories;H-16
+Parcelus Major;Parcelus;Expansion Region;O-12
+Ovissi;Manda;Mid Rim;R-14
+Parcelus Minor;Parcelus;Expansion Region;O-12
+Parcovey Minor;Hune;Mid Rim;Q-12
+Pengalan;;Inner Rim;O-8
+Parein;Sarin;Outer Rim Territories;O-18
+Penhalla;Klina;Outer Rim Territories;S-13
+Pargaux;;Core Worlds;K-12
+Peppel;Corva;Outer Rim Territories;P-3
+Parkella;Elbaran;Mid Rim;J-17
+Per Lupelo;;Inner Rim;L-8
+Parkis;;Colonies;M-10
+Peragus;Xappyh;Outer Rim Territories;Q-4
+Parlatal;Javin (Yarith);Outer Rim Territories;K-18
+Pergitor;Minos Cluster;Outer Rim Territories;M-20
+Parliock;Ariarch;Mid Rim;J-6
+Peridon's Folly;Esaga;Mid Rim;Q-11
+Parmel;Parmel;Outer Rim Territories;O-18
+Perilious;Pelgrin;Outer Rim Territories;R-17
+Parmic;Parmic;Outer Rim Territories;P-19
+Perilix;;Colonies;L-9
+Parnassos;;Unknown Regions;H-6
+Perimako Major;Ash Worlds;Outer Rim Territories;S-7
+Parozha;Dustig;Mid Rim;M-16
+Perin;Trianii Space*;Wild Space;R-3
+Parshoone;Perinn;Outer Rim Territories;J-4
+Perithal;;Inner Rim;N-14
+Parthovian Cluster;;Wild Space;T-4
+Perlandia;Stensen;Outer Rim Territories;I-17
+Partold;Instrop;Outer Rim Territories;T-17
+Perlemia;;Core Worlds;L-9
+Parwa;Seswenna;Outer Rim Territories;M-18
+Perma;;Core Worlds;M-11
+Pas'sic;Oricho;Outer Rim Territories;M-5
+Permondiri;;Core Worlds;J-13
+Pasa Novo;Onatos;Mid Rim;R-15
+Pernam Minor;Minos Cluster;Outer Rim Territories;M-20
+Pasaana;Ombakond;Expansion Region;O-13
+Pernella;Tapani;Colonies;L-13
+Pasher;;Inner Rim;M-14
+Persavi;Taldot;Mid Rim;Q-9
+Pashvi;;Wild Space;I-5
+Persaya;;Inner Rim;K-8
+Pasmin;Cronese Mandate;Outer Rim Territories;S-6
+Persis;Bes Ber Bikade;Expansion Region;L-15
+Pastil;Abrion;Outer Rim Territories;S-15
+Perthrillia;;Colonies;J-13
+Pastoria;Juris;Outer Rim Territories;P-17
+Pervi;;Colonies;L-13
+Patch;Cademimu;Outer Rim Territories;M-6
+Pervick;Corva;Outer Rim Territories;P-3
+Pathandr;;Inner Rim;O-8
+Pesfavri;;Unknown Regions;G-8
+Patitite Pattuna;Bright Jewel;Mid Rim;L-7
+Peshara;;Core Worlds;L-10
+Patriim;Seswenna;Outer Rim Territories;M-18
+Pesitiin;;Expansion Region;I-8
+Patrolia;;Inner Rim;L-14
+Pesmenben;Teraab;Mid Rim;Q-11
+Paucris Major;Tamarin;Outer Rim Territories;N-18
+Pestoriv;;Colonies;N-12
+Paulking;Centrality;Outer Rim Territories;U-8
+Petabys Station;Halm;Mid Rim;J-16
+Pavia;Tapani;Colonies;L-13
+Petrakis;;Inner Rim;O-11
+Pavo Prime;;Inner Rim;N-10
+Petrusia;Nuon e Safyd;Expansion Region;P-12
+Pax;Kira;Expansion Region;N-16
+Phaeda;Cademimu;Outer Rim Territories;L-6
+PDC3141-02;Trax;Mid Rim;P-10
+Phaegon;Grumani;Outer Rim Territories;N-17
+Pedd;D'Astan;Outer Rim Territories;O-6
+Phandas;;Deep Core;M-11
+Pedducis Chorios;Meridian;Outer Rim Territories;R-7
+Phaseera;Lantillian;Mid Rim;P-8
+Pedorian;Bryx;Mid Rim;R-8
+Phateem;Nouane;Inner Rim;N-8
+Peg Shar;Halla;Mid Rim;R-8
+Phatrong;Thrasybule;Outer Rim Territories;P-6
+Pegg;Tynquay;Outer Rim Territories;R-4
+Phattro;Abrion;Outer Rim Territories;S-15
+Peirs;Kathol;Outer Rim Territories;M-21
+Phelarion;Seswenna;Outer Rim Territories;M-18
+Pelagon;Tapani;Colonies;L-13
+Phelope;Hapes Cluster;Inner Rim;O-9
+Peldon Minor;Cassander;Outer Rim Territories;L-5
+Phelzepham;Esuain;Mid Rim;P-7
+Pelemax;;Colonies;M-9
+Phemis;Corellian;Core Worlds;M-11
+Pelgrin;Pelgrin;Outer Rim Territories;R-17
+Pheryon;;Inner Rim;J-8
+Pelkonen;Koradin;Outer Rim Territories;J-18
+Phibia;Haserian;Mid Rim;Q-15
+Pella;Tapani;Colonies;L-13
+Philaxia;Har Worlds;Expansion Region;J-16
+Pellastrallas;Agarix;Mid Rim;K-18
+Phindar;Demetras;Outer Rim Territories;P-6
+Peluchia;Kurost;Mid Rim;Q-11
+Phinel's Folly;Auril;Outer Rim Territories;R-7
+Pembric;Kathol;Outer Rim Territories;M-21
+Pho Ph'eah;Kalamith;Outer Rim Territories;P-5
+Pencael;;Colonies;M-12
+Phoebus;Thanium;Outer Rim Territories;R-6
+Pendal;Homon;Mid Rim;M-7
+Phorliss;Dolomar;Core Worlds;K-9
+Pendari;Vensensor;Expansion Region;K-16
+Phorose;;Colonies;M-13
+Pendarr;Alchenaut;Expansion Region;L-15
+Phorsa Gedd;Dohlbani;Mid Rim;R-13
+Pendaxa;Jjannex;Outer Rim Territories;K-19
+Phosphura Belt Nebula;Atravis;Outer Rim Territories;L-20
+Penegelen;;Inner Rim;L-14
+Phothrell;;Inner Rim;M-8
+Penga;;Inner Rim;N-10
+Phr'sha;Fei Hu;Mid Rim;P-13
+Phracas;;Core Worlds;J-10
+Polis Massa;Subterrel;Outer Rim Territories;K-20
+Phraetiss;Farrfin;Core Worlds;K-9
+Pollillus;Vannell;Core Worlds;J-10
+Phrill;Astal;Outer Rim Territories;P-17
+Polmanar;Javin (Anoat);Outer Rim Territories;K-18
+Phu;;Colonies;J-13
+Poln;(Candoras);Outer Rim Territories;J-5
+Picadir;Mayagil;Outer Rim Territories;N-18
+Polneye;Farlax;Core Worlds;K-10
+Pickerin;Bright Jewel;Mid Rim;L-7
+Polomie;Oriolan;Mid Rim;J-16
+Picutorion;Kwymar;Outer Rim Territories;Q-4
+Polordio;Danjar;Outer Rim Territories;M-19
+Pieldi;Juvex;Mid Rim;L-18
+Polroth;Bryx;Mid Rim;R-8
+Pii;Arkanis;Outer Rim Territories;R-16
+Polus;Oricho;Outer Rim Territories;M-6
+Pijal;;Inner Rim;L-8
+Polyneus;;Inner Rim;J-14
+Pil Diller;Quelii;Outer Rim Territories;O-6
+Pondakree;;Colonies;N-12
+Piluvia;Torch Nebula;Outer Rim Territories;P-19
+Pondut Station;Corporate Sector;Outer Rim Territories;S-4
+Pinara;Sujimis;Outer Rim Territories;P-19
+Ponemah;Zuma (Spar);Outer Rim Territories;H-16
+Pindra;;Inner Rim;N-9
+Ponolapo;Atravis;Outer Rim Territories;L-19
+Pinett;Elrood;Outer Rim Territories;M-20
+Ponton;Tharin;Outer Rim Territories;S-8
+Pinoora;Gordian Reach;Outer Rim Territories;P-6
+Pontus;Tolonda;Outer Rim Territories;Q-18
+Pinperu;Calamari;Outer Rim Territories;U-6
+Porchello;Elbaran;Mid Rim;J-17
+Pinurquia;Rolion;Outer Rim Territories;Q-7
+Poressi;Dantus;Outer Rim Territories;K-6
+Pioku;Trans-Jardeen;Expansion Region;K-15
+Pormthulis;Kira;Expansion Region;N-16
+Pion;;Wild Space;H-14
+Porpor;Grohl;Outer Rim Territories;S-16
+Pipada;Videnda;Outer Rim Territories;M-18
+Port Bianco;;Colonies;L-13
+Pippip;Illisurevimurasi;Outer Rim Territories;Q-4
+Port Evokk;Senex;Mid Rim;L-18
+Pipyyr;Bakura;Outer Rim Territories;G-16
+Port Ferrule;Suolriep (Iotran Expanse);Outer Rim Territories;S-8
+Pirik;Tharin (Divis Arm);Outer Rim Territories;S-8
+Port Jerrell;Koradin;Outer Rim Territories;J-18
+Pirin;Locris;Expansion Region;O-8
+Port Lasgo;Bheriz;Outer Rim Territories;U-10
+Piroket;Arkanis;Outer Rim Territories;R-16
+Port Lennax;Ojoster;Outer Rim Territories;N-7
+Pirol;Farlax;Core Worlds;K-10
+Port Mackie;Deadalis;Expansion Region;J-7
+Pirralor;Juvex;Mid Rim;L-18
+Port Nowhere;;Wild Space;H-19
+Pirsen;Eidoloni;Mid Rim;L-16
+Port Yonder;Pelgrin;Outer Rim Territories;R-18
+Pitann;Kathol;Outer Rim Territories;M-21
+Portminia;Sprizen;Outer Rim Territories;N-5
+Piton;;Core Worlds;K-12
+Portocari;Belsmuth;Outer Rim Territories;O-6
+Pitrillistia;Mieru'kar;Outer Rim Territories;O-3
+Porus Vida;;Inner Rim;O-9
+Pits of Plooma;Veragi;Outer Rim Territories;L-3
+Poseidenna;Calamari;Outer Rim Territories;U-7
+Piu;Kallea;Outer Rim Territories;K-21
+Pothor;Roche;Mid Rim;Q-8
+Pizilis;Terr'skiar;Mid Rim;P-10
+Pouffra;Rolion;Outer Rim Territories;Q-7
+Pizkoss;;Core Worlds;K-10
+Povanaria;Gordian Reach;Outer Rim Territories;P-6
+Pkihantri;;Core Worlds;L-12
+Poviduze;;Expansion Region;J-14
+Pkori;;Wild Space;J-5
+Poytta;;Hutt Space;T-12
+Plavin;;Colonies;L-9
+Pozzi;Tapani;Colonies;L-13
+Plavonia;Kriz;Outer Rim Territories;J-18
+Praadost;Nembus;Outer Rim Territories;P-4
+Plazir;;Outer Rim Territories;N-2
+Praesitlyn;Sluis;Outer Rim Territories;M-19
+Pleem's Nexus;Mezeg;Mid Rim;N-7
+Prahvin;;Inner Rim;M-14
+Pleida;Oricho;Outer Rim Territories;M-6
+Praidaw;;Inner Rim;K-14
+Pleknok;;Unknown Regions;G-9
+Prakith;;Deep Core;K-10
+Plesstil;Veragi;Outer Rim Territories;L-3
+Prakith Minor;;Colonies;L-9
+Plexis;;Core Worlds;L-13
+Praktin;Thusa;Mid Rim;O-7
+Plin Minor;;Inner Rim;K-14
+Pral;;Wild Space;L-21
+Ploo;Ploo;Expansion Region;N-7
+Prandril;Minos Cluster;Outer Rim Territories;M-20
+Plood;Pacanth Reach;Outer Rim Territories;G-16
+Praven Prime;Quelii;Outer Rim Territories;O-6
+Plooriod;Ploo;Expansion Region;N-7
+Praxat Sil;Jidlor Marches;Mid Rim;J-16
+Pluthan;;Wild Space;U-8
+Praxlis;Praxlis;Core Worlds;J-10
+Plympto;Corellian;Core Worlds;M-11
+Praya;Clacis;Outer Rim Territories;K-4
+Po'yin;Phelleem;Outer Rim Territories;S-7
+Prazhi;Cyrillian Protectorate;Expansion Region;O-12
+Poderis;Orus;Inner Rim;M-8
+Prefsbelt;Prefsbelt;Outer Rim Territories;K-5
+Polaar;Eidoloni;Mid Rim;L-16
+Prekaz;;Core Worlds;K-9
+Polanis;Corellian;Core Worlds;M-11
+Presbalin;Gordian Reach;Outer Rim Territories;P-6
+Pressylla;Oricho;Outer Rim Territories;M-6
+Qlothos;;Inner Rim;M-14
+Presteen;Senex;Mid Rim;L-17
+Qonto;;Wild Space;J-3
+Prexiar;Steniplis;Outer Rim Territories;L-19
+Qoribu;;Unknown Regions;H-7
+Pria;;Core Worlds;M-10
+Qotile;Colundra;Outer Rim Territories;S-5
+Prildaz;Farlax;Core Worlds;K-10
+Qretu;;Inner Rim;L-15
+Primarin;;Inner Rim;M-13
+Qu'mock;Kathol;Outer Rim Territories;M-21
+Primea;Vak Combine*;Unknown Regions;F-7
+Quadrant Seven;Barsa;Mid Rim;J-6
+Primtara;Primtara;Mid Rim;P-15
+Quaensan Prime;Gendius;Mid Rim;J-17
+Primus Cabru;Allied Tion;Outer Rim Territories;S-6
+Quaggia;;Hutt Space;S-9
+Prine;Vilonis;Mid Rim;O-16
+Qualai;Kallea;Outer Rim Territories;K-20
+Priole Danna;Sprizen;Outer Rim Territories;O-5
+Qualtrough;Belsmuth;Outer Rim Territories;O-6
+Prishardia;Antemeridian;Outer Rim Territories;R-7
+Quamar;Bruanii;Mid Rim;K-17
+Prishella;Kessel;Outer Rim Territories;T-10
+Quan-Shui;Montitian Grant;Expansion Region;J-15
+Procopia;Tapani;Colonies;L-13
+Quanducial;Gordian Reach;Outer Rim Territories;Q-6
+Prolifera;Corosi;Outer Rim Territories;N-6
+Quanton;Obtrexta;Outer Rim Territories;K-4
+Promencius;Thanium;Outer Rim Territories;S-5
+Quarmendy;Yucrales;Mid Rim;R-15
+Prospera Jang;Kurost;Mid Rim;Q-11
+Quarzite;;Inner Rim;M-13
+Protazk;Kwymar;Outer Rim Territories;Q-4
+Quas Killam;Terr'skiar;Mid Rim;P-10
+Protobranch;;Core Worlds;J-13
+Queel;Doldur;Mid Rim;P-15
+Protogeyser;;Inner Rim;K-8
+Quelii;Quelii;Outer Rim Territories;O-6
+Proxima Dibal;;Wild Space;Q-3
+Quell;Nuiri;Outer Rim Territories;Q-6
+Pugal;Glythe;Mid Rim;J-7
+Quellor;Quellor;Colonies;N-12
+Pulassas Minor;Koradin;Outer Rim Territories;J-18
+Quellus;;Wild Space;G-14
+Puloorn;Spinward;Outer Rim Territories;M-3
+Queluhan Nebula;;Wild Space;H-12
+Purala;Kibilini;Outer Rim Territories;Q-17
+Quence;Quence;Outer Rim Territories;O-18
+Purcassia;;Colonies;L-13
+Quenk;Corusca;Core Worlds;L-9
+Purnham;Shelsha;Colonies;M-9
+Quermia;Nilgaard;Outer Rim Territories;S-5
+Pursin;Atravis;Outer Rim Territories;L-19
+Ques;;Hutt Space;S-8
+Pusat Station;Halla;Mid Rim;R-8
+Quesaya;Andirma;Expansion Region;L-15
+Pybus;;Hutt Space;S-11
+Quesh;;Hutt Space;S-10
+Pygorix;Gordian Reach;Outer Rim Territories;Q-6
+Quesna;Toblain;Outer Rim Territories;O-18
+Pyjridj;Agarix;Mid Rim;K-17
+Questal;Questal;Core Worlds;J-12
+Pyolli;Seswenna;Outer Rim Territories;M-18
+Quethold;;Unknown Regions;I-5
+Pypin;Trianii Space*;Wild Space;R-3
+Queyta;Danjar;Outer Rim Territories;M-19
+Pyra;Fei Hu;Mid Rim;P-13
+Quian;;Core Worlds;L-9
+Pyrlix Miasma;Tyus;Mid Rim;N-16
+Quiberon;Quiberon;Outer Rim Territories;T-15
+Pyros;;Colonies;K-13
+Quila;Rolion;Outer Rim Territories;P-7
+Pyrr;;Wild Space;U-6
+Quilan;Roche;Mid Rim;Q-8
+Pzandias;Bryx;Mid Rim;S-7
+Quilken;Abrion;Outer Rim Territories;R-15
+Pzob;Herios;Outer Rim Territories;T-15
+Quint;;Inner Rim;M-8
+Q'Maere;Kathol;Outer Rim Territories;M-21
+Quintar Nebula;Surron;Expansion Region;O-13
+Q'mara;Juvex;Mid Rim;L-18
+Quintarad, The;;Wild Space;H-18
+Q'nithian;Nembus;Outer Rim Territories;P-4
+Quintil;Svivreni;Outer Rim Territories;N-19
+Qalita Prime;;Inner Rim;J-13
+Quintus;Albarrio;Outer Rim Territories;K-5
+Qalydon;Sertar;Outer Rim Territories;R-5
+Quockra;Minos Cluster;Outer Rim Territories;M-20
+Qaras;(Minyavi);Mid Rim;I-16
+Quooria;Farstey;Expansion Region;O-8
+Qat Chrystac;Parnabe;Expansion Region;L-16
+Quyste;Thesme;Outer Rim Territories;O-6
+Qeimet;Juris;Outer Rim Territories;P-17
+R-Duba;Quiberon;Outer Rim Territories;T-15
+Qemia;Strabin;Mid Rim;M-7
+R'alla;Corporate Sector;Outer Rim Territories;S-3
+Qexis;Danjar;Outer Rim Territories;N-19
+R'terleD'er;Kriz;Outer Rim Territories;J-18
+Qhulosk;Tharin;Outer Rim Territories;T-8
+Raada;D'Astan;Outer Rim Territories;O-5
+Qi Lozar;Grumani;Outer Rim Territories;M-17
+Raamen;Tacuni;Expansion Region;N-15
+Qiaxx;Cor'ric;Outer Rim Territories;P-18
+Rachuk;Rachuk;Colonies;N-11
+Qiilura;Qiilura;Mid Rim;L-7
+Radama Void;Esstran;Outer Rim Territories;Q-5
+Qina;Zuma (Moddell);Outer Rim Territories;H-16
+Raddan;Tharin;Outer Rim Territories;S-8
+Qixoni Nebula;;Colonies;K-13
+Radhii;;Wild Space;I-18
+Radnor;Daimar;Mid Rim;Q-16
+Ravaath;Pacanth Reach;Outer Rim Territories;H-16
+Raed;;Colonies;N-11
+Ravager's Rift;Iska;Mid Rim;J-17
+Rafa;Centrality;Outer Rim Territories;T-8
+Raxus Prime;Tion Hegemony;Outer Rim Territories;S-5
+Rafft;;Inner Rim;J-8
+Raxxa;;Core Worlds;M-10
+Ragith;Majoor;Expansion Region;N-15
+Raydonia;Belsmuth;Outer Rim Territories;O-6
+Ragmar;Karthakk;Outer Rim Territories;Q-17
+Raysol Prime;Duluur;Colonies;M-13
+Ragna;Daimar;Mid Rim;Q-16
+Razia;;Colonies;M-13
+Ragnar;Merel;Outer Rim Territories;Q-18
+Rbollea;Hapes Cluster;Inner Rim;O-9
+Ragnook;Bothan;Mid Rim;R-14
+Reamma;Corbett;Mid Rim;I-17
+Rago;;Wild Space;I-7
+Reaper's World;Nilgaard;Outer Rim Territories;S-5
+Ragoon;;Core Worlds;K-9
+Rearqu Cluster;Taldot;Mid Rim;P-8
+Raider's Point;Corellian;Core Worlds;M-11
+Reboam;Hapes Cluster;Inner Rim;O-9
+Rainboh;Hapes Cluster;Inner Rim;O-9
+Recluse's Nebula;Irishi;Mid Rim;K-6
+Rainbow Nebulae;Hunnoverrs;Outer Rim Territories;R-16
+Recopia;;Core Worlds;M-11
+Rainos Cluster;Rocantor;Expansion Region;L-15
+Red Hand Cluster;Trax;Mid Rim;Q-10
+Raithal;;Colonies;M-9
+Red Nebula;;Wild Space;G-21
+Rajtiri;Dona Laza;Expansion Region;P-9
+Red Twins, The;;Wild Space;I-7
+Rakaa;;Core Worlds;J-12
+Red Yars;Croynar;Inner Rim;M-14
+Rakata Prime;;Unknown Regions;G-11
+Redcap;Savareen;Outer Rim Territories;Q-17
+Rakhuuun;Mytaranor;Mid Rim;Q-10
+Redhurne;Metatessu;Mid Rim;R-9
+Rakrir;Kwymar;Outer Rim Territories;Q-4
+Redoubt, The;;Unknown Regions;H-7
+Ralchon;Gaulus;Outer Rim Territories;S-17
+Redrish;Kuat;Core Worlds;M-10
+Ralgos;Esstran;Outer Rim Territories;Q-5
+Redspace Reefs;Oktos;Mid Rim;R-12
+Ralltiir;Darpa;Core Worlds;L-9
+Reecee;;Inner Rim;J-8
+Ralme;Brak;Expansion Region;O-14
+Reega;Demetras;Outer Rim Territories;P-7
+Raltac;;Inner Rim;K-8
+Reegian;Sumitra;Expansion Region;O-7
+Ramoa;Sprizen;Outer Rim Territories;N-5
+Reena;Tapani;Colonies;L-13
+Ramodi;Tregillis;Expansion Region;M-15
+Reena Minor;Bothan;Mid Rim;R-14
+Ramook;;Wild Space;O-3
+Reesaria;Bheriz;Outer Rim Territories;U-10
+Ramordia;Majoor;Expansion Region;N-15
+Refgar;Demophon;Core Worlds;M-10
+Ramorea;;Inner Rim;O-7
+Refnar;Pakuuni;Outer Rim Territories;T-6
+Rampa;Corporate Sector;Outer Rim Territories;S-4
+Refnu;Sprizen;Outer Rim Territories;N-5
+Rampa Minor;Baxel;Outer Rim Territories;U-12
+Refrax;Mortex;Outer Rim Territories;R-5
+Ramsir;Jospro;Outer Rim Territories;S-7
+Regalia;Meram;Outer Rim Territories;O-4
+Randa;Kessel;Outer Rim Territories;T-10
+Regalia Station;Cadavine;Outer Rim Territories;P-17
+Randon;Mytaranor;Mid Rim;Q-10
+Regel;;Wild Space;I-7
+Randorn;Belderone;Outer Rim Territories;Q-6
+Regellia;Minos Cluster;Outer Rim Territories;M-20
+Rango Tan;Relgim;Outer Rim Territories;L-5
+Reginard;Pakuuni;Outer Rim Territories;T-6
+Rangorah;Calaron;Outer Rim Territories;T-9
+Regis Kor;Gendius;Mid Rim;J-17
+Ranklinge;Shelsha;Colonies;M-9
+Regolith;;Colonies;N-12
+Rannon;Instrop;Outer Rim Territories;T-17
+Regor-Mada;Tantra;Outer Rim Territories;M-19
+Ranroon;Mortex;Outer Rim Territories;R-5
+Regulan;Albanin;Outer Rim Territories;U-12
+Rantine Space Station;Tamarin;Outer Rim Territories;N-19
+Regulgo;Ryndellian;Mid Rim;P-17
+Rantofar;;Core Worlds;M-11
+Rehemsa;;Core Worlds;M-11
+Rapacc;Paccian Governance*;Unknown Regions;E-7
+Rehn;Brak;Expansion Region;O-14
+Raquish;Lambda;Mid Rim;Q-15
+Reibrin;Suolriep (Ansuroer);Outer Rim Territories;S-8
+Rarlech;;Unknown Regions;H-5
+Reigalius;Yucrales;Mid Rim;Q-15
+Rashfond;;Inner Rim;L-14
+Rekardia;Vensensor;Expansion Region;K-16
+Raskane;Sepan;Expansion Region;P-13
+Rekelos;Arc d'Stot;Expansion Region;K-15
+Raspar;Tragan Cluster;Outer Rim Territories;N-5
+Rekkana;;Core Worlds;L-9
+Rasterous;;Inner Rim;O-10
+Rekkiad;Chorlian;Outer Rim Territories;S-4
+Rata Nebula;Chiss Space*;Unknown Regions;E-9
+Relarr;;Core Worlds;M-10
+Ratamesh;Farstey;Expansion Region;O-8
+Relatta;;Inner Rim;N-8
+Rathalay;Taldot;Mid Rim;R-9
+Relephon;Hapes Cluster;Inner Rim;O-9
+Ratit;;Inner Rim;M-14
+Relik;Steniplis;Outer Rim Territories;L-19
+Rattatak;Trilon;Outer Rim Territories;H-16
+Relkass;Saijo;Outer Rim Territories;K-20
+Rellio;Tapani;Colonies;L-13
+Riesa;Tapani;Colonies;L-13
+Rellnas;Har Worlds;Expansion Region;J-16
+Riflor;Narrant;Mid Rim;J-16
+Reltooine;Corporate Sector;Outer Rim Territories;R-3
+Rigel;Bheriz;Outer Rim Territories;U-11
+Remitik;Wazta;Outer Rim Territories;J-18
+Rigoron;Dimean;Expansion Region;P-13
+Remmon Nebula;Iskin;Mid Rim;O-16
+Rigovia;;Inner Rim;N-8
+Rena;;Colonies;K-13
+Riileb;;Hutt Space;T-12
+Renatasia;Centrality;Outer Rim Territories;U-8
+Rijel;Dalqan;Expansion Region;M-7
+Rend;Surron;Expansion Region;O-13
+Rikadi;;Inner Rim;J-13
+Rendili;;Core Worlds;M-11
+Rikmania;Steniplis;Outer Rim Territories;L-19
+Renegg;Kuat;Core Worlds;M-10
+Rilias;Mayagil;Outer Rim Territories;M-18
+Renforra;Dalicron;Outer Rim Territories;K-20
+Rim;Kibilini;Outer Rim Territories;Q-17
+Renillis;;Inner Rim;L-14
+Rimbaux;Halthor;Outer Rim Territories;M-6
+Rennokk;Kessel;Outer Rim Territories;U-10
+Rimcee Station;Braxant;Outer Rim Territories;J-3
+Rentalles;D'Astan;Outer Rim Territories;O-4
+Rimma;;Core Worlds;L-13
+Rentaxius;;Inner Rim;O-8
+Rina Major;Stensen;Outer Rim Territories;I-17
+Rentean;Jjannex;Outer Rim Territories;K-19
+Rinagom;Corporate Sector;Outer Rim Territories;S-3
+Rentor;Chiss Space*;Unknown Regions;F-8
+Rindao;Hadar;Mid Rim;L-17
+Reo;(Maraqoo);Mid Rim;I-7
+Rindia;Nembus;Outer Rim Territories;P-4
+Reopi;;Core Worlds;M-10
+Rindoon;Rseik;Outer Rim Territories;N-19
+Repea;Auril;Outer Rim Territories;R-7
+Rine-cathe;;Core Worlds;L-9
+Resh 9376;Nuiri;Outer Rim Territories;Q-6
+Ring of Kafrene;Thand;Expansion Region;J-15
+Resht;;Colonies;N-10
+Ring, The;Javin (Anoat);Outer Rim Territories;K-18
+Resilon;Bortele;Mid Rim;S-8
+Ringali Nebula;Bormea;Core Worlds;L-9
+Resti Kel;Juvex;Mid Rim;L-18
+Ringlite;Tamarin;Outer Rim Territories;N-19
+Retep;Daimar;Mid Rim;Q-16
+Ringneldia;Centrality;Outer Rim Territories;T-8
+Rethel Point;Far Xandil;Mid Rim;P-16
+Ringo Vinda;Eucer;Mid Rim;R-7
+Retta;;Wild Space;U-8
+Rinn;Baxel;Outer Rim Territories;U-12
+Rettna;Esaga;Mid Rim;Q-11
+Rintonne;Lambda;Mid Rim;P-16
+Reuss;Portmoak;Outer Rim Territories;P-18
+Rion;Kessel;Outer Rim Territories;T-10
+Reventine;Seswenna;Outer Rim Territories;M-18
+Rior;Tamarin;Outer Rim Territories;N-18
+Revery;Noonian;Outer Rim Territories;N-6
+Riosa;;Inner Rim;J-8
+Revkinn;Parmel;Outer Rim Territories;O-18
+Rirsack;Belsmuth;Outer Rim Territories;O-6
+Revyia;Veragi;Outer Rim Territories;L-2
+Risban;Tion Hegemony;Outer Rim Territories;S-5
+Rex Strata;Wazta;Outer Rim Territories;J-18
+Rishi;Abrion;Outer Rim Territories;S-15
+Reyna;Tapani;Colonies;L-13
+Risso;;Inner Rim;N-14
+Reyniu;Mayagil;Outer Rim Territories;N-18
+Rivoria;Tunka;Outer Rim Territories;J-19
+Reynon;Albarrio;Outer Rim Territories;K-5
+Rivvidu;D'Astan;Outer Rim Territories;O-5
+Reytha;Harron;Expansion Region;O-12
+Ro Mira;Vensori;Mid Rim;P-8
+Rezi;Bajic;Outer Rim Territories;P-17
+Ro-Loo Triangle;Lambda;Mid Rim;P-16
+Rhamalai;Varada;Outer Rim Territories;I-19
+Rocantor;Rocantor;Expansion Region;L-15
+Rhamsis Callo;Danjar;Outer Rim Territories;N-19
+Rocedila;Auril;Outer Rim Territories;R-6
+Rhanipur;Hevvrol;Mid Rim;O-15
+Rocrin;Airam;Outer Rim Territories;M-20
+Rhelg;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Rocun Cluster;Yminis;Outer Rim Territories;S-14
+Rhen Var;Thanium;Outer Rim Territories;R-6
+Rodaj;;Inner Rim;L-15
+Rhigar;Chiss Space*;Unknown Regions;E-9
+Rodia;Savareen;Outer Rim Territories;R-16
+Rhilithan;Indrexu;Outer Rim Territories;S-5
+Rodis;Zuma (Sugai);Outer Rim Territories;H-16
+Rhinnal;Darpa;Core Worlds;L-9
+Rogue Antar;Steniplis;Outer Rim Territories;M-18
+Rhommamool;Merthian;Expansion Region;N-13
+Rohm;Hevvrol;Mid Rim;O-15
+Rhuvia;Relgim;Outer Rim Territories;L-5
+Roil, The;Gordian Reach;Outer Rim Territories;Q-5
+Rial Kroon;Noonian;Outer Rim Territories;M-6
+Rokaria;Tynquay;Outer Rim Territories;Q-4
+Rianon;Tapani;Colonies;L-13
+Rokirex;Herios;Outer Rim Territories;T-16
+Ribento;Quence;Outer Rim Territories;O-19
+Rol;Noonian;Outer Rim Territories;M-6
+Ricaldi;Tapani;Colonies;L-13
+Roldalna;Kira;Expansion Region;N-16
+Riddellia;Albanin;Outer Rim Territories;T-12
+Romar;Galov;Outer Rim Territories;T-13
+Ridlay;Lambda;Mid Rim;P-16
+Romik;Quelii;Outer Rim Territories;O-6
+Ridley;;Inner Rim;L-8
+Romin;Romintine;Mid Rim;Q-8
+Romossobar;Eucer;Mid Rim;R-7
+Ryloon;Velcar;Outer Rim Territories;J-5
+Ronaphaven;Garis;Outer Rim Territories;N-17
+Rylorii Minor;Rocantor;Expansion Region;L-15
+Rondai;;Inner Rim;J-8
+Ryloth;Gaulus (Ryloth);Outer Rim Territories;R-17
+Ronyards;;Inner Rim;N-13
+Rynmar;Hapes Cluster;Inner Rim;O-9
+Roon;Abrion;Outer Rim Territories;S-15
+Ryoone;Wazta;Outer Rim Territories;I-17
+Roona;Bes Ber Bikade;Expansion Region;L-15
+Rystan;;Wild Space;M-20
+Roost;Bitrose;Outer Rim Territories;T-17
+Ryvellia;Treffani;Expansion Region;O-14
+Ropagi;Kira;Expansion Region;N-16
+Ryvester;Meridian;Outer Rim Territories;R-7
+Roqoo Depot;;Inner Rim;O-9
+Ryyk Nebula;Trans-Vulta;Mid Rim;N-7
+Rorak;;Hutt Space;S-12
+RZ7-6113-23;Chopani;Outer Rim Territories;L-4
+Rordak;Pelgrin;Outer Rim Territories;R-17
+Saarn;Esstran;Outer Rim Territories;P-5
+Rorgam;Terr'skiar;Mid Rim;Q-10
+Sab Rufo;;Inner Rim;N-8
+Rotas;Yminis;Outer Rim Territories;S-14
+Sabanash;Tyus;Mid Rim;N-16
+Rothana;Quiberon;Outer Rim Territories;T-15
+Sabata;Halla;Mid Rim;R-9
+Rotoga;Alchenaut;Expansion Region;L-16
+Saberhing;Corellian;Core Worlds;M-11
+Roundtree;;Inner Rim;M-14
+Sabrash;Metatessu;Mid Rim;R-9
+Routh;Velcar;Outer Rim Territories;J-5
+Sabrixin;Samix;Outer Rim Territories;Q-19
+Rowacki;;Inner Rim;O-10
+Saclas;Corporate Sector;Outer Rim Territories;S-4
+Roxuli;(Roxuli);Expansion Region;I-8
+Sacorria;Corellian;Core Worlds;M-11
+Rrulinn;Yushan;Mid Rim;K-17
+Saffa;Halla;Mid Rim;R-8
+Rseik;Rseik;Outer Rim Territories;N-20
+Saffalore;Corporate Sector;Outer Rim Territories;S-4
+RTK111;Yminis;Outer Rim Territories;S-14
+Safrifa;Videnda;Outer Rim Territories;M-18
+Ruac;Lothal;Outer Rim Territories;U-7
+Sag Kemper;Tamarin;Outer Rim Territories;N-18
+Ruan;;Core Worlds;K-10
+Sagar;Wentrion;Inner Rim;N-13
+Ruathi;Jjannex;Outer Rim Territories;K-19
+Sagma;Illisurevimurasi;Outer Rim Territories;Q-4
+Rubinero;;Core Worlds;L-12
+Sahbrontee;;Mid Rim;I-15
+Rubogea;;Core Worlds;L-9
+Saheelindeel;Tion Hegemony;Outer Rim Territories;S-6
+Rudrig;Tion Hegemony;Outer Rim Territories;S-6
+Saijo;Saijo;Outer Rim Territories;K-20
+Rudun;Kontahr;Mid Rim;R-11
+Saila Na;Javin (Anoat);Outer Rim Territories;K-18
+Rugosa;Sanbra;Outer Rim Territories;O-17
+Sakavi Tar;;Outer Rim Territories;I-19
+Ruhe;Savareen;Outer Rim Territories;Q-17
+Saki;;Hutt Space;S-11
+Ruhnuk;;Wild Space;G-13
+Sakidopa;;Hutt Space;S-11
+Ruisto;Calamari;Outer Rim Territories;U-6
+Sakiduba;;Hutt Space;S-11
+Rulaar;Senex;Mid Rim;L-17
+Sakifwanna;;Hutt Space;T-11
+Rullag;Cadma;Outer Rim Territories;T-8
+Sakreen;Ash Worlds;Outer Rim Territories;S-7
+Ruloosia;Oktos;Mid Rim;R-12
+Sakuub;Pelgrin;Outer Rim Territories;R-18
+Rumil;Mezeg;Mid Rim;N-7
+Salagor;;Inner Rim;N-13
+Runaway Prince;;Hutt Space;R-11
+Salaktori Anchorage;;Inner Rim;O-10
+Ruoss Minor;;Colonies;M-9
+Salaniss;;Wild Space;H-17
+Rurgavea;;Core Worlds;L-13
+Saleucami;Suolriep;Outer Rim Territories;S-8
+Rushan;Andirma;Expansion Region;L-15
+Salgarus;;Colonies;L-9
+Rustibar;Churnis;Mid Rim;J-7
+Salient;Aparo;Outer Rim Territories;R-3
+Rutal;;Wild Space;J-13
+Salin;Sprizen;Outer Rim Territories;N-5
+Rutan;Atravis;Outer Rim Territories;L-20
+Salissia;;Outer Rim Territories;T-5
+Ruugia;Altier;Expansion Region;O-13
+Salliche;;Core Worlds;K-10
+Ruul;;Core Worlds;M-10
+Salmagodro;;Inner Rim;M-8
+Ruuria;Xappyh;Outer Rim Territories;Q-3
+Salobea;Noonian;Outer Rim Territories;M-6
+Ruusan;Teraab;Mid Rim;P-11
+Salstan;Marzoon;Mid Rim;I-16
+Ruweln;Bothan;Mid Rim;R-14
+Saltear;Tarabba;Outer Rim Territories;M-19
+Rya;Kwymar;Outer Rim Territories;P-4
+Salteract;Rayter;Outer Rim Territories;J-19
+Ryarten;Corthenia;Mid Rim;K-7
+Salvara;Tennuutta;Mid Rim;Q-7
+Ryborea;Ryborean;Expansion Region;J-8
+Samaria;;Core Worlds;M-11
+Rycep;Jjannex;Outer Rim Territories;L-19
+Samarine;D'Astan (Samarine);Outer Rim Territories;O-5
+Rychel;Dalonbian;Outer Rim Territories;L-2
+Samhar;Grumani;Outer Rim Territories;N-17
+Rydar;Antemeridian;Outer Rim Territories;R-7
+Sammun;Ash Worlds (Batonn);Outer Rim Territories;T-7
+Rydonni Prime;;Core Worlds;M-11
+Samovar;Koradin;Outer Rim Territories;I-18
+Sanbra;Sanbra;Outer Rim Territories;O-17
+Sechar;Tharin (Divis Arm);Outer Rim Territories;S-8
+Sandonia;;Inner Rim;N-14
+Secundus Ando;Lambda;Mid Rim;Q-15
+Sanej;;Inner Rim;N-13
+Sedapard Cluster;;Mid Rim;O-16
+Sanjin;;Colonies;M-13
+Sedesia;Druess;Mid Rim;O-16
+Sanrafsix;Grumani;Outer Rim Territories;N-17
+Sedratis;;Core Worlds;M-11
+Santarine;Hook Nebula;Outer Rim Territories;O-18
+Sedri;Tharin (Periphery);Outer Rim Territories;S-8
+Santheria;Esuain;Mid Rim;Q-7
+Seelos;Kwymar;Outer Rim Territories;Q-4
+Sanyassa;Zuma (Moddell);Outer Rim Territories;H-16
+Seeratter;;Wild Space;G-14
+Sanza;Sloo;Mid Rim;P-14
+Seezar's Planet;Jjannex;Outer Rim Territories;L-19
+Sapella;Kathol;Outer Rim Territories;M-21
+Sefon;Tapani;Colonies;L-13
+Sappire;Dalicron;Outer Rim Territories;K-20
+Seftek;Vorzyd;Outer Rim Territories;R-6
+Saqqar;;Hutt Space;T-11
+Segra Milo;Jospro;Outer Rim Territories;R-7
+Saracor;Oriolan;Mid Rim;J-16
+Seidhkona;;Wild Space;T-5
+Saraf Cobar;Montitian Grant;Expansion Region;J-15
+Seikosha;Nembus;Outer Rim Territories;P-4
+Sarapin;;Core Worlds;M-10
+Seitia Prime;Seitia;Outer Rim Territories;K-19
+Sarconia;;Colonies;M-10
+Selab;Hapes Cluster;Inner Rim;O-9
+Sardoran;;Core Worlds;M-11
+Selaggis;Quelii;Outer Rim Territories;N-6
+Sareet;Stensen;Outer Rim Territories;I-17
+Selavia;Suolriep;Outer Rim Territories;S-10
+Sargesso;Tharin;Outer Rim Territories;S-8
+Selenius;D'Aelgoth;Mid Rim;L-17
+Sargon;Hapes Cluster;Inner Rim;O-9
+Seline;Dalonbian;Outer Rim Territories;M-3
+Sarina;Mektrun;Mid Rim;L-17
+Selitan;Gordian Reach;Outer Rim Territories;P-6
+Sarjenn;Tragan Cluster;Outer Rim Territories;N-5
+Sellasas;Jjannex;Outer Rim Territories;L-18
+Sarka;Sarka;Mid Rim;Q-8
+Selnesh;Irishi;Mid Rim;K-6
+Sarkania;;Inner Rim;M-14
+Selsor;Zarracina;Expansion Region;O-14
+Sarkhai;M'shinni;Mid Rim;M-7
+Seltaya Major;Mieru'kar;Outer Rim Territories;O-3
+Sarko;Venzeiia;Expansion Region;O-12
+Seltos;Mulgard;Mid Rim;N-16
+Sarlucif;;Wild Space;S-4
+Seluket;;Inner Rim;I-9
+Sarm;;Wild Space;I-8
+Selvaris;;Wild Space;I-9
+Sarnikken;Fakir;Colonies;K-9
+Selvernis;Svivreni;Outer Rim Territories;O-19
+Sarnus;;Wild Space;O-3
+Semag;Semagi;Mid Rim;I-16
+Sarpazia;Illodia;Core Worlds;K-13
+Sembla;Sertar (Mahrusha);Outer Rim Territories;S-5
+Sarq;;Mid Rim;I-15
+Senex;Senex;Mid Rim;L-17
+Sarrahban;Cyrillian Protectorate;Expansion Region;O-12
+Sennatt;Bothan;Mid Rim;R-14
+Sarranket;Brevost;Expansion Region;O-15
+Sennex;Hapes Cluster;Inner Rim;O-9
+Sarrassia;Grumani;Outer Rim Territories;N-17
+Sennoa;Ojoster;Outer Rim Territories;N-7
+Sarrelon;Brevost;Expansion Region;O-15
+Senthrodys;;Inner Rim;O-10
+Sarrish;Vensensor;Expansion Region;K-16
+Sentuvia;;Inner Rim;N-8
+Sartoy;Mieru'kar;Outer Rim Territories;N-3
+Seoul;;Wild Space;H-20
+Sarumo;Merel;Outer Rim Territories;Q-19
+Sepan;Sepan;Expansion Region;P-13
+Saruwen Station;Tamarin;Outer Rim Territories;N-18
+Septevorres;Antemeridian;Outer Rim Territories;R-7
+Sarvchi;Chiss Space*;Unknown Regions;F-9
+Septra;Kathol;Outer Rim Territories;M-20
+Sason;Cassander (Tadrin);Outer Rim Territories;K-5
+Seraphan;;Colonies;N-10
+Sathiemon;Illisurevimurasi;Outer Rim Territories;Q-4
+Serat;Senex;Mid Rim;L-18
+Sauwecer;Videnda;Outer Rim Territories;L-18
+Sereeda;Ash Worlds;Outer Rim Territories;T-7
+Savareen;Savareen;Outer Rim Territories;Q-16
+Seregar;Calaron;Outer Rim Territories;U-9
+Savek;Esstran (Sith Worlds);Outer Rim Territories;R-4
+Serelia;Oriolan;Mid Rim;J-16
+Sawaya;Thesme;Outer Rim Territories;O-6
+Serenity;Tashtor;Mid Rim;J-16
+Sayblohn;Quess;Mid Rim;N-16
+Serenno;D'Astan;Outer Rim Territories;P-5
+Scarif;Abrion;Outer Rim Territories;S-15
+Sergia;Kalakan;Inner Rim;J-15
+Scarl;Tapani;Colonies;L-13
+Serianan;;Wild Space;P-2
+Schesa;Chiss Space*;Unknown Regions;F-8
+Sermeria;Locris;Expansion Region;O-8
+Scillal;Centrality;Outer Rim Territories;T-8
+Sern Prime;Sern;Colonies;L-13
+Scipio;Albarrio;Outer Rim Territories;K-5
+Sernpidal;Dalonbian;Outer Rim Territories;L-3
+Seatos;Sluis;Outer Rim Territories;M-19
+Serolonis;Kriz;Outer Rim Territories;J-18
+Sebaddon;;Mid Rim;Q-11
+Serpine;Illisurevimurasi;Outer Rim Territories;Q-4
+Sebiris;Kathol;Outer Rim Territories;M-21
+Serria;Rocantor;Expansion Region;L-15
+Serroco;Ploo;Expansion Region;N-7
+Shi'kar Straits;Nembus;Outer Rim Territories;P-4
+Serule;;Core Worlds;K-9
+Shibric;;Inner Rim;N-14
+Sesid;Corva;Outer Rim Territories;P-4
+Shifa;Tapani;Colonies;L-13
+Sespe;Tharin (Periphery);Outer Rim Territories;S-9
+Shiffrin;Tammuz;Outer Rim Territories;T-15
+Sestina;;Core Worlds;M-11
+Shihon;Chiss Space*;Unknown Regions;E-8
+Sestooine;Relgim;Outer Rim Territories;L-5
+Shikitari;;Unknown Regions;G-14
+Sestria;Testarr;Core Worlds;M-13
+Shili;Ehosiq;Expansion Region;L-8
+Seswenna;Seswenna;Outer Rim Territories;M-18
+Shimia;Dalchon;Outer Rim Territories;R-17
+Setar;Inner Cluster;Inner Rim;O-11
+Shimmer;Rayter;Outer Rim Territories;J-19
+Setolio;Tapani;Colonies;L-13
+Shinbone;;Wild Space;T-17
+Setor;;Colonies;L-8
+Shindra;Tapani;Colonies;L-13
+Setron;Noori;Expansion Region;O-11
+Shintel;Kathol;Outer Rim Territories;M-21
+Sev Tok;Kurost;Mid Rim;Q-11
+Shiva;;Wild Space;L-21
+Sevarcos;Tamarin;Outer Rim Territories;N-19
+Shogun;Quence;Outer Rim Territories;O-18
+Sevari;Chorlian;Outer Rim Territories;S-4
+Shola;Tammuz;Outer Rim Territories;U-14
+Sevetta;Sevetta;Outer Rim Territories;T-16
+Shoon;Senex;Mid Rim;L-18
+Sewalia;;Inner Rim;L-14
+Shopani;Tapani;Colonies;L-13
+Seylott;Sarin;Outer Rim Territories;P-18
+Shoroni;;Colonies;M-9
+Seymarti;;Colonies;M-13
+Shosho;Graador;Mid Rim;I-17
+Seyugi;;Core Worlds;M-11
+Shotem;;Colonies;J-13
+Sh'ung-tesk;Ciutric;Outer Rim Territories;N-4
+Shownar;Parmic;Outer Rim Territories;P-19
+Sha'rellia;;Hutt Space;S-12
+Shramar;Clacis;Outer Rim Territories;K-4
+Shackel;Chaykin;Expansion Region;O-14
+Shrokaan;Baroli;Expansion Region;N-14
+Shadda Nebula;Toblain;Outer Rim Territories;O-18
+Shu-Torun;Chaama;Mid Rim;J-7
+Shador;Maerdocian;Mid Rim;Q-13
+Shuldene;Javin (Yarith);Outer Rim Territories;J-18
+Shadren;Belsmuth;Outer Rim Territories;O-6
+Shulstine;;Colonies;M-9
+Shafr;Toblain;Outer Rim Territories;O-17
+Shulxi;;Core Worlds;L-12
+Shahkir;;Inner Rim;M-14
+Shumari;Parmel;Outer Rim Territories;O-18
+Shalam;;Inner Rim;M-7
+Shumavar;Atravis;Outer Rim Territories;L-19
+Shalankie;;Inner Rim;O-9
+Shumogi;;Core Worlds;M-12
+Shallow March;Mortex;Outer Rim Territories;S-5
+Shuraden;Koradin;Outer Rim Territories;I-18
+Shalm;Zuma (Ikenomin);Outer Rim Territories;H-16
+Shurrupak;Vulcusion;Expansion Region;L-16
+Shaltin;Thanium;Outer Rim Territories;S-6
+Shusugaunt;Raioballo;Outer Rim Territories;L-4
+Shalyvane;Indrexu;Outer Rim Territories;S-5
+Shuxl;Javin (Yarith);Outer Rim Territories;K-18
+Shantipole;Roche;Mid Rim;Q-8
+Sibensko;Bes Ber Bikade;Expansion Region;L-15
+Shar'Ack;Atrivis;Outer Rim Territories;L-5
+Sibetta;Gomar;Inner Rim;K-14
+Sharb;Chiss Space*;Unknown Regions;F-8
+Sibilaar;Bozhnee;Outer Rim Territories;L-18
+Shard;Wazta;Outer Rim Territories;J-18
+Sibisime;Sombure;Mid Rim;K-17
+Sharlissia;Bon'nyuw-Luq;Outer Rim Territories;N-18
+Sídi;Illisurevimurasi;Outer Rim Territories;Q-4
+Shasa;;Inner Rim;N-12
+Sienar TF73;Tharin;Outer Rim Territories;S-8
+Shasfath;;Inner Rim;J-14
+Sif-Alula;Trestis;Expansion Region;K-8
+Shatuun;Kathol;Outer Rim Territories;M-21
+Sif-Uwana;;Colonies;K-8
+Shaum Hii;Tragan Cluster;Outer Rim Territories;N-5
+Sif'kric;Mezeg;Mid Rim;M-7
+Shawken;;Core Worlds;L-9
+Sifuchi;Lostar;Expansion Region;M-7
+Shawti;;Hutt Space;S-9
+Sigil;Chorlian;Outer Rim Territories;S-4
+Shaylin;Pakuuni;Outer Rim Territories;T-6
+Sigma Station;Demetras;Outer Rim Territories;P-7
+Shaymore;Immerian Outback;Expansion Region;N-14
+Sika;Brevost;Expansion Region;O-15
+Shedu Maad;Hapes Cluster;Inner Rim;O-9
+Sikkem;Thanium;Outer Rim Territories;R-6
+Sheela;Abrion;Outer Rim Territories;S-15
+Sikurd;Tynquay;Outer Rim Territories;Q-4
+Sheh Soahi;Cassander;Outer Rim Territories;K-5
+Sil Gohtta;Lol;Outer Rim Territories;Q-18
+Shelkonwa;Shelsha;Colonies;M-9
+Sil'Lume;Seitia;Outer Rim Territories;K-19
+Shella;Tapani;Colonies;L-13
+Sileria;Corellian;Core Worlds;M-11
+Shenio;Kalamith;Outer Rim Territories;P-5
+Silken;;Wild Space;O-20
+Sheris;Belsmuth;Outer Rim Territories;O-6
+Silla;Strabin;Mid Rim;M-7
+Shesharile;Minos Cluster;Outer Rim Territories;M-20
+Silorna;Imberlin;Expansion Region;P-13
+Sheva;Tapani;Colonies;L-13
+Silunes;Arc d'Stot;Expansion Region;K-15
+Siluria;Atravis;Outer Rim Territories;L-19
+Slession;;Inner Rim;K-14
+Silver Station;Doldur;Mid Rim;P-15
+Slivia;Astal;Outer Rim Territories;Q-17
+Silversisi;;Inner Rim;M-8
+Sljee;Ehosiq;Expansion Region;M-8
+Silvestri;Ado;Mid Rim;L-17
+Sloogaria;Rseik;Outer Rim Territories;N-19
+Sim'char'ser;Albanin;Outer Rim Territories;U-12
+Slotern;Wazta;Outer Rim Territories;J-18
+Simbarc;Cadma;Outer Rim Territories;T-8
+Sluis Van;Sluis;Outer Rim Territories;M-19
+Simento-Threk;Meram;Outer Rim Territories;O-4
+Sluudren;Chorlian;Outer Rim Territories;S-4
+Simik;;Inner Rim;L-14
+Smarab;Dohlbani;Mid Rim;R-14
+Simocadia;;Inner Rim;J-13
+Smarck;Cademimu;Outer Rim Territories;K-6
+Simoom;Senex;Mid Rim;L-18
+Smarteel;;Wild Space;U-14
+Simoth;Mortex;Outer Rim Territories;R-5
+Smuggler's Run;Gaulus;Outer Rim Territories;S-18
+Simpla;Kalamith;Outer Rim Territories;O-5
+Sneeve;Kastolar;Mid Rim;Q-10
+Simra;;Colonies;L-13
+Snevu;;Unknown Regions;H-7
+Sinded;D'Aelgoth;Mid Rim;L-17
+Snowdn;Centrality;Outer Rim Territories;U-8
+Sinjan;Albarrio;Outer Rim Territories;K-5
+Snugano;Spirva;Mid Rim;L-17
+Sinkar;Fakir;Colonies;K-9
+Sochi;;Inner Rim;M-9
+Sinsang;Raioballo;Outer Rim Territories;L-4
+Soco-Jarel;Xappyh;Outer Rim Territories;Q-4
+Sinta;Hune;Mid Rim;Q-12
+Socorro;Kibilini;Outer Rim Territories;Q-17
+Sintheti;Noonian;Outer Rim Territories;N-6
+Soika;;Inner Rim;M-8
+Sinton;Rago;Mid Rim;I-7
+Sojourn;Carrion;Outer Rim Territories;J-4
+Siola;;Core Worlds;K-12
+Solacton;Tharin (Periphery);Outer Rim Territories;S-8
+Sionia;;Hutt Space;S-10
+Solaest;Belsmuth;Outer Rim Territories;O-6
+Sipo;Kwymar;Outer Rim Territories;Q-4
+Solanus;Lothal;Outer Rim Territories;U-7
+Sipsk;Kanz;Outer Rim Territories;N-4
+Solarine;Suolriep;Outer Rim Territories;S-8
+Sirdar;Oricho;Outer Rim Territories;M-6
+Solassus;;Core Worlds;M-11
+Siriamp;Halm;Mid Rim;J-16
+Solay;Lothal;Outer Rim Territories;U-7
+Sirpar;Arkanis;Outer Rim Territories;R-17
+Solem;Rayter;Outer Rim Territories;J-19
+Sisk;Calaron;Outer Rim Territories;U-9
+Solibus;Chitarghar;Expansion Region;K-15
+Siskeen;Hunnoverrs;Outer Rim Territories;R-17
+Solitair;Garwian Unity*;Unknown Regions;D-8
+Sittana;;Core Worlds;L-9
+Solloops;Kuat;Core Worlds;M-10
+Sivad;Iskin;Mid Rim;O-16
+Solu;Meridian;Outer Rim Territories;R-6
+Siveria;Kibilini;Outer Rim Territories;Q-17
+Solubria;Shadola;Outer Rim Territories;T-8
+Sivoria;Hapes Cluster;Inner Rim;O-9
+Somavva;Tharin (Divis Arm);Outer Rim Territories;S-8
+Sixela;Thuris;Outer Rim Territories;P-18
+Someilk;Seswenna;Outer Rim Territories;M-17
+Skako;;Core Worlds;L-9
+Somov Rit;Onatos;Mid Rim;R-15
+Skangravi;Msst;Mid Rim;P-7
+Son-tuul;Perinn;Outer Rim Territories;J-4
+Skann;Astal;Outer Rim Territories;Q-18
+Sondarr;Sertar;Outer Rim Territories;R-5
+Skaradosh;;Inner Rim;N-13
+Sonn Vilmari;Colundra;Outer Rim Territories;S-5
+Skaross;Morshdine;Outer Rim Territories;O-4
+Sontara;;Core Worlds;M-12
+Skarpos;Grumani;Outer Rim Territories;N-17
+Sontor;Tungra;Outer Rim Territories;K-19
+Skärtis;Senex;Mid Rim;L-17
+Soola;Khuiumin;Outer Rim Territories;O-18
+Skeebo;Shadola;Outer Rim Territories;U-8
+Sooma;Thanium;Outer Rim Territories;R-6
+Skeressa;Cadma;Outer Rim Territories;T-8
+Sooncanoo;;Inner Rim;K-8
+Skine;Skine;Outer Rim Territories;Q-19
+Sorca Retreat;;Inner Rim;O-8
+Skone;Brak;Expansion Region;O-14
+Sorderia;Suolriep;Outer Rim Territories;S-9
+Skor;Airam;Outer Rim Territories;M-20
+Sorella;Tapani;Colonies;L-13
+Skorrupon;Trans-Vulta;Mid Rim;N-7
+Sorfina;;Inner Rim;O-8
+Skree;Chitarghar;Expansion Region;K-15
+Sorgal;Mieru'kar;Outer Rim Territories;N-4
+Skuhl;Spadja;Outer Rim Territories;R-5
+Sorgan;Karthakk;Outer Rim Territories;Q-17
+Skustell Cluster;Tarabba;Outer Rim Territories;N-19
+Sorimow;Pacanth Reach;Outer Rim Territories;H-16
+Skuumaa;Mytaranor;Mid Rim;Q-9
+Sorjus;Meridian;Outer Rim Territories;R-7
+Skye;Varada;Outer Rim Territories;H-19
+Sorl;Dantus;Outer Rim Territories;J-6
+Skynara;Skine;Outer Rim Territories;P-19
+Sormahil;Corva;Outer Rim Territories;P-3
+Slandarvia M-9;Homon;Mid Rim;M-7
+Sorotarr;Yushan;Mid Rim;K-17
+Sleedara;;Core Worlds;L-12
+Sorrus;Kalamith;Outer Rim Territories;O-5
+Sleheyron;;Hutt Space;S-10
+Sortuvia;Xappyh;Outer Rim Territories;Q-3
+Soruus;Cronese Mandate;Outer Rim Territories;S-6
+Stend;Juris;Outer Rim Territories;P-17
+Soterios;Tapani;Colonies;L-13
+Stennaros;Har Worlds (Stennes);Expansion Region;K-16
+Soul's Lament;Greater Plooriod;Expansion Region;M-7
+Stenness;Airon;Inner Rim;O-10
+Soule;;Core Worlds;L-12
+Stenos;Spadja;Outer Rim Territories;R-5
+Soullex;;Wild Space;P-3
+Stensen's Colony;Stensen;Outer Rim Territories;I-16
+Soun;;Expansion Region;J-8
+Sterdic;Ryndellian;Mid Rim;P-17
+Space Station Scardia;Null Zone;Expansion Region;P-12
+Stewjon;;Deep Core;M-10
+Space Station Trenchant;Trax;Mid Rim;Q-10
+Stic;Xappyh;Outer Rim Territories;Q-3
+Spaceport THX1138;Fath;Outer Rim Territories;K-6
+Stieg;Calaron;Outer Rim Territories;T-9
+Spalex;Dantus;Outer Rim Territories;J-6
+Stivic;Garwian Unity*;Unknown Regions;D-8
+Spangled Veil Nebula;Meridian;Outer Rim Territories;R-7
+Stobar;Boeus;Expansion Region;M-15
+Spanthaer;;Inner Rim;N-9
+Stoga;Bitrose;Outer Rim Territories;T-17
+Sparingia;;Core Worlds;L-13
+Storinal;Noonian;Outer Rim Territories;N-6
+Sparth;Prefsbelt;Outer Rim Territories;K-6
+Storthus;Churba;Mid Rim;P-15
+Spawn Nebula;Corva;Outer Rim Territories;P-4
+Stovax;;Core Worlds;J-10
+Speco;Bon'nyuw-Luq;Outer Rim Territories;N-18
+Stradtofen Cluster;Varada;Outer Rim Territories;I-20
+Spee;Saijo;Outer Rim Territories;K-20
+Strata;;Inner Rim;L-8
+Spefik;Atrivis;Outer Rim Territories;L-5
+Stribos;;Core Worlds;M-10
+Spellhaus;Meerian;Outer Rim Territories;O-6
+Strokill Prime;Calamari;Outer Rim Territories;U-6
+Sperin;Bajic;Outer Rim Territories;P-17
+Stygeon;Nuiri;Outer Rim Territories;Q-6
+Spice Terminus;Parmic;Outer Rim Territories;P-18
+Stygian Caldera;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Spillwater;(Candoras);Outer Rim Territories;J-5
+Stygmarn;Tarabba;Outer Rim Territories;N-19
+Spinax;Allied Tion;Outer Rim Territories;S-6
+Stylar Nebula;Corva;Outer Rim Territories;P-4
+Spindrift;Rseik;Outer Rim Territories;N-20
+Styx;Baxel;Outer Rim Territories;U-11
+Spintir;Spadja;Outer Rim Territories;Q-6
+Suarbi;Quence;Outer Rim Territories;O-19
+Spira;Lytton;Core Worlds;L-10
+Suba;Atravis;Outer Rim Territories;L-19
+Spirador;Tandon;Mid Rim;Q-14
+Subterrel;Subterrel;Outer Rim Territories;L-20
+Spirana;;Inner Rim;N-13
+Sucharme;Grohl;Outer Rim Territories;R-15
+Sposia;Chiss Space*;Unknown Regions;F-8
+Sufezz;Jubilar;Outer Rim Territories;T-8
+Sprizen;Sprizen;Outer Rim Territories;N-5
+Suhuurmin;Quence;Outer Rim Territories;P-18
+Spuma;Seswenna;Outer Rim Territories;M-18
+Sukkult;;Inner Rim;L-14
+Spunchina;;Wild Space;H-17
+Suliana;Senex;Mid Rim;L-18
+Spur, The;Quence;Outer Rim Territories;O-18
+Sulloria;Svivreni;Outer Rim Territories;O-19
+Squamat;Mayagil;Outer Rim Territories;M-18
+Sullust;Brema;Outer Rim Territories;M-17
+Squan Station;(Arboo);Outer Rim Territories;S-16
+Sulorine;Suolriep;Outer Rim Territories;S-7
+Squarr;Atrivis;Outer Rim Territories;L-5
+Sumarin;Abrion;Outer Rim Territories;S-15
+Sran;Ash Worlds;Outer Rim Territories;T-6
+Sumitra;Sumitra;Expansion Region;N-7
+Sriluur;Tharin (Periphery);Outer Rim Territories;S-8
+Sump;Koradin;Outer Rim Territories;I-18
+Sronk;Oplovis;Outer Rim Territories;M-5
+Sunaj;Videnda;Outer Rim Territories;L-18
+Ssi-ruuvi Cluster;;Unknown Regions;C-16
+Sundered Veil, The;Phelleem;Outer Rim Territories;S-7
+Ssori;Klina;Outer Rim Territories;S-13
+Sunin;Tharin;Outer Rim Territories;S-8
+Staggec;Bajic;Outer Rim Territories;P-17
+Sunrise;;Unknown Regions;F-7
+Stalimur;Tion Hegemony;Outer Rim Territories;S-6
+Sunshi;Rseik;Outer Rim Territories;N-20
+Stalsinek;Hapes Cluster;Inner Rim;O-9
+Suntilla;;Colonies;N-12
+StarForge Nebula;Ado;Mid Rim;M-17
+Suolriep;Suolriep;Outer Rim Territories;S-8
+Starlag;Hevvrol;Mid Rim;O-15
+Surakkea;Terr'skiar;Mid Rim;P-10
+Starlyte Station;Ado;Mid Rim;M-17
+Suraz;Kalamith (Mirrin);Outer Rim Territories;P-5
+Starport Borgo;Oricho;Outer Rim Territories;M-6
+Surcaris;Trans-Vulta;Mid Rim;O-7
+StarStation 12;;Wild Space;O-20
+Surd Nebula;Atravis;Outer Rim Territories;L-19
+Starswarm Cluster;Koros;Deep Core;L-10
+Surdapan Station;Ojoster;Outer Rim Territories;N-7
+Stassia;;Deep Core;L-10
+Suria;Bajic;Outer Rim Territories;P-17
+Station 88;Vorc;Mid Rim;J-7
+Surpossia;Cyrillian Protectorate;Expansion Region;O-12
+Station Zeta;;Inner Rim;K-14
+Surron;Surron;Expansion Region;O-13
+Steelious;;Core Worlds;K-13
+Suurja;Ojoster;Outer Rim Territories;N-7
+Steergard;Woostri;Expansion Region;M-16
+Sva'leer;Corva;Outer Rim Territories;P-3
+Stellan;Hunnoverrs;Outer Rim Territories;R-16
+Svaaha;;Core Worlds;K-9
+Svivren;Svivreni;Outer Rim Territories;O-19
+Talravin;;Core Worlds;M-10
+Svolten;Esstran (Sith Worlds);Outer Rim Territories;R-4
+Talrezan;Tandon;Mid Rim;Q-14
+Swarquen;Videnda;Outer Rim Territories;M-18
+Taltos;Ado;Mid Rim;M-17
+Swedlan;Kathol;Outer Rim Territories;M-21
+Talu;Ojoster;Outer Rim Territories;N-7
+Swellen;Airam;Outer Rim Territories;L-20
+Talvaria;Phelleem;Outer Rim Territories;S-7
+Switchmount;Gendius;Mid Rim;J-17
+Tamazall;Boeus;Expansion Region;M-15
+Sy Myrth;Jospro;Outer Rim Territories;S-7
+Tamban;;Core Worlds;K-10
+Syboona;Danjar;Outer Rim Territories;N-18
+Tamber;Tapani;Colonies;L-13
+Symbia;Koros;Deep Core;K-10
+Tamboon;Tungra;Outer Rim Territories;K-19
+Syndaar;Thrasybule;Outer Rim Territories;P-6
+Tambor Station;Belasco;Expansion Region;P-11
+Syned;Grumani;Outer Rim Territories;N-17
+Tammar;Tharin;Outer Rim Territories;T-8
+Syngia;Sertar;Outer Rim Territories;R-5
+Tammuz-an;Tammuz;Outer Rim Territories;T-14
+Syni;;Wild Space;P-19
+Tamra;Tolonda;Outer Rim Territories;Q-17
+Synistahg;Lothal;Outer Rim Territories;U-7
+Tamsye Prime;Thanium;Outer Rim Territories;R-5
+Synjax;Maldrood;Mid Rim;R-7
+Tanaria;Esuain;Mid Rim;P-7
+Syruss;Pakuuni;Outer Rim Territories;T-5
+Tancon;Koradin;Outer Rim Territories;J-18
+Syvris;Al'Nasrl;Outer Rim Territories;T-13
+Tanda;Tapani;Colonies;L-13
+T'olan;Tiala;Mid Rim;K-7
+Tandankin;Spadja;Outer Rim Territories;R-6
+T'surr;Nuon e Safyd;Expansion Region;P-12
+Tandgor;Sertar;Outer Rim Territories;R-5
+Ta'klah;Jjannex;Outer Rim Territories;L-18
+Tandhor;Kwymar;Outer Rim Territories;P-4
+Taanab;;Inner Rim;O-8
+Tandis;;Inner Rim;N-8
+Tabiid;Perkell;Mid Rim;Q-7
+Tandun;Kalamith;Outer Rim Territories;P-5
+Taboon;Airon;Inner Rim;O-10
+Tangar;Fath;Outer Rim Territories;K-6
+Taborin;Mayagil;Outer Rim Territories;M-18
+Tangenine;Tangenine;Core Worlds;M-12
+Tah'Nuhna;Haserian;Mid Rim;Q-14
+Tanger;Tapani;Colonies;L-13
+Tahina;Chorlian;Outer Rim Territories;R-4
+Tangrada-Nii;;Core Worlds;K-13
+Tahini;;Inner Rim;L-14
+Tangrene;Morshdine;Outer Rim Territories;O-4
+Tahlboor;Thanium;Outer Rim Territories;R-5
+Tanis;Atravis;Outer Rim Territories;L-19
+Tais Brabbo;Shadola;Outer Rim Territories;U-8
+Tanjay;;Core Worlds;K-9
+Taka Shier;Tharin;Outer Rim Territories;S-8
+Tanquilla Beach;Kathol;Outer Rim Territories;M-21
+Takobo;Noonian;Outer Rim Territories;N-6
+Tansyl;Iskin;Mid Rim;O-16
+Takodana;Tashtor;Mid Rim;J-16
+Tanta Aurek;Grumani;Outer Rim Territories;M-17
+Tal Nami;;Hutt Space;R-9
+Tanta Besh;Grumani;Outer Rim Territories;M-17
+Tal Pi;D'Astan;Outer Rim Territories;P-5
+Tantajo;Halori;Mid Rim;P-7
+Tala;;Inner Rim;N-9
+Tantara;;Inner Rim;K-8
+Talasea;Morobe;Colonies;N-11
+Tanthior;Corellian;Core Worlds;M-11
+Talay;Dufilvian;Mid Rim;Q-16
+Tantiss Station;Dalonbian;Outer Rim Territories;M-3
+Talcene;Talcene;Mid Rim;Q-8
+Tantive;Kwymar;Outer Rim Territories;Q-4
+Talcharaim;Hapes Cluster;Inner Rim;O-9
+Tanto Winn;Alui;Mid Rim;O-17
+Talcim Cluster;Cegul;Outer Rim Territories;M-20
+Tantra;Tantra;Outer Rim Territories;M-19
+Taldorrah;Baroli;Expansion Region;N-14
+Tantsor;;Unknown Regions;I-5
+Taldot;Taldot;Mid Rim;Q-9
+Tanya;Tapani;Colonies;L-13
+Talesia;Sarka;Mid Rim;Q-8
+Tanzis;Tapani;Colonies;L-13
+Talfaglio;Corellian;Core Worlds;M-11
+Tao-Grant;Manda;Mid Rim;R-15
+Talhovi;Juvex;Mid Rim;L-18
+Tar Morden;Vensensor;Expansion Region;K-16
+Talir;Tharin (Karstaxon);Outer Rim Territories;S-8
+Tarabba Prime;Tarabba;Outer Rim Territories;M-19
+Talivar;Chorlian;Outer Rim Territories;S-4
+Taral;Calamari;Outer Rim Territories;U-7
+Tallaan;Tapani;Colonies;L-13
+Taraloon;Surron;Expansion Region;O-13
+Tallaso;D'Aelgoth;Mid Rim;K-17
+Taratos;;Inner Rim;J-14
+Tallek;Dalicron;Outer Rim Territories;K-19
+Tarawa;Steniplis;Outer Rim Territories;L-19
+Tallia;;Core Worlds;K-10
+Tarchalia;Luuq;Mid Rim;L-7
+Talofan;Bajic;Outer Rim Territories;P-18
+Targappia;;Colonies;N-12
+Talor;Varada;Outer Rim Territories;H-19
+Targarth;Corosi;Outer Rim Territories;M-6
+Taloraan;;Expansion Region;I-15
+Targonn;;Outer Rim Territories;U-7
+Taloron;;Wild Space;I-6
+Targusian;Rayter;Outer Rim Territories;J-19
+Talpiddi;Koradin;Outer Rim Territories;I-18
+Targyon;Nembus;Outer Rim Territories;P-5
+Tarhassan;Harron;Expansion Region;O-11
+Tel;Halthor;Outer Rim Territories;L-6
+Taria;Lifh;Mid Rim;R-8
+Tel Minor;Brak;Expansion Region;O-14
+Taris;Ojoster (Taris);Outer Rim Territories;N-7
+Telanka;Svivreni;Outer Rim Territories;O-19
+Tarivo;Lantillian;Mid Rim;P-9
+Telaris;Pakuuni;Outer Rim Territories;T-6
+Tarkenia;Karthakk;Outer Rim Territories;Q-17
+Telepan;;Core Worlds;M-11
+Tarlandia;;Core Worlds;L-9
+Telerath;Nouane;Inner Rim;N-7
+Tarlia;Dalicron;Outer Rim Territories;K-20
+Teljkon;Kossa;Expansion Region;O-11
+Tarmidia;Kailion;Expansion Region;O-13
+Telkadis;Greater Plooriod;Expansion Region;M-7
+Tarn;Doldur;Mid Rim;P-15
+Telkur Station;Hapes Cluster;Inner Rim;O-9
+Tarnith;Ojoster;Outer Rim Territories;N-7
+Tellanada;Bruanii;Mid Rim;K-18
+Tarnoonga;Arkanis;Outer Rim Territories;R-17
+Tellanroaeg;Gaulus;Outer Rim Territories;S-17
+Tarolax;Jidlor Marches;Mid Rim;I-15
+Tellik;;Inner Rim;N-7
+Taronda;Corbett;Mid Rim;I-17
+Tellivar;;Colonies;M-9
+Taroon;Rseik;Outer Rim Territories;N-20
+Tellon;Sombure;Mid Rim;K-17
+Tarsa;D'Aelgoth;Mid Rim;L-17
+Teloc Ol-sen;Eclorar;Mid Rim;Q-12
+Tarshan;Maerdocian;Mid Rim;Q-12
+Telos;Kwymar;Outer Rim Territories;Q-4
+Tarsunt;Bothan;Mid Rim;R-14
+Telti;;Inner Rim;N-10
+Tartaglia;Hollan;Mid Rim;M-7
+Temako;Antemeridian;Outer Rim Territories;R-7
+Tartaria;Alderaan;Core Worlds;M-10
+Temerancé;Merel;Outer Rim Territories;Q-19
+Tas-La;;Hutt Space;S-9
+Temesher;Lantillian;Mid Rim;P-9
+Tasariq;;Inner Rim;J-14
+Tempes;Atravis;Outer Rim Territories;L-20
+Tascollan Nebula;Abrion;Outer Rim Territories;S-15
+Tenara;Gordian Reach;Outer Rim Territories;Q-6
+Tashtor Seneca;Tashtor;Mid Rim;J-16
+Tendo;Quess;Mid Rim;N-17
+Taskeed;Tharin;Outer Rim Territories;S-7
+Tenoo;Bri'ahl;Outer Rim Territories;I-17
+Taspir;Dynali;Outer Rim Territories;J-3
+Tensor;;Core Worlds;M-10
+Tasrin;;Colonies;N-10
+Tentator;;Colonies;L-9
+Tassahondee Station;Parmel;Outer Rim Territories;O-18
+Tentraxis;;Inner Rim;N-9
+Tassar;D'Astan;Outer Rim Territories;P-5
+Tentrix;Baroli;Expansion Region;N-15
+Tassio Moon;Kuat;Core Worlds;M-10
+Tenupe;;Wild Space;I-8
+Tastiged;Oricho;Outer Rim Territories;M-6
+Tepasi;Tagge Space;Core Worlds;L-9
+Tatooine;Arkanis;Outer Rim Territories;R-16
+Teptixii;;Unknown Regions;I-4
+Tauber;Jaso;Inner Rim;L-14
+Ter Abbes;Locris;Expansion Region;O-8
+Tavitz;Tapani;Colonies;L-13
+Teralov;Ash Worlds;Outer Rim Territories;T-6
+Tavya;Tapani;Colonies;L-13
+Terephon;Hapes Cluster;Inner Rim;O-9
+Taw Provode;Nuiri;Outer Rim Territories;Q-6
+Teres Lutha Minor;Farrfin;Core Worlds;K-9
+Tawl;Tungra;Outer Rim Territories;K-18
+Tergamenion;Grumani;Outer Rim Territories;M-17
+Tay'ah'loo;Elbaran;Mid Rim;J-17
+Teriona;Spirva;Mid Rim;L-17
+Tazan;Merthian;Expansion Region;N-13
+Teriq Noi;Trailing Grant;Expansion Region;J-15
+Tcoleet;;Colonies;N-10
+Terman;Tharin (Periphery);Outer Rim Territories;S-8
+TD-10036-EM-1271;Montitian Grant;Expansion Region;J-15
+Terminus;Kallea;Outer Rim Territories;K-20
+Te Hasa;Veragi (Gree Enclave);Outer Rim Territories;K-2
+Ternin;Alchenaut;Expansion Region;L-16
+Teagan;Kwymar;Outer Rim Territories;Q-4
+Terr'skiar;Terr'skiar;Mid Rim;P-10
+Teardrop;Shelsha;Colonies;M-9
+Terra Sool;Immeria;Expansion Region;O-14
+Tebru;Juris;Outer Rim Territories;P-17
+TerraAsta;;Colonies;L-9
+Tedel;Ehosiq;Expansion Region;L-8
+Terrelia;;Inner Rim;L-14
+Tedonia;Khuiumin;Outer Rim Territories;O-18
+Terrijo;Venzeiia;Expansion Region;O-12
+Teedio;Auril;Outer Rim Territories;R-7
+Tertiary Feswe;Gordian Reach;Outer Rim Territories;P-6
+Teevan;Kalamith;Outer Rim Territories;P-5
+Tertiary Fujar;Tamarin;Outer Rim Territories;N-19
+Tefau;Suolriep;Outer Rim Territories;S-9
+Tertiary Kesmere;Raioballo;Outer Rim Territories;L-4
+Tegrat;Koradin;Outer Rim Territories;J-18
+Tertiary Usaita;;Inner Rim;M-13
+Teh'Jar;Minos Cluster;Outer Rim Territories;M-20
+Tervissis;Sertar;Outer Rim Territories;R-5
+Tehar;;Mid Rim;I-7
+Tessen;Phelleem;Outer Rim Territories;S-7
+Tei-Untis;;Core Worlds;K-10
+Teth;Baxel;Outer Rim Territories;U-12
+Teirasa;Iskin;Mid Rim;O-16
+Tetso;;Core Worlds;M-10
+Teklos;;Inner Rim;L-14
+Tevel;Prefsbelt;Outer Rim Territories;J-5
+Tekurr'k;Senex;Mid Rim;L-18
+Tevraki;;Colonies;N-9
+Tevu;Arc d'Stot;Expansion Region;K-16
+ThonBoka Nebula;Centrality;Outer Rim Territories;U-8
+Teya;Lostar;Expansion Region;M-7
+Thonner;Zuma (Moddell);Outer Rim Territories;H-16
+Teyr;;Colonies;L-13
+Thoran;Bothan;Mid Rim;R-14
+Th'irus;;Wild Space;S-4
+Thorat;Galov;Outer Rim Territories;T-14
+Thabeska;Morshdine;Outer Rim Territories;O-5
+Thorgeld;;Core Worlds;L-9
+Thabit;;Inner Rim;M-14
+Thornhedge Nebula;Terr'skiar;Mid Rim;P-10
+Thaere;Thaere;Expansion Region;O-14
+Thorsgild;Meerian;Outer Rim Territories;N-7
+Thairwsthis;M'shinni;Mid Rim;M-7
+Thorum;Vendusii;Mid Rim;P-16
+Thakwaa;Tunka;Outer Rim Territories;I-19
+Thory Prime;Thory;Mid Rim;K-7
+Thalassia;Meram;Outer Rim Territories;P-4
+Thosa;Wyl;Outer Rim Territories;R-4
+Thaldo;Graador;Mid Rim;J-17
+Thousand Moons;Circarpous;Expansion Region;O-12
+Thandon Nebula;Corporate Sector;Outer Rim Territories;S-3
+Thovinack;Kanz;Outer Rim Territories;N-4
+Thandruss;Thand;Expansion Region;J-15
+Thracior;;Core Worlds;K-12
+Thanium;Thanium;Outer Rim Territories;R-6
+Thrad;Phelleem;Outer Rim Territories;S-7
+Thannt;Ryndellian;Mid Rim;O-17
+Thrago;Chiss Space*;Unknown Regions;H-8
+Thanta Zilbra;Xappyh;Outer Rim Territories;Q-3
+Thraisai;;Wild Space;U-9
+Thape;Lambda;Mid Rim;Q-15
+Thrakia;Hapes Cluster;Inner Rim;O-9
+Tharados;Onatos;Mid Rim;R-15
+Thrantin;Ollonir Boundaries;Colonies;J-9
+Tharben;Kastolar;Mid Rim;R-10
+Threfal;Iska;Mid Rim;J-16
+Tharkos;Thanium;Outer Rim Territories;R-6
+Threndria;Yminis;Outer Rim Territories;S-15
+Tharl;Zuma (Sugai);Outer Rim Territories;H-16
+Thrinittik;;Colonies;L-8
+Tharnaka;Seitia;Outer Rim Territories;K-19
+Throffdon;;Inner Rim;J-9
+Thassalia;Albanin;Outer Rim Territories;U-12
+Throova;;Colonies;M-12
+Thaylia;Sprizen;Outer Rim Territories;N-5
+Thrugii;Kibilini;Outer Rim Territories;Q-17
+Theal;;Mid Rim;J-15
+Thrynka;Dohlbani;Mid Rim;R-14
+Thearterra;Chiss Space*;Unknown Regions;E-8
+Thule;Esstran;Outer Rim Territories;Q-5
+Thebeon;;Core Worlds;K-12
+Thulia;Kurost;Mid Rim;Q-12
+Thedavio;;Expansion Region;I-8
+Thull's Shroud;Senex;Mid Rim;L-17
+Thela;Aparo;Outer Rim Territories;R-4
+Thull's Vault;Juvex;Mid Rim;K-18
+Thelj;Airam;Outer Rim Territories;M-20
+Thumbsnapper's Bridge;Phelleem;Outer Rim Territories;S-7
+Thelpi;;Inner Rim;K-14
+Thuna;;Wild Space;I-6
+Themis;;Inner Rim;L-15
+Thune;Wazta;Outer Rim Territories;I-18
+Thennqor;Sarka;Mid Rim;Q-8
+Thurhanna Minor;Tynquay;Outer Rim Territories;R-4
+Therenor;Doldur;Mid Rim;P-15
+Thustra;Sumitra;Expansion Region;O-7
+Thermon;Juvex;Mid Rim;L-17
+Thyferra;Jaso;Inner Rim;L-14
+Theron;Vilonis;Mid Rim;O-16
+Thyron;;Colonies;M-9
+Theros Major;Hollan;Mid Rim;M-7
+Thyrsus;;Inner Rim;M-8
+Theselon;Hapes Cluster;Inner Rim;O-9
+Tibrin;Hadar;Mid Rim;L-18
+Thesme;Thesme;Outer Rim Territories;O-5
+Tibro;Baronos;Colonies;N-9
+Thession;Bortele;Mid Rim;S-8
+Tiems;Belderone;Outer Rim Territories;R-6
+Thiafeña;Mulgard;Mid Rim;N-16
+Tieos;Abrion;Outer Rim Territories;S-15
+Thila;Illisurevimurasi;Outer Rim Territories;Q-4
+Tierell;Thesme;Outer Rim Territories;O-6
+Thisspias;Farstey;Expansion Region;O-8
+Tierfon;Sumitra;Expansion Region;O-7
+Thixia;Alderaan;Core Worlds;M-10
+Tiferep Major;D'Aelgoth;Mid Rim;L-17
+Thoadeye;;Deep Core;M-11
+Tifnyl;Elrood;Outer Rim Territories;M-19
+Thobek;Farlax;Core Worlds;K-10
+Tiikae;Koradin;Outer Rim Territories;J-18
+Thodia;Perkell;Mid Rim;Q-7
+Tiisheraan;;Core Worlds;L-13
+Thokos;;Core Worlds;L-9
+Tikath;Noonian;Outer Rim Territories;M-6
+Thokosia;Maerdocian;Mid Rim;Q-13
+Till Chorios;Meridian;Outer Rim Territories;R-6
+Tholatin;Mytaranor;Mid Rim;P-10
+Tillo;Tapani;Colonies;L-13
+Tholaz;Farlax;Core Worlds;K-10
+Tilth;;Colonies;M-12
+Tholian;Meram;Outer Rim Territories;P-4
+Tilurus;Kessel;Outer Rim Territories;T-10
+Tholon;;Wild Space;H-17
+Timbra Ott;Kathol;Outer Rim Territories;M-21
+Tholoth;;Colonies;N-12
+Timja;Suolriep;Outer Rim Territories;S-8
+Thomork;;Core Worlds;L-12
+Timora;Bakura;Outer Rim Territories;G-16
+Thomquizzar;Meerian;Outer Rim Territories;O-6
+Tinallis;Juvex;Mid Rim;L-18
+Tinia;Zeemacht Cluster;Inner Rim;N-8
+Torrad;Talcene;Mid Rim;Q-8
+Tinnel;Quanta;Core Worlds;M-12
+Torrenoteer;Spadja;Outer Rim Territories;R-5
+Tinoon;Javin (Anoat);Outer Rim Territories;K-18
+Torria;;Core Worlds;M-12
+Tinta;Hapes Cluster;Inner Rim;O-9
+Tortali;Airam;Outer Rim Territories;L-19
+Tintel;Belasco;Expansion Region;P-11
+Torve;Brak;Expansion Region;O-14
+Tinuvia;Tragan Cluster;Outer Rim Territories;N-5
+Toshara;Cadma;Outer Rim Territories;T-8
+Tion;Tion Hegemony;Outer Rim Territories;S-5
+Toskhowwl;Ottega;Mid Rim;M-6
+Tirac Munda;Hevvrol;Mid Rim;P-15
+Tosste;Atravis;Outer Rim Territories;L-19
+Tiragga;Mieru'kar;Outer Rim Territories;N-3
+Tothis;Corporate Sector;Outer Rim Territories;S-3
+Tirahnn;Zeemacht Cluster;Inner Rim;N-8
+Touksingal;Corva;Outer Rim Territories;P-3
+Tirn;Esstran;Outer Rim Territories;Q-5
+Tourani;Yucrales;Mid Rim;R-15
+Tirsa;Corporate Sector;Outer Rim Territories;S-4
+Tovarskl;;Wild Space;J-4
+Tisht;;Hutt Space;T-11
+Tovash Tchii;Alui;Mid Rim;O-17
+Tiss'sharl;Xappyh;Outer Rim Territories;R-4
+Tovio;Aida;Mid Rim;Q-13
+Tizon;Farlax;Core Worlds;K-10
+Toydaria;;Hutt Space;R-11
+Tlactehon;Kailion;Expansion Region;O-13
+Tozeer;Hunnoverrs;Outer Rim Territories;R-16
+Tlönia;Demetras;Outer Rim Territories;P-7
+Tozil;Tashtor;Mid Rim;J-16
+To'hok Neige;Kriz;Outer Rim Territories;J-18
+Tragrud;Tharin (Periphery);Outer Rim Territories;S-8
+Tocan;Sumitra;Expansion Region;N-7
+Trailia;Lothal;Outer Rim Territories;U-7
+Tocco;Tapani;Colonies;L-13
+Tralfin;Xappyh;Outer Rim Territories;Q-3
+Tocoya;Ktilac Regions;Inner Rim;N-9
+Tralgaria;Parmic;Outer Rim Territories;P-18
+Todirium;Demetras;Outer Rim Territories;P-7
+Trallan;;Colonies;K-9
+Todola;Albarrio;Outer Rim Territories;K-5
+Tramanos;Grumani;Outer Rim Territories;N-17
+Todouhar;Seswenna;Outer Rim Territories;M-18
+Trammen;Harron;Expansion Region;O-11
+Togominda;Javin (Yarith);Outer Rim Territories;K-18
+Trammis;Centrality;Outer Rim Territories;U-8
+Togoria;Taldot;Mid Rim;P-9
+Tran Mariel;Farlax;Core Worlds;K-10
+Tokmia;Javin (Anoat);Outer Rim Territories;K-18
+Tranchar;Belderone;Outer Rim Territories;R-6
+Tokuut;Demetras;Outer Rim Territories;P-7
+Trancret;Perkell;Mid Rim;Q-7
+Tol Ado;Seitia;Outer Rim Territories;K-19
+Transel;;Colonies;L-13
+Tol Amn;;Hutt Space;R-11
+Tranthellix;Senex;Mid Rim;L-18
+Tolan;;Colonies;L-9
+Trantor;;Core Worlds;M-10
+Toledian;Narrant;Mid Rim;I-16
+Traptoforia;Thrasybule;Outer Rim Territories;P-6
+Tolfrania;;Inner Rim;N-9
+Trascor;Corva;Outer Rim Territories;P-3
+Tolig;Mayagil;Outer Rim Territories;N-18
+Trasemene;Phelleem;Outer Rim Territories;S-7
+Tollello;Dail;Outer Rim Territories;Q-18
+Trasse;Sarka;Mid Rim;Q-8
+Tomark;Ividal;Mid Rim;Q-14
+Trassitan;Veragi;Outer Rim Territories;L-3
+Tomo-Reth;;Inner Rim;L-14
+Traval-Pacor;Pacor;Mid Rim;K-7
+Ton-Falk;Pakuuni;Outer Rim Territories;T-5
+Travnin;Minos Cluster;Outer Rim Territories;M-20
+Tonnis;Tonnis;Inner Rim;I-9
+Travyx;Halm;Mid Rim;J-16
+Toola;Nilgaard;Outer Rim Territories;S-5
+Trebela;Altier;Expansion Region;O-13
+Tooma;Colundra;Outer Rim Territories;S-5
+Treffani;Treffani;Expansion Region;O-14
+Toong'l;Jubilar;Outer Rim Territories;T-7
+Tregillis;Tregillis;Expansion Region;M-15
+Toorja;Tapani;Colonies;L-13
+Trellen;;Core Worlds;M-10
+Toprawa;Kalamith;Outer Rim Territories;P-5
+Trenchenovu;Kriz;Outer Rim Territories;K-19
+Torch Nebula;Torch Nebula;Outer Rim Territories;P-19
+Trendivar;Hunnoverrs;Outer Rim Territories;R-16
+Toria-vic Nebula;;Wild Space;S-3
+Trenwyth;Stensen;Outer Rim Territories;I-16
+Torina;Elrood;Outer Rim Territories;M-19
+Tresidiss;Quence;Outer Rim Territories;P-18
+Torize;Kathol;Outer Rim Territories;M-21
+Trevi;Quess;Mid Rim;N-17
+Torku;;Inner Rim;M-13
+Trevura;;Inner Rim;K-14
+Tormin;Prackla;Expansion Region;O-8
+Treylon;;Colonies;L-13
+Torn Station;Mytaranor;Mid Rim;P-10
+Tri-Barr Station;;Inner Rim;N-11
+Torolis;Bothan;Mid Rim;Q-13
+Trian;Trianii Space*;Wild Space;R-3
+Torost;Bryx;Mid Rim;R-7
+Triellus;Jospro;Outer Rim Territories;R-7
+Torphlus;Roche;Mid Rim;Q-8
+Triewahl;Homon;Mid Rim;M-7
+Torpris;Uoti;Core Worlds;K-9
+Trif;Ciutric;Outer Rim Territories;N-4
+Torque;Gordian Reach;Outer Rim Territories;P-6
+Triffis;Hevvrol;Mid Rim;O-15
+Trigalis;Juris;Outer Rim Territories;P-17
+Twilight Void, The;;Unknown Regions;D-7
+Trigaskian Blur;;Wild Space;W-10
+Twin Nebulae;Javin;Outer Rim Territories;K-18
+Triitus;Corva;Outer Rim Territories;P-4
+Twin Sun Station;Garis;Outer Rim Territories;N-17
+Trillia;Imberlin;Expansion Region;P-13
+Twins, The;Obtrexta;Outer Rim Territories;K-4
+Trindello;Zuma (Moddell);Outer Rim Territories;H-16
+Twith;;Core Worlds;K-9
+Trinith;Mondress;Expansion Region;I-7
+Twon Ketee;Quence;Outer Rim Territories;P-18
+Trinovat;Gordian Reach;Outer Rim Territories;P-6
+Tyan;Tyan;Mid Rim;K-7
+Trinta;Halthor;Outer Rim Territories;L-6
+Tyaonon;;Wild Space;R-18
+Trionak;Javin (Yarith);Outer Rim Territories;J-18
+Tyberious;;Inner Rim;L-8
+Tristall;;Colonies;L-9
+Tydane;Bryx;Mid Rim;R-7
+Triton;Mayagil;Outer Rim Territories;M-18
+Tyed Kant;;Core Worlds;M-10
+Trivar;Nuiri;Outer Rim Territories;Q-6
+Tyegin;;Inner Rim;O-10
+Trogan;Jospro;Outer Rim Territories;R-7
+Tyluun;Juvex;Mid Rim;L-18
+Troglofa;Belderone;Outer Rim Territories;R-6
+Tyne Albamon;Rseik;Outer Rim Territories;N-20
+Troika;Colundra;Outer Rim Territories;S-5
+Tyne's Horky;Teraab;Mid Rim;Q-11
+Troiken;Colundra;Outer Rim Territories;S-5
+Tynna;Tynna;Expansion Region;N-14
+Troos;Gordian Reach;Outer Rim Territories;Q-5
+Typhonic Nebula;Trax;Mid Rim;Q-11
+Trosh;Cegul;Outer Rim Territories;L-20
+Tyrellia;Minos Cluster;Outer Rim Territories;M-20
+Troska;Dantus;Outer Rim Territories;J-6
+Tyria;Hevvrol;Mid Rim;P-15
+Troxar;Bes Ber Bikade;Expansion Region;L-15
+Tyrusia;;Inner Rim;N-8
+Trundalki;Xan;Mid Rim;Q-15
+Tyshapahl;Kalamith;Outer Rim Territories;P-5
+Trunska;;Colonies;J-13
+Tythe;Savareen;Outer Rim Territories;Q-16
+Trupellia;;Colonies;M-13
+Tython;;Deep Core;K-10
+Truuine;;Inner Rim;O-11
+Tyus Cluster;Tyus;Mid Rim;N-16
+Truuzdann;Corellian;Core Worlds;M-11
+Tyybann;;Inner Rim;J-13
+Truvi;Atravis;Outer Rim Territories;L-20
+Tzarib;Mestani;Inner Rim;J-9
+Truwel;Videnda;Outer Rim Territories;L-18
+U-Tendik;Trans-Nebular;Mid Rim;Q-16
+Trydara;Barsa;Mid Rim;J-6
+U'Dray;Hook Nebula;Outer Rim Territories;O-18
+Trymant;Subterrel;Outer Rim Territories;L-20
+Uaua;Centrality;Outer Rim Territories;U-8
+Tsaokallus;Talcene;Mid Rim;R-8
+Uba;Barsa;Mid Rim;J-6
+Tsevuka;Cademimu;Outer Rim Territories;M-6
+Ubardia;;Colonies;N-12
+Tsoss Beacon;;Deep Core;L-11
+Ubduria;;Inner Rim;N-8
+Tsukimitsurin;Churnis;Mid Rim;J-6
+Ubertica;Barsa;Mid Rim;J-6
+Tsukkia;Fakir;Colonies;K-9
+Ubrikkia;Kastolar;Mid Rim;Q-10
+Tsyk;;Hutt Space;T-13
+Ubuuga;Halori;Mid Rim;Q-7
+Tu'oon;Juris;Outer Rim Territories;P-17
+Ucret;;Core Worlds;K-10
+Tuerto;Brema;Outer Rim Territories;M-17
+Udine;;Inner Rim;M-15
+Tujiamoor;;Inner Rim;K-14
+Udnil;Airam;Outer Rim Territories;M-20
+Tulatharri Junction;Veragi;Outer Rim Territories;K-3
+Udrin Cara;Lannik Wilds;Mid Rim;R-13
+Tulpi;;Inner Rim;N-13
+Ueda;Xappyh;Outer Rim Territories;Q-3
+Tumani;Hapes Cluster;Inner Rim;O-9
+Uhltenden;Thrasybule;Outer Rim Territories;P-6
+Tumus;Tapani;Colonies;L-13
+Ukatis;;Inner Rim;L-15
+Tun Wala;Ktilac Regions;Inner Rim;N-9
+Ukio;Abrion;Outer Rim Territories;S-15
+Tund;Centrality;Outer Rim Territories;U-8
+Ulda Frav;Hangshan;Expansion Region;P-11
+Tungra;Tungra;Outer Rim Territories;K-18
+Ulicia;Corporate Sector;Outer Rim Territories;S-3
+Tunguray;Brema;Outer Rim Territories;M-17
+Ulion;Kuat;Core Worlds;M-10
+Turak;Parmel;Outer Rim Territories;O-18
+Ulkantha;Tharin;Outer Rim Territories;S-8
+Turcan;Parmel;Outer Rim Territories;O-18
+Ulmatra;;Hutt Space;S-10
+Turclom;Dustig;Mid Rim;N-16
+Ulness Prime;Merthian;Expansion Region;N-13
+Turco Prime;Sarka;Mid Rim;Q-8
+Ultaar;Bortele;Mid Rim;R-8
+Tureen;Kriz;Outer Rim Territories;K-19
+Umaren'k;;Unknown Regions;G-9
+Turkana;Pakuuni;Outer Rim Territories;T-6
+Umbara;Ghost Nebula;Expansion Region;P-10
+Turrak;Tamarin;Outer Rim Territories;N-19
+Umgul;Mulgard;Mid Rim;N-16
+Turrani;Bheriz;Outer Rim Territories;U-11
+Umme;Trilon;Outer Rim Territories;G-15
+Tusken's Eye;;Wild Space;I-8
+Umthyg;Juvex;Mid Rim;K-18
+Tuttin;;Inner Rim;M-14
+Unagin;Al'Nasrl;Outer Rim Territories;T-13
+Unavartan;Gaulus;Outer Rim Territories;S-17
+Uvadala;Ividal;Mid Rim;P-15
+Unguule Nebula;;Wild Space;I-20
+Uvena;Seswenna;Outer Rim Territories;M-18
+Unnipar;;Wild Space;H-19
+Uveron;;Colonies;M-9
+Unox;Astal;Outer Rim Territories;P-18
+Uviuy Exen;Shwuy;Colonies;L-9
+Unroola Dawn;Doldur;Mid Rim;P-15
+Uvoss;Cassander (Tadrin);Outer Rim Territories;K-5
+Unzel;Lantillian;Mid Rim;P-9
+Uyter;Lantillian;Mid Rim;P-9
+Uogo'cor;Trax;Mid Rim;Q-10
+V'shar;;Wild Space;U-15
+Uokara;;Unknown Regions;H-6
+Va'art;Roche;Mid Rim;Q-8
+Upekzar;Esstran (Sith Worlds);Outer Rim Territories;R-5
+Vaal;Gordian Reach;Outer Rim Territories;P-5
+Upell;Agarix;Mid Rim;K-18
+Vaathkree;Tharin (Periphery);Outer Rim Territories;S-8
+Uphrades;;Inner Rim;M-8
+Vaced;Jalor;Mid Rim;J-7
+Upper Brightday;Trestis;Expansion Region;K-8
+Vactooine;Arkanis;Outer Rim Territories;R-16
+Upper Etrega;;Colonies;M-10
+Vadnay;Spinward;Outer Rim Territories;M-2
+Uquine;;Colonies;N-10
+Vadooria;Halla;Mid Rim;S-9
+UR-1060;Zuma (Moddell);Outer Rim Territories;H-16
+Vadran;Rago;Mid Rim;I-7
+UR-2212-GR;;Unknown Regions;H-6
+Vaenrood;Pakuuni;Outer Rim Territories;T-6
+UR-2650;Zuma (Moddell);Outer Rim Territories;H-16
+Vagadarr;;Inner Rim;K-14
+UR-3741;Zuma (Moddell);Outer Rim Territories;H-16
+Vagar Praxut;;Unknown Regions;H-9
+UR-5292-FH;;Wild Space;H-7
+Vagneria;;Core Worlds;K-12
+UR-6572-AK;;Unknown Regions;G-8
+Vagran;Corellian;Core Worlds;M-11
+UR-8827;Zuma (Moddell);Outer Rim Territories;H-16
+Vahaba;Quelii;Outer Rim Territories;N-6
+UR-9353;Zuma (Moddell);Outer Rim Territories;H-16
+Vakkar;Fakir;Colonies;K-9
+UR41-284;;Unknown Regions;G-8
+Vaklin;;Inner Rim;M-14
+Urajab;Vulcusion;Expansion Region;L-16
+Valahari;D'Astan (Valahari);Outer Rim Territories;N-5
+Urber;Videnda;Outer Rim Territories;L-18
+Valashar;Churnis;Mid Rim;I-7
+Urce;Urce Space;Mid Rim;L-6
+Valboraan;Kastolar;Mid Rim;R-10
+Urch;Tower Dimension*;Unknown Regions;F-7
+Valc;Perinn;Outer Rim Territories;J-4
+Urdur;Corporate Sector;Outer Rim Territories;S-4
+Vale;Atravis;Outer Rim Territories;L-19
+Uridia;Yucrales;Mid Rim;R-14
+Valera;;Colonies;L-13
+Uriek;Ash Worlds;Outer Rim Territories;T-7
+Valfin;Meram;Outer Rim Territories;O-4
+Urkupp;Auril;Outer Rim Territories;R-6
+Valgauth;Nojic;Expansion Region;P-9
+Urn-Aram;Wazta;Outer Rim Territories;I-17
+Validusia;Bes Ber Bikade;Expansion Region;L-15
+Uro;Wazta;Outer Rim Territories;I-17
+Vallt;Juris;Outer Rim Territories;P-17
+Ursellin;Noolian;Mid Rim;Q-13
+Vallusk Cluster;Gordian Reach;Outer Rim Territories;Q-6
+Urthak;Gendius;Mid Rim;J-17
+Valnoos;Morshdine;Outer Rim Territories;O-5
+Uru;Atravis;Outer Rim Territories;L-19
+Valo;Rseik;Outer Rim Territories;N-19
+Urun;Belasco;Expansion Region;O-11
+Valorsi;Juvex;Mid Rim;L-17
+Usean;Tunka;Outer Rim Territories;I-18
+Valrar;Glythe;Mid Rim;J-7
+Useria;;Inner Rim;N-9
+Valron;Rocantor;Expansion Region;L-15
+Ushmin;Relgim;Outer Rim Territories;K-4
+Valsedian;;Hutt Space;S-11
+Ushruu;Altier;Expansion Region;O-13
+Valtava;Valtava;Inner Rim;I-8
+Usk;;Hutt Space;T-10
+Valtha Divide;;Wild Space;S-4
+Usnia;Senex;Mid Rim;L-18
+Valtos;;Wild Space;I-8
+Usta;Gordian Reach;Outer Rim Territories;Q-6
+Vanahame;Grumani;Outer Rim Territories;N-17
+Ut;Hapes Cluster;Inner Rim;O-9
+Vanan;Atravis;Outer Rim Territories;L-19
+Utapau;Tarabba;Outer Rim Territories;N-19
+Vanaria;Rseik;Outer Rim Territories;N-20
+Utaruun;Arkanis;Outer Rim Territories;R-16
+Vandelae;;Inner Rim;O-10
+Utegetu Nebula;;Wild Space;I-8
+Vandelhelm;Epsi Collective;Expansion Region;M-15
+Utharis;;Core Worlds;K-10
+Vandin;Tharin;Outer Rim Territories;S-8
+Uthor;Agarix;Mid Rim;K-18
+Vandor;Sloo;Mid Rim;P-14
+Uthtara;Eucer;Mid Rim;R-7
+Vandos;Nuiri;Outer Rim Territories;Q-7
+Uthura;;Inner Rim;M-13
+Vandron;D'Aelgoth;Mid Rim;L-17
+Utor;;Inner Rim;L-15
+Vandyne;Morshdine;Outer Rim Territories;O-5
+Utrica;Tamarin;Outer Rim Territories;N-19
+Vanguerre;Roche;Mid Rim;Q-8
+Utrost;Corusca (Coruscant);Core Worlds;L-9
+Vanik;;Inner Rim;L-14
+Uukaablis;Kathol;Outer Rim Territories;M-21
+Vanjervalis;;Colonies;N-11
+Vannan;Nijune;Outer Rim Territories;O-4
+Vendara;Kwymar;Outer Rim Territories;Q-4
+Vannix;;Core Worlds;M-10
+Vendaxa;Chaykin;Expansion Region;O-14
+Vanooria;;Core Worlds;M-10
+Vendrak;Videnda;Outer Rim Territories;M-18
+Vanqor;Sertar;Outer Rim Territories;R-5
+Vendusii;Vendusii;Mid Rim;P-16
+Vanquo;Meerian;Outer Rim Territories;O-6
+Venedlia;Instrop;Outer Rim Territories;S-16
+Vantillia;;Inner Rim;M-13
+Venerable Stirta;Ghost Nebula;Expansion Region;P-10
+Vanzeist;Suolriep;Outer Rim Territories;S-8
+Venestria;Clacis;Outer Rim Territories;K-4
+Var-Shaa;Dustig;Mid Rim;N-17
+Vengler;;Wild Space;H-18
+Varada;Varada;Outer Rim Territories;I-19
+Venir;Kuat;Core Worlds;M-10
+Varadan;Senex;Mid Rim;L-18
+Venjagga;;Colonies;K-9
+Vardos;;Core Worlds;L-9
+Vensor;Vensori;Mid Rim;P-8
+Vardoss;Vardoss;Expansion Region;J-8
+Ventil;Trax;Mid Rim;Q-10
+Vargos;Mortex;Outer Rim Territories;R-5
+Vento;;Core Worlds;L-9
+Variax;Aldino;Mid Rim;J-17
+Ventooine;Corva;Outer Rim Territories;P-3
+Varic;Chorlian;Outer Rim Territories;S-4
+Ventran;Var Hagen;Mid Rim;M-16
+Varkana;Quelii;Outer Rim Territories;O-6
+Ventrillia;;Core Worlds;L-12
+Varl;;Hutt Space;S-11
+Ventruun;Grumani;Outer Rim Territories;M-17
+Varlinaar;Koradin;Outer Rim Territories;J-18
+Ventrux;Thesme;Outer Rim Territories;O-6
+Varn;Quelii;Outer Rim Territories;O-6
+Venustria;;Colonies;N-12
+Varnak;Kurost;Mid Rim;Q-11
+Venzeiia;Venzeiia;Expansion Region;O-12
+Varonat;Javin (Anoat);Outer Rim Territories;K-18
+Veragi;Veragi;Outer Rim Territories;L-3
+Varristad;Abrion;Outer Rim Territories;S-15
+Verdanaia;;Core Worlds;M-11
+Vartos;Tharin;Outer Rim Territories;S-8
+Verdanth;Bon'nyuw-Luq;Outer Rim Territories;N-17
+Varvrona;Obtrexta;Outer Rim Territories;K-4
+Verde;Tharin (Periphery);Outer Rim Territories;S-8
+Varvva;Barsa;Mid Rim;J-6
+Verdi;Rayter;Outer Rim Territories;J-19
+Vasar;Corellian;Core Worlds;M-11
+Verdoria;;Core Worlds;M-11
+Vasch;Arkanis;Outer Rim Territories;R-17
+Vergill;Hapes Cluster;Inner Rim;O-9
+Vasha;Zuma (Moddell);Outer Rim Territories;H-16
+Verig;Raioballo;Outer Rim Territories;L-4
+Vashka;Kibilini;Outer Rim Territories;Q-17
+Verinti;Vorzyd;Outer Rim Territories;R-6
+Vassek;Wazta;Outer Rim Territories;I-17
+Verisin;Bajic;Outer Rim Territories;P-17
+Vastrip;;Inner Rim;N-7
+Verkuyl;Stensen;Outer Rim Territories;H-17
+Vasuuli;Kliap;Colonies;M-9
+Vernet;Baroli;Expansion Region;N-14
+Vatleria;Calaron;Outer Rim Territories;T-9
+Vernid;Kanz;Outer Rim Territories;M-4
+Vatta;;Wild Space;M-21
+Veroleem;;Unknown Regions;I-6
+Vavarna;Jjannex;Outer Rim Territories;L-18
+Veron;Senex;Mid Rim;L-17
+Vaykaaris;;Colonies;K-13
+Veron Minor;Mektrun;Mid Rim;L-17
+Vaynai;Chorlian;Outer Rim Territories;S-4
+Veronia;Oricho;Outer Rim Territories;M-6
+Veccacopia;Tunka;Outer Rim Territories;I-19
+Veros;Dimean;Expansion Region;P-13
+Vectinia;Hewett;Mid Rim;M-7
+Verossia;Strabin;Mid Rim;M-7
+Vedis;Mayagil;Outer Rim Territories;N-18
+Verroth;Belsmuth;Outer Rim Territories;O-6
+Veek;Weneen;Outer Rim Territories;N-6
+Vertseth;;Colonies;N-10
+Veelo;Vorzyd;Outer Rim Territories;R-6
+Verullia;Kira;Expansion Region;N-15
+Veil Nebula;D'Astan;Outer Rim Territories;N-5
+Vesari;;Inner Rim;O-10
+Veil, The;Farstey;Expansion Region;O-8
+Vesla;Corosi;Outer Rim Territories;N-6
+Velabri;;Outer Rim Territories;S-18
+Vesla Minor;;Wild Space;I-14
+Velanaria;Videnda;Outer Rim Territories;L-18
+Vespaara;Suolriep;Outer Rim Territories;S-8
+Velex;Locris;Expansion Region;O-8
+Vessitoar;Ottega;Mid Rim;M-6
+Velga;Juvex;Mid Rim;L-18
+Vestar;Rseik;Outer Rim Territories;N-20
+Vellas Pavo;Grumani;Outer Rim Territories;M-17
+Vestor Nebula;Trans-Nebular;Mid Rim;R-16
+Vellity;Trax;Mid Rim;Q-10
+Vestral;Mortex;Outer Rim Territories;R-5
+Velmor;Halori;Mid Rim;P-7
+Vetine;Merrick;Inner Rim;L-14
+Velossia;Manda;Mid Rim;R-15
+Vex;Zuma (Moddell);Outer Rim Territories;H-16
+Velusia;;Core Worlds;L-9
+Vexar;Corporate Sector;Outer Rim Territories;S-4
+Velx-Shel;Corellian;Core Worlds;M-11
+Vexos;;Wild Space;G-14
+Vena;Nojic;Expansion Region;P-9
+Vexta;Carrion;Outer Rim Territories;J-4
+Venaari;Venaarian;Mid Rim;O-8
+Viamarr;;Inner Rim;N-7
+Vianax;Lol;Outer Rim Territories;Q-18
+Voon;Krenher;Core Worlds;K-9
+Vicondor;Vorc;Mid Rim;J-7
+Voorlach;Duluur;Colonies;M-13
+Videll;;Colonies;M-13
+Voorsbain;Senex;Mid Rim;L-18
+Vidicx;Eclorar;Mid Rim;Q-12
+Vor Deo;Arkanis;Outer Rim Territories;R-17
+Viga;Lostar;Expansion Region;M-7
+Vorian;Immalia;Expansion Region;K-8
+Viidaav;Bryx;Mid Rim;R-7
+Vorkaa;Graador;Mid Rim;I-17
+Vilosoria;Lifh;Mid Rim;R-8
+Vorlag;Thuris;Outer Rim Territories;P-18
+Vincorba;Piryn Shar;Expansion Region;K-16
+Vornax;Thanium;Outer Rim Territories;S-5
+Vindalia;;Colonies;L-13
+Vorpa'ya;Mandalore;Outer Rim Territories;O-7
+Vinnax;;Wild Space;S-3
+Vorpal Nebula;Halthor;Outer Rim Territories;M-6
+Vinsoth;Quelii;Outer Rim Territories;N-5
+Vorrnti;;Inner Rim;L-8
+Vint;Sevetta;Outer Rim Territories;T-16
+Vorsia;;Inner Rim;N-9
+Vinth;Venzeiia;Expansion Region;O-13
+Vortex;Glythe;Mid Rim;K-7
+Vintrus;Manda;Mid Rim;R-15
+Vorusku;Juris;Outer Rim Territories;P-17
+Vinzen Neela;Parmic;Outer Rim Territories;P-18
+Vorzyd;Vorzyd;Outer Rim Territories;R-6
+Vir Aphshire;Tharin;Outer Rim Territories;S-8
+Vosch Cluster;Ado;Mid Rim;M-17
+Viraanntesse;Dona Laza;Expansion Region;P-9
+Voss;Allied Tion;Outer Rim Territories;S-6
+Virgillia;Koradin;Outer Rim Territories;I-18
+Vosteltig;Oplovis;Outer Rim Territories;M-5
+Viridia;Halthor;Outer Rim Territories;M-6
+Voxx Cluster;Ash Worlds;Outer Rim Territories;S-7
+Virkoi;;Inner Rim;N-9
+Vr'gedia;Mytaranor;Mid Rim;P-9
+Virmeude;Mayagil;Outer Rim Territories;M-18
+Vrakolia;;Core Worlds;K-13
+Virujansi;;Inner Rim;O-10
+Vretha;Hollan;Mid Rim;M-7
+Vishay;Vish;Mid Rim;N-16
+Vrogas Vas;Sujimis;Outer Rim Territories;O-19
+Vispil;Thrasybule;Outer Rim Territories;P-6
+Vrosynri;Nijune;Outer Rim Territories;N-5
+Visseon;;Inner Rim;N-10
+Vryssa;Dalicron;Outer Rim Territories;K-19
+Vivonah;Atravis;Outer Rim Territories;L-19
+Vuchelle;Atrivis;Outer Rim Territories;L-5
+Vixnix;Rago;Mid Rim;I-7
+Vulcar;Juvex;Mid Rim;L-18
+Vixoseph;Tantra;Outer Rim Territories;M-19
+Vulcusion;Vulcusion;Expansion Region;L-16
+Viyent;Har Worlds;Expansion Region;J-16
+Vulderania;;Core Worlds;L-10
+Vizcarra;Cegul;Outer Rim Territories;L-20
+Vulpinus Nebula;Vatha;Expansion Region;K-16
+Vjun;Nuiri;Outer Rim Territories;Q-6
+Vulpter;;Deep Core;L-10
+Vlemoth Port;Instrop;Outer Rim Territories;S-16
+Vulta;Trans-Vulta;Mid Rim;N-7
+Vnex;Gordian Reach;Outer Rim Territories;Q-6
+Vultar;;Core Worlds;L-10
+Vo Tunbren;Cegul (Tadra);Outer Rim Territories;M-20
+Vulvarch;;Colonies;L-13
+Vob;Ktilac Regions;Inner Rim;N-9
+Vuma;;Core Worlds;M-10
+Vobes;;Core Worlds;J-10
+Vun'Hanna;;Unknown Regions;D-7
+Vodran;;Hutt Space;S-9
+Vunakia;Phelleem;Outer Rim Territories;S-7
+Vogel;Var Hagen;Mid Rim;M-16
+Vundaria;;Inner Rim;N-9
+Vohai;Parmel;Outer Rim Territories;O-18
+Vur;Ojoster;Outer Rim Territories;N-7
+Void of Aogros;;Wild Space;H-18
+Vurdon Ka;Darlonn;Inner Rim;M-9
+Void of Chopani;Chopani;Outer Rim Territories;L-4
+Vuundalla;Bri'ahl;Outer Rim Territories;I-17
+Void Station;Bothan;Mid Rim;R-14
+Vuzsa;Arkanis;Outer Rim Territories;R-16
+Voidfire Nebula;Palamut;Expansion Region;N-13
+VV-99-7JE-2N71;Shiwal;Mid Rim;L-7
+Voktunma;;Core Worlds;M-11
+Vvaw;Calaron;Outer Rim Territories;U-9
+Volgax;;Core Worlds;K-10
+Vycinyth;Tapani;Colonies;L-13
+Volik;;Unknown Regions;H-7
+Vykos;Relgim;Outer Rim Territories;L-5
+Volta;Chaykin;Expansion Region;O-14
+Vyndal;Chorlian;Outer Rim Territories;S-4
+Voltare;;Inner Rim;K-8
+Vyron;Kurost;Mid Rim;Q-11
+Von-Alai;Locris;Expansion Region;O-8
+Wadi Raffa;Airam;Outer Rim Territories;M-20
+Vonak;Dalonbian;Outer Rim Territories;L-3
+Wakeelmui;;Colonies;L-9
+Vondarc;Var Hagen;Mid Rim;M-16
+Wakiza;Farlax;Core Worlds;K-10
+Vondoru;;Unknown Regions;G-6
+Walalla;;Inner Rim;J-13
+Voniss;;Mid Rim;I-7
+Walin'or;Shiwal;Mid Rim;M-7
+Vontor;;Hutt Space;S-9
+Wann Tsir;Sepan;Expansion Region;P-13
+Voolukaria;;Core Worlds;K-13
+Warchigade;Toblain;Outer Rim Territories;O-18
+Warlentta;Strabin;Mid Rim;M-7
+Wrea;Gaulus;Outer Rim Territories;S-17
+Warrin Station;Couronne;Expansion Region;P-10
+Wretch of Tayron;Videnda;Outer Rim Territories;L-18
+Wasco;Bri'ahl;Outer Rim Territories;I-17
+Wrodi;Meerian;Outer Rim Territories;O-6
+Waskiro;Jospro;Outer Rim Territories;R-7
+Wroona;;Inner Rim;L-15
+Wayland;Ojoster;Outer Rim Territories;N-7
+Wrosdi;Spinward;Outer Rim Territories;N-2
+Waymancy;;Inner Rim;K-8
+Wukkar;;Core Worlds;L-10
+Wazta;Wazta;Outer Rim Territories;J-18
+Wxtm;Gaulus;Outer Rim Territories;R-17
+Wecacoe;;Colonies;K-13
+Wyloff;Wyloff;Colonies;L-8
+Weerden;Corusca;Core Worlds;K-9
+Wyndigal;Ash Worlds;Outer Rim Territories;S-7
+Wehttam;Farlax;Core Worlds;K-10
+Wynkahthu;Alderath;Mid Rim;L-7
+Weik;;Wild Space;H-20
+Wynth;Wyloff;Colonies;L-8
+Weldii;;Core Worlds;L-13
+Wyveral;Homon;Mid Rim;M-7
+Wells;Perkell;Mid Rim;Q-7
+X3-299-11;;Wild Space;S-4
+Wellsia;Illodia;Core Worlds;K-13
+Xa Fel;Kanchen;Core Worlds;K-9
+Wellte-ir;Trax;Mid Rim;Q-10
+Xagobah;Mayagil;Outer Rim Territories;M-18
+Welsl;Brak;Expansion Region;O-14
+Xais;Yminis;Outer Rim Territories;S-14
+Wen'he'dinae;Eidoloni;Mid Rim;L-16
+Xal;Zuma (Ablajeck);Outer Rim Territories;H-16
+Wenderal;Aparo;Outer Rim Territories;R-3
+Xala;;Wild Space;H-14
+Werania;Biivren;Expansion Region;P-9
+Xanas;Xan;Mid Rim;Q-15
+Werma;Xappyh;Outer Rim Territories;Q-3
+Xandil;Lambda;Mid Rim;P-16
+Werncin;Kwymar;Outer Rim Territories;Q-4
+Xandonia;Askarian;Expansion Region;P-11
+Werta;Oriolan;Mid Rim;J-16
+Xandros;Locris;Expansion Region;O-8
+Wetyin's Colony;Gordian Reach;Outer Rim Territories;Q-5
+Xanlanner;Wyl;Outer Rim Territories;S-4
+Weytta;Auril;Outer Rim Territories;S-6
+Xantar;Corva;Outer Rim Territories;P-4
+Whassik;Perkell;Mid Rim;Q-7
+Xartun;Ojoster;Outer Rim Territories;O-7
+Wheel, The;Maldrood;Mid Rim;R-7
+Xaza;Xan;Mid Rim;Q-15
+Whelori;;Colonies;K-13
+Xend;;Inner Rim;M-8
+Whendyll;Cademimu;Outer Rim Territories;L-6
+Xendek;Calaron;Outer Rim Territories;T-9
+Whiforla;;Inner Rim;M-13
+Xenxiar;Trax;Mid Rim;P-10
+Whinndor;Grumani;Outer Rim Territories;N-17
+Xeron;;Inner Rim;M-14
+Whirl, The;;Inner Rim;K-8
+Xerthia;;Inner Rim;K-14
+Wick;Instrop;Outer Rim Territories;S-16
+Xerton;;Wild Space;J-3
+Widek;Farlax;Core Worlds;K-10
+Xerxes;;Core Worlds;M-11
+Wielu;;Inner Rim;N-13
+Xibariz;;Inner Rim;O-9
+Wilpiet;Cademimu;Outer Rim Territories;M-6
+Xifal;Allied Tion;Outer Rim Territories;S-6
+Winagrew;Graador;Mid Rim;J-17
+Xilxash;Yminis;Outer Rim Territories;S-15
+Winnikk;Sumitra;Expansion Region;O-7
+Xirl;;Wild Space;O-20
+Winsit;Cegul;Outer Rim Territories;L-20
+Xiunsrus;Quence;Outer Rim Territories;P-18
+Winter's Edge;Koradin;Outer Rim Territories;J-18
+Xivalia;Bes Ber Bikade;Expansion Region;L-15
+Wistril;Fath;Outer Rim Territories;K-6
+Xo;Spinward;Outer Rim Territories;N-2
+Witch Nebula;;Colonies;L-9
+Xobome;;Colonies;N-10
+Wizar;;Wild Space;I-8
+Xochtl;Gordian Reach;Outer Rim Territories;P-6
+Wobani;Bryx;Mid Rim;R-8
+Xoemefel;Marzoon;Mid Rim;I-16
+Wodan;Hapes Cluster;Inner Rim;O-9
+Xolu;;Hutt Space;S-13
+Wodenstam;Skine;Outer Rim Territories;Q-19
+Xoman;Halla;Mid Rim;S-9
+Wol Cabassh;Quelii;Outer Rim Territories;O-6
+Xorao;Mezeg;Mid Rim;M-7
+Woldona;Sevetta;Outer Rim Territories;T-16
+Xorrn;Ferra;Outer Rim Territories;S-16
+Womrik;Dufilvian;Mid Rim;Q-15
+Xorth;;Core Worlds;L-10
+Woostri;Woostri;Expansion Region;M-16
+XT987;;Inner Rim;J-8
+Woqua;;Core Worlds;K-10
+Xu'hu;Quiberon;Outer Rim Territories;S-15
+Wor Tandell;Dolomar;Core Worlds;K-9
+Xuaquarres;Ash Worlds;Outer Rim Territories;S-7
+Worru'du;Torranix;Core Worlds;K-10
+XV-344H;Esstran;Outer Rim Territories;Q-5
+Worxer;Elrood;Outer Rim Territories;M-20
+Xxan;Antemeridian;Outer Rim Territories;R-7
+Woteba;;Wild Space;I-8
+Xyquine;Corellian;Core Worlds;M-11
+Wranag;Bajic;Outer Rim Territories;P-17
+Y'Dar;Astal;Outer Rim Territories;P-17
+Y'nybeth;Tokamac;Expansion Region;O-13
+Ylesia;;Hutt Space;T-12
+Y'Trella;Sarin;Outer Rim Territories;P-18
+Ylix;M'shinni;Mid Rim;M-7
+Yablari;Vorzyd;Outer Rim Territories;R-6
+Yllotat;Bothan;Mid Rim;R-14
+Yabol Opa;;Colonies;M-9
+Yn;;Inner Rim;K-14
+Yabosta;Rocantor;Expansion Region;L-15
+Yntrann;;Wild Space;O-3
+Yabrenito;Semagi;Mid Rim;I-16
+Yoberra;Airam;Outer Rim Territories;M-20
+Yag'Dhul;;Inner Rim;L-14
+Yoggoy;;Unknown Regions;H-7
+Yaga Minor;Prefsbelt;Outer Rim Territories;K-5
+Yolthani;Nijune;Outer Rim Territories;N-5
+Yagara;Hadar;Mid Rim;L-17
+Yoon Cloud;;Wild Space;V-9
+Yaka;;Colonies;M-8
+Yordain Core;;Inner Rim;L-15
+Yakorki;Pacanth Reach;Outer Rim Territories;G-16
+Yorgraxx;Prefsbelt;Outer Rim Territories;K-5
+Yalara;;Wild Space;I-21
+Yoribuunt;Tharin;Outer Rim Territories;S-8
+Yalbec Prime;Rolion;Outer Rim Territories;P-7
+Yorn Skot;;Inner Rim;N-14
+Yaled;Jubilar;Outer Rim Territories;T-7
+Yoturba;;Mid Rim;I-7
+Yalln;Mortex;Outer Rim Territories;R-5
+Yout;Qiilura;Mid Rim;L-7
+Yama'chen;Nicandra;Mid Rim;L-7
+Yrrna;Tamarin;Outer Rim Territories;N-19
+Yamradi;Varada;Outer Rim Territories;I-19
+Ytha'ac Cluster;Airam;Outer Rim Territories;M-20
+Yan Korelda;Prefsbelt;Outer Rim Territories;J-5
+Yuga;Sanbra;Outer Rim Territories;O-17
+Yanibar;;Wild Space;R-19
+Yugami;Atravis;Outer Rim Territories;L-19
+Yanis;;Core Worlds;L-12
+Yulant;;Core Worlds;L-10
+Yankirk;Ado;Mid Rim;L-17
+Yungbrii;Far Xandil;Mid Rim;O-16
+Yantha;;Inner Rim;N-8
+Yunkor;Jjannex;Outer Rim Territories;K-19
+Yar Togna;Sarin;Outer Rim Territories;P-18
+Yurb;Suolriep;Outer Rim Territories;S-10
+Yarille;Fath;Outer Rim Territories;K-6
+Yutan;Ombakond;Expansion Region;P-12
+Yarith;Javin (Yarith);Outer Rim Territories;J-18
+Yutusk;Mortex;Outer Rim Territories;R-5
+Yarma;Tharin;Outer Rim Territories;T-8
+Yuvern;Oplovis;Outer Rim Territories;M-5
+Yarnil;Toblain;Outer Rim Territories;N-18
+Yuw;Herdessa;Mid Rim;Q-16
+Yaronn;;Wild Space;T-5
+Yvara;Kathol;Outer Rim Territories;M-21
+Yarrv;;Core Worlds;K-13
+Ywllandr;Prefsbelt;Outer Rim Territories;K-5
+Yartiga;Spirva;Mid Rim;K-17
+Z-LOQ;D'Aelgoth;Mid Rim;L-17
+Yashuvhu;;Unknown Regions;F-9
+Z'fell;Farlax;Core Worlds;K-10
+Yasilor;Bajic;Outer Rim Territories;P-17
+Z'trop;Tamarin;Outer Rim Territories;N-18
+Yathik;Boeus;Expansion Region;M-15
+Zaadja;Savareen;Outer Rim Territories;R-16
+Yavin;Gordian Reach;Outer Rim Territories;P-6
+Zabba;Bheriz;Outer Rim Territories;T-11
+Ychthyton;Belderone;Outer Rim Territories;R-6
+Zabian;Phelleem;Outer Rim Territories;S-7
+Yde;Nicandra;Mid Rim;M-7
+Zadaria;Hapes Cluster;Inner Rim;O-9
+Yeksom;Antemeridian;Outer Rim Territories;R-7
+Zaddja;Trilon;Outer Rim Territories;H-15
+Yelsain;Minos Cluster;Outer Rim Territories;M-20
+Zairona;Bon'nyuw-Luq;Outer Rim Territories;N-18
+Yerbana;Savareen;Outer Rim Territories;Q-17
+Zakuul;;Unknown Regions;D-13
+Yerej;Tungra;Outer Rim Territories;K-18
+Zallo;Tamarin;Outer Rim Territories;N-18
+Yerphonia;;Core Worlds;L-9
+Zalori;Hapes Cluster;Inner Rim;O-9
+Yeshocq;Mulgard;Mid Rim;N-16
+Zaloriis;Askarian;Expansion Region;P-12
+Yethra;Bon'nyuw-Luq;Outer Rim Territories;N-17
+Zalso;;Core Worlds;M-11
+Yetnis;;Inner Rim;K-8
+Zamael;;Deep Core;K-12
+Yetoom;Senex;Mid Rim;L-18
+Zanbar;Mandalore;Outer Rim Territories;O-7
+Yev;Yushan;Mid Rim;K-17
+Zandrax;Nilgaard;Outer Rim Territories;T-5
+Yhifar;Juvex;Mid Rim;L-17
+Zarak;Greater Plooriod;Expansion Region;M-7
+Yhuli;Jospro;Outer Rim Territories;R-7
+Zaraksander;Imberlin;Expansion Region;P-14
+Yinchorr;Fellwe;Expansion Region;L-8
+Zardossa Stix;;Colonies;J-13
+Yir Tangee;;Colonies;L-8
+Zaria;Juvex;Mid Rim;L-17
+Yirt-4138-Grek-12;Fakir;Colonies;K-9
+Zarkis;Suolriep;Outer Rim Territories;S-9
+Yisgga;;Inner Rim;M-13
+Zarracina;Zarracina;Expansion Region;O-14
+Yitabo;Kastolar;Mid Rim;Q-10
+Zarsteck;;Core Worlds;M-12
+Yityl;Quence;Outer Rim Territories;O-18
+Zastiga;Kallea;Outer Rim Territories;K-20
+Ylagia;Rocantor;Expansion Region;L-15
+Zav Alox;Trilon;Outer Rim Territories;H-15
+Zavian Abyss;Ghost Nebula;Expansion Region;P-10
+Zorbia;Zuma (Moddell);Outer Rim Territories;H-16
+Zaxxovia;Gomar;Inner Rim;K-14
+Zosha;;Unknown Regions;F-6
+Zayron;Corva;Outer Rim Territories;P-3
+Zrak;Nijune;Outer Rim Territories;N-5
+Zchtek;Bortele;Mid Rim;R-8
+Zuggit;;Inner Rim;M-13
+Zebitrope;Centrality;Outer Rim Territories;T-8
+Zuliria;Eucer;Mid Rim;R-7
+Zeenada;Immerian Outback;Expansion Region;O-14
+Zusi;Var Hagen;Mid Rim;M-16
+Zeffo;Kanz;Outer Rim Territories;M-3
+ZXK-100346;Atravis;Outer Rim Territories;L-19
+ZeHeth;Dustig;Mid Rim;N-16
+Zybahhod;Herios;Outer Rim Territories;T-15
+Zeitooine;;Inner Rim;N-13
+Zygerria;Chorlian;Outer Rim Territories;S-4
+Zekulae;Zeemacht Cluster;Inner Rim;N-8
+Zygia;Manda;Mid Rim;R-14
+Zelaba;Outer Jalor;Mid Rim;I-7
+Zyluria;Juvex;Mid Rim;L-17
+Zelos;Tyus;Mid Rim;N-16
+Zyzar;Astal;Outer Rim Territories;Q-17
+Zeltros;;Inner Rim;O-10
+Zyzek;;Unknown Regions;F-9
+Zemiah's Den;;Core Worlds;J-12
+Zznza;Yminis;Outer Rim Territories;S-14
+Zenezia;Thand;Expansion Region;J-15
+Zenn-La;Venzeiia;Expansion Region;O-12
+Zenox Cluster;;Colonies;K-13
+Zeolosia;Mulgard (Hallu);Mid Rim;N-16
+Zephry;Javin (Anoat);Outer Rim Territories;K-18
+Zequardia;Dalchon;Outer Rim Territories;R-17
+Zerm;Kessel;Outer Rim Territories;T-10
+Zero Drift;Lantillian;Mid Rim;P-8
+Zeta 0-9;;Wild Space;K-2
+Zhadalene;Kanz;Outer Rim Territories;N-4
+Zhann;;Colonies;M-13
+Zhanox;Javin (Anoat);Outer Rim Territories;K-18
+Zhina;Farlax;Core Worlds;K-10
+Zhotta;Mayagil;Outer Rim Territories;M-18
+Zi'Dek;Kallea;Outer Rim Territories;K-20
+Zigoola;;Wild Space;U-6
+Zimara;Calaron;Outer Rim Territories;U-9
+Zin Taal;Carrion;Outer Rim Territories;J-4
+Zinchori;;Inner Rim;O-9
+Ziost;Esstran (Sith Worlds);Outer Rim Territories;R-4
+Zipthar;Dalonbian;Outer Rim Territories;L-2
+Zircon;Calaron;Outer Rim Territories;T-9
+Zirulast;Belasco;Expansion Region;P-11
+Zisia;;Hutt Space;S-10
+Zissh;Brevost;Expansion Region;O-15
+Ziugen;;Hutt Space;T-12
+Zlarbv;;Inner Rim;O-10
+Zobbera;Karthakk;Outer Rim Territories;Q-17
+Zoh;Sarka;Mid Rim;Q-8
+Zohakka;Corthenia;Mid Rim;K-7
+Zolan;Lambda;Mid Rim;P-16
+Zoma;Hunnoverrs;Outer Rim Territories;S-17
+Zona Miki;Thrasybule;Outer Rim Territories;P-6
+Zondula;Oriolan;Mid Rim;J-16
+Zongorlu;Noonian;Outer Rim Territories;M-6
+Zonju;;Wild Space;J-21
+Zoph;Wazta;Outer Rim Territories;J-18
+Zoraster;Zoraster;Outer Rim Territories;U-13
+Zorb;Meram;Outer Rim Territories;O-4


### PR DESCRIPTION
- add CSV overlay synchronization pipeline
- support official semicolon-separated Disney CSV format
- support full planets/export CSV format
- add exact planet-name matching
- add Roman suffix/base-name fallback matching
- add curated-only planet insertion logic
- add overlay status tracking:
  - active
  - modified
  - inserted
  - deleted
  - skipped
- add --mark-deleted support
- add --dry-run overlay validation
- preserve ArcGIS baseline as canonical coordinate source
- keep coordinates stored internally as parsecs
- improve SQLite repository integration
- update CLI integration for csv overlay workflow
- rewrite README documentation for v0.3.1 architecture
- add end-to-end overlay test workflow