### PR TITLE
fix(sync): avoid schema bootstrap metadata writes during dry-run

### DIFF
--- a/crates/sw_galaxy_map_sync/src/db/sqlite.rs
+++ b/crates/sw_galaxy_map_sync/src/db/sqlite.rs
@@ -364,6 +364,7 @@ pub fn ensure_required_schema(
     conn: &Connection,
     planets_table: &str,
     unknown_table: &str,
+    persist_meta: bool,
 ) -> Result<()> {
     let has_planets = table_exists(conn, planets_table)?;
     let has_unknown = table_exists(conn, unknown_table)?;
@@ -379,32 +380,35 @@ pub fn ensure_required_schema(
                 create_table_like(conn, planets_table, unknown_table)?;
             }
 
-            let mut created_tables = vec![
-                "meta",
-                "planets",
-                "planets_unknown",
-                "waypoints",
-                "waypoint_planets",
-                "routes",
-                "route_detours",
-                "route_waypoints",
-                "planet_aliases",
-                "planets_search",
-            ];
+            if persist_meta {
+                let mut created_tables = vec![
+                    "meta",
+                    "planets",
+                    "planets_unknown",
+                    "waypoints",
+                    "waypoint_planets",
+                    "routes",
+                    "route_detours",
+                    "route_waypoints",
+                    "planet_aliases",
+                    "planets_search",
+                ];
 
-            if enable_fts {
-                created_tables.push("planets_fts");
+                if enable_fts {
+                    created_tables.push("planets_fts");
+                }
+
+                let meta = json!({
+                    "crate_version": env!("CARGO_PKG_VERSION"),
+                    "operation": "schema_bootstrap",
+                    "completed_at_utc": chrono::Utc::now().to_rfc3339(),
+                    "fts_enabled": enable_fts,
+                    "created_tables": created_tables,
+                });
+
+                upsert_meta_json(conn, "sync.schema.last_bootstrap", &meta)?;
             }
 
-            let meta = json!({
-                "crate_version": env!("CARGO_PKG_VERSION"),
-                "operation": "schema_bootstrap",
-                "completed_at_utc": chrono::Utc::now().to_rfc3339(),
-                "fts_enabled": enable_fts,
-                "created_tables": created_tables,
-            });
-
-            upsert_meta_json(conn, "sync.schema.last_bootstrap", &meta)?;
             Ok(())
         }
 

--- a/crates/sw_galaxy_map_sync/src/pipeline/arcgis_import.rs
+++ b/crates/sw_galaxy_map_sync/src/pipeline/arcgis_import.rs
@@ -77,7 +77,12 @@ pub fn import_arcgis_to_sqlite(options: &ArcgisImportOptions) -> Result<ArcgisIm
     let mut conn = Connection::open(&options.db)
         .with_context(|| format!("Unable to open DB: {}", options.db.display()))?;
 
-    ensure_required_schema(&conn, &options.table, &options.unknown_table)?;
+    ensure_required_schema(
+        &conn,
+        &options.table,
+        &options.unknown_table,
+        !options.dry_run,
+    )?;
 
     let tx = conn.transaction()?;
     {

--- a/crates/sw_galaxy_map_sync/src/pipeline/csv_overlay.rs
+++ b/crates/sw_galaxy_map_sync/src/pipeline/csv_overlay.rs
@@ -32,7 +32,12 @@ pub fn apply_csv_overlay(options: &CsvOverlayOptions) -> Result<CsvOverlayStats>
     if options.dry_run {
         let conn = Connection::open(&options.db)
             .with_context(|| format!("Unable to open DB: {}", options.db.display()))?;
-        ensure_required_schema(&conn, &options.table, &options.unknown_table)?;
+        ensure_required_schema(
+            &conn,
+            &options.table,
+            &options.unknown_table,
+            !options.dry_run,
+        )?;
         let repo = SqlitePlanetRepository::new(&conn, &options.table);
         repo.ensure_table_exists()?;
 
@@ -57,7 +62,12 @@ pub fn apply_csv_overlay(options: &CsvOverlayOptions) -> Result<CsvOverlayStats>
     let mut conn = Connection::open(&options.db)
         .with_context(|| format!("Unable to open DB: {}", options.db.display()))?;
 
-    ensure_required_schema(&conn, &options.table, &options.unknown_table)?;
+    ensure_required_schema(
+        &conn,
+        &options.table,
+        &options.unknown_table,
+        !options.dry_run,
+    )?;
 
     let tx = conn.transaction()?;
     {


### PR DESCRIPTION
- add metadata persistence guard to ensure_required_schema
- prevent dry-run operations from writing bootstrap metadata
- preserve dry-run non-persistent behavior guarantees

close #65