### PR TITLE
Fix CSV overlay deletion consistency issues

### DIFF
--- a/crates/sw_galaxy_map_sync/src/db/sqlite.rs
+++ b/crates/sw_galaxy_map_sync/src/db/sqlite.rs
@@ -334,13 +334,15 @@ impl<'conn> SqlitePlanetRepository<'conn> {
         Ok(())
     }
 
-    fn set_status(&self, fid: i64, status: &str) -> Result<()> {
+    pub fn set_status(&self, fid: i64, status: &str) -> Result<()> {
+        let deleted = i64::from(status.eq_ignore_ascii_case("deleted"));
+
         let sql = format!(
-            "UPDATE {} SET status = ?2, deleted = 0 WHERE FID = ?1",
+            "UPDATE {} SET status = ?2, deleted = ?3 WHERE FID = ?1",
             quote_ident(&self.table)
         );
 
-        self.conn.execute(&sql, params![fid, status])?;
+        self.conn.execute(&sql, params![fid, status, deleted])?;
 
         Ok(())
     }

--- a/crates/sw_galaxy_map_sync/src/db/sqlite.rs
+++ b/crates/sw_galaxy_map_sync/src/db/sqlite.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context, Result, bail};
-use rusqlite::{Connection, OptionalExtension, params};
+use anyhow::{bail, Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::models::{
     CsvOverlayOutcome, CsvOverlayRow, NormalizedPlanet, PlanetDbRow, UpsertOutcome,
@@ -448,13 +448,7 @@ fn exists_in_csv(db_row: &PlanetDbRow, csv_rows: &[CsvOverlayRow]) -> bool {
         let csv_name = cmp_key(&row.system);
         let csv_base = strip_roman_suffix(&csv_name);
 
-        db_name == csv_name
-            || db_base == csv_name
-            || db_name == csv_base
-            || db_base == csv_base
-            || (cmp_key(&db_row.sector) == cmp_key(&row.sector)
-                && cmp_key(&db_row.region) == cmp_key(&row.region)
-                && cmp_key(&db_row.grid) == cmp_key(&row.grid))
+        db_name == csv_name || db_base == csv_name || db_name == csv_base || db_base == csv_base
     })
 }
 

--- a/crates/sw_galaxy_map_sync/src/db/sqlite.rs
+++ b/crates/sw_galaxy_map_sync/src/db/sqlite.rs
@@ -1,5 +1,5 @@
-use anyhow::{bail, Context, Result};
-use rusqlite::{params, Connection, OptionalExtension};
+use anyhow::{Context, Result, bail};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::models::{
     CsvOverlayOutcome, CsvOverlayRow, NormalizedPlanet, PlanetDbRow, UpsertOutcome,


### PR DESCRIPTION
## Summary

This PR fixes two post-release issues in the `v0.3.1` CSV overlay pipeline.

### Fixed

- overlay deletion matching no longer uses shared sector/region/grid metadata
- deletion checks now require exact or Roman-normalized planet identity
- `deleted` flag is now synchronized with `status = "deleted"`
- logically deleted rows are correctly excluded from later overlay passes

### Issues closed

- close #61
- close #62

### Validation

Verified with:

- cargo build
- cargo fmt
- cargo clippy -D warnings
- cargo test
- ArcGIS import
- CSV overlay
- repeated overlay runs
- --mark-deleted workflow