### PR TITLE
Add sync execution metadata persistence and schema bootstrap logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "sw_galaxy_map_sync"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,6 +4390,7 @@ name = "sw_galaxy_map_sync"
 version = "0.3.2"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "csv",
  "indicatif",

--- a/crates/sw_galaxy_map_sync/Cargo.toml
+++ b/crates/sw_galaxy_map_sync/Cargo.toml
@@ -22,6 +22,7 @@ serde_json.workspace = true
 indicatif.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+chrono.workspace = true
 sw_galaxy_map_core = { path = "../sw_galaxy_map_core" }
 
 [lib]

--- a/crates/sw_galaxy_map_sync/Cargo.toml
+++ b/crates/sw_galaxy_map_sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map_sync"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]
 description = "ArcGIS-first synchronization and ingestion tool for the Star Wars galaxy map and Astronavis datasets"

--- a/crates/sw_galaxy_map_sync/src/db/sqlite.rs
+++ b/crates/sw_galaxy_map_sync/src/db/sqlite.rs
@@ -2,9 +2,9 @@ use crate::models::{
     CsvOverlayOutcome, CsvOverlayRow, NormalizedPlanet, PlanetDbRow, UpsertOutcome,
 };
 use crate::utils::{build_planet_norm, cmp_key, same_overlay_fields, strip_roman_suffix};
-use anyhow::{bail, Context, Result};
-use rusqlite::{params, Connection, OptionalExtension};
-use serde_json::{json, Value};
+use anyhow::{Context, Result, bail};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde_json::{Value, json};
 
 /// SQLite repository for planet synchronization/import operations.
 pub struct SqlitePlanetRepository<'conn> {

--- a/crates/sw_galaxy_map_sync/src/db/sqlite.rs
+++ b/crates/sw_galaxy_map_sync/src/db/sqlite.rs
@@ -1,10 +1,10 @@
-use anyhow::{Context, Result, bail};
-use rusqlite::{Connection, OptionalExtension, params};
-use serde_json::Value;
 use crate::models::{
     CsvOverlayOutcome, CsvOverlayRow, NormalizedPlanet, PlanetDbRow, UpsertOutcome,
 };
 use crate::utils::{build_planet_norm, cmp_key, same_overlay_fields, strip_roman_suffix};
+use anyhow::{bail, Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::{json, Value};
 
 /// SQLite repository for planet synchronization/import operations.
 pub struct SqlitePlanetRepository<'conn> {
@@ -379,6 +379,32 @@ pub fn ensure_required_schema(
                 create_table_like(conn, planets_table, unknown_table)?;
             }
 
+            let mut created_tables = vec![
+                "meta",
+                "planets",
+                "planets_unknown",
+                "waypoints",
+                "waypoint_planets",
+                "routes",
+                "route_detours",
+                "route_waypoints",
+                "planet_aliases",
+                "planets_search",
+            ];
+
+            if enable_fts {
+                created_tables.push("planets_fts");
+            }
+
+            let meta = json!({
+                "crate_version": env!("CARGO_PKG_VERSION"),
+                "operation": "schema_bootstrap",
+                "completed_at_utc": chrono::Utc::now().to_rfc3339(),
+                "fts_enabled": enable_fts,
+                "created_tables": created_tables,
+            });
+
+            upsert_meta_json(conn, "sync.schema.last_bootstrap", &meta)?;
             Ok(())
         }
 

--- a/crates/sw_galaxy_map_sync/src/db/sqlite.rs
+++ b/crates/sw_galaxy_map_sync/src/db/sqlite.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use rusqlite::{Connection, OptionalExtension, params};
-
+use serde_json::Value;
 use crate::models::{
     CsvOverlayOutcome, CsvOverlayRow, NormalizedPlanet, PlanetDbRow, UpsertOutcome,
 };
@@ -483,4 +483,23 @@ fn quote_ident(value: &str) -> String {
 
 fn round3(value: f64) -> f64 {
     (value * 1000.0).round() / 1000.0
+}
+
+/// Inserts or updates a JSON metadata value in the `meta` table.
+///
+/// The `meta.key` column is expected to be a primary key.
+pub fn upsert_meta_json(conn: &Connection, key: &str, value: &Value) -> Result<()> {
+    let json = serde_json::to_string_pretty(value)?;
+
+    conn.execute(
+        r#"
+        INSERT INTO meta (key, value)
+        VALUES (?1, ?2)
+        ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value
+        "#,
+        params![key, json],
+    )?;
+
+    Ok(())
 }

--- a/crates/sw_galaxy_map_sync/src/pipeline/arcgis_import.rs
+++ b/crates/sw_galaxy_map_sync/src/pipeline/arcgis_import.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use rusqlite::Connection;
 use std::fs;
 use std::path::PathBuf;
-
-use crate::db::sqlite::{SqlitePlanetRepository, ensure_required_schema};
+use serde_json::json;
+use crate::db::sqlite::{SqlitePlanetRepository, ensure_required_schema, upsert_meta_json};
 use crate::models::{ArcgisImportResult, UpsertOutcome};
 use crate::sources::arcgis::fetch_arcgis_dataset;
 
@@ -104,6 +104,26 @@ pub fn import_arcgis_to_sqlite(options: &ArcgisImportOptions) -> Result<ArcgisIm
         }
     }
     tx.commit()?;
+
+    if !options.dry_run {
+        let meta = json!({
+        "crate_version": env!("CARGO_PKG_VERSION"),
+        "operation": "arcgis_import",
+        "completed_at_utc": chrono::Utc::now().to_rfc3339(),
+        "fetched": result.fetched,
+        "known": result.known,
+        "unknown": result.unknown,
+        "known_inserted": result.inserted,
+        "known_updated": result.updated,
+        "known_skipped": result.skipped,
+        "unknown_inserted": result.unknown_inserted,
+        "unknown_updated": result.unknown_updated,
+        "unknown_skipped": result.unknown_skipped,
+        "dry_run": result.dry_run,
+    });
+
+        upsert_meta_json(&conn, "sync.arcgis.last_run", &meta)?;
+    }
 
     Ok(result)
 }

--- a/crates/sw_galaxy_map_sync/src/pipeline/arcgis_import.rs
+++ b/crates/sw_galaxy_map_sync/src/pipeline/arcgis_import.rs
@@ -1,11 +1,11 @@
-use anyhow::{Context, Result};
-use rusqlite::Connection;
-use std::fs;
-use std::path::PathBuf;
-use serde_json::json;
 use crate::db::sqlite::{SqlitePlanetRepository, ensure_required_schema, upsert_meta_json};
 use crate::models::{ArcgisImportResult, UpsertOutcome};
 use crate::sources::arcgis::fetch_arcgis_dataset;
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use serde_json::json;
+use std::fs;
+use std::path::PathBuf;
 
 /// Options for ArcGIS JSON export.
 #[derive(Debug, Clone)]
@@ -107,20 +107,20 @@ pub fn import_arcgis_to_sqlite(options: &ArcgisImportOptions) -> Result<ArcgisIm
 
     if !options.dry_run {
         let meta = json!({
-        "crate_version": env!("CARGO_PKG_VERSION"),
-        "operation": "arcgis_import",
-        "completed_at_utc": chrono::Utc::now().to_rfc3339(),
-        "fetched": result.fetched,
-        "known": result.known,
-        "unknown": result.unknown,
-        "known_inserted": result.inserted,
-        "known_updated": result.updated,
-        "known_skipped": result.skipped,
-        "unknown_inserted": result.unknown_inserted,
-        "unknown_updated": result.unknown_updated,
-        "unknown_skipped": result.unknown_skipped,
-        "dry_run": result.dry_run,
-    });
+            "crate_version": env!("CARGO_PKG_VERSION"),
+            "operation": "arcgis_import",
+            "completed_at_utc": chrono::Utc::now().to_rfc3339(),
+            "fetched": result.fetched,
+            "known": result.known,
+            "unknown": result.unknown,
+            "known_inserted": result.inserted,
+            "known_updated": result.updated,
+            "known_skipped": result.skipped,
+            "unknown_inserted": result.unknown_inserted,
+            "unknown_updated": result.unknown_updated,
+            "unknown_skipped": result.unknown_skipped,
+            "dry_run": result.dry_run,
+        });
 
         upsert_meta_json(&conn, "sync.arcgis.last_run", &meta)?;
     }

--- a/crates/sw_galaxy_map_sync/src/pipeline/csv_overlay.rs
+++ b/crates/sw_galaxy_map_sync/src/pipeline/csv_overlay.rs
@@ -1,10 +1,10 @@
-use anyhow::{Context, Result};
-use rusqlite::Connection;
-use std::path::PathBuf;
-
-use crate::db::sqlite::{SqlitePlanetRepository, ensure_required_schema};
+use crate::db::sqlite::{ensure_required_schema, upsert_meta_json, SqlitePlanetRepository};
 use crate::models::{CsvOverlayFormat, CsvOverlayOutcome, CsvOverlayStats};
 use crate::sources::csv::load_overlay_csv;
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use serde_json::json;
+use std::path::PathBuf;
 
 /// Options for the official CSV overlay pipeline.
 #[derive(Debug, Clone)]
@@ -80,6 +80,31 @@ pub fn apply_csv_overlay(options: &CsvOverlayOptions) -> Result<CsvOverlayStats>
         }
     }
     tx.commit()?;
+
+    if !options.dry_run {
+        let meta = json!({
+            "crate_version": env!("CARGO_PKG_VERSION"),
+            "operation": "csv_overlay",
+            "completed_at_utc": chrono::Utc::now().to_rfc3339(),
+            "csv_path": options.csv.display().to_string(),
+            "format": format!("{:?}", options.format),
+            "delimiter": options
+                .delimiter
+                .map(char::from)
+                .map(|c| c.to_string()),
+            "rows_read": stats.rows_read,
+            "inserted": stats.inserted,
+            "active": stats.active,
+            "modified_exact": stats.modified_exact,
+            "modified_suffix": stats.modified_suffix,
+            "deleted": stats.deleted,
+            "skipped": stats.skipped,
+            "mark_deleted": options.mark_deleted,
+            "dry_run": stats.dry_run,
+        });
+
+        upsert_meta_json(&conn, "sync.csv_overlay.last_run", &meta)?;
+    }
 
     Ok(stats)
 }

--- a/crates/sw_galaxy_map_sync/src/pipeline/csv_overlay.rs
+++ b/crates/sw_galaxy_map_sync/src/pipeline/csv_overlay.rs
@@ -1,4 +1,4 @@
-use crate::db::sqlite::{ensure_required_schema, upsert_meta_json, SqlitePlanetRepository};
+use crate::db::sqlite::{SqlitePlanetRepository, ensure_required_schema, upsert_meta_json};
 use crate::models::{CsvOverlayFormat, CsvOverlayOutcome, CsvOverlayStats};
 use crate::sources::csv::load_overlay_csv;
 use anyhow::{Context, Result};


### PR DESCRIPTION
## Summary

This PR introduces persistent synchronization metadata logging for `sw_galaxy_map_sync`.

The sync pipeline now records structured JSON execution summaries in the `meta` table for:

- ArcGIS imports
- CSV overlay runs
- schema bootstrap operations

---

## Added

### Sync execution metadata

The following keys are now persisted in `meta`:

| Key | Description |
|---|---|
| `sync.arcgis.last_run` | Last ArcGIS import execution summary |
| `sync.csv_overlay.last_run` | Last CSV overlay execution summary |
| `sync.schema.last_bootstrap` | Last schema bootstrap event |

---

## ArcGIS metadata

ArcGIS imports now persist:

- crate version
- UTC completion timestamp
- fetched/known/unknown statistics
- inserted/updated/skipped counters
- dry-run state

---

## CSV overlay metadata

CSV overlay runs now persist:

- crate version
- UTC completion timestamp
- CSV path
- format/delimiter
- inserted/modified/deleted/skipped statistics
- dry-run state
- mark_deleted flag

---

## Schema bootstrap metadata

When `create_schema()` is actually invoked, the sync layer now records:

- crate version
- UTC timestamp
- FTS availability
- list of created tables

including:

- meta
- planets
- planets_unknown
- routes
- waypoints
- planet_aliases
- planets_search
- planets_fts (when enabled)

---

## Notes

- metadata is NOT written during `--dry-run`
- schema bootstrap metadata is written only when schema creation actually occurs
- existing DBs are not rebuilt or modified unnecessarily

---

## Validation

Verified with:

- cargo build
- cargo fmt
- cargo clippy -D warnings
- cargo test
- ArcGIS import
- CSV overlay
- repeated overlay runs
- schema bootstrap scenarios