### PR TITLE
sw_galaxy_map_sync v0.4.2 - Standalone ArcGIS provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,7 +4660,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "sw_galaxy_map_core",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "sw_galaxy_map_sync"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/sw_galaxy_map_sync/Cargo.toml
+++ b/crates/sw_galaxy_map_sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sw_galaxy_map_sync"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Alessandro Maestri <umpire274@gmail.com>"]
 description = "ArcGIS-first synchronization and ingestion tool for the Star Wars galaxy map and Astronavis datasets"

--- a/crates/sw_galaxy_map_sync/Cargo.toml
+++ b/crates/sw_galaxy_map_sync/Cargo.toml
@@ -23,7 +23,6 @@ indicatif.workspace = true
 regex.workspace = true
 reqwest.workspace = true
 chrono.workspace = true
-sw_galaxy_map_core = { version = "0.15.2", path = "../sw_galaxy_map_core" }
 
 sqlx = { version = "0.8.6", default-features = false, features = [
     "postgres",

--- a/crates/sw_galaxy_map_sync/src/sources/arcgis.rs
+++ b/crates/sw_galaxy_map_sync/src/sources/arcgis.rs
@@ -6,15 +6,21 @@ use std::time::Duration;
 use crate::models::{ArcgisDataset, ArcgisRecord, NormalizedPlanet};
 use crate::utils::{build_planet_norm, hash_source, normalize_text};
 
-/// Fetch raw ArcGIS attributes through the core provider.
+const ARCGIS_LAYER_URL: &str = "https://services1.arcgis.com/1v2rNoG1em5vEBVC/arcgis/rest/services/Star_Wars_Galaxy_Map/FeatureServer/0";
+
+#[derive(Debug, Clone, Copy)]
+struct ArcgisLayerInfo {
+    max_record_count: i64,
+}
+
+/// Fetch raw ArcGIS attributes directly from the ArcGIS FeatureServer.
 pub fn fetch_raw_features(page_size: i64) -> Result<Vec<Value>> {
     let client = Client::builder()
         .timeout(Duration::from_secs(60))
         .build()
         .context("Unable to create HTTP client")?;
 
-    let layer_info = sw_galaxy_map_core::provision::arcgis::fetch_layer_info(&client)
-        .context("Unable to fetch ArcGIS layer info")?;
+    let layer_info = fetch_layer_info(&client).context("Unable to fetch ArcGIS layer info")?;
 
     let effective_page_size = if page_size <= 0 {
         layer_info.max_record_count
@@ -22,8 +28,93 @@ pub fn fetch_raw_features(page_size: i64) -> Result<Vec<Value>> {
         page_size
     };
 
-    sw_galaxy_map_core::provision::arcgis::fetch_all_features(&client, effective_page_size)
-        .context("Unable to fetch ArcGIS features")
+    fetch_all_features(&client, effective_page_size).context("Unable to fetch ArcGIS features")
+}
+
+fn fetch_layer_info(client: &Client) -> Result<ArcgisLayerInfo> {
+    let response = client
+        .get(ARCGIS_LAYER_URL)
+        .query(&[("f", "json")])
+        .send()
+        .context("Unable to send ArcGIS layer info request")?
+        .error_for_status()
+        .context("ArcGIS layer info request failed")?;
+
+    let json: Value = response
+        .json()
+        .context("Unable to decode ArcGIS layer info response")?;
+
+    let max_record_count = json
+        .get("maxRecordCount")
+        .and_then(Value::as_i64)
+        .unwrap_or(2000);
+
+    Ok(ArcgisLayerInfo { max_record_count })
+}
+
+fn fetch_all_features(client: &Client, page_size: i64) -> Result<Vec<Value>> {
+    let mut all = Vec::new();
+    let mut offset = 0_i64;
+
+    loop {
+        let page = fetch_feature_page(client, offset, page_size)?;
+
+        if page.is_empty() {
+            break;
+        }
+
+        let page_len = page.len();
+        all.extend(page);
+
+        if page_len < page_size as usize {
+            break;
+        }
+
+        offset += page_size;
+    }
+
+    Ok(all)
+}
+
+fn fetch_feature_page(client: &Client, offset: i64, page_size: i64) -> Result<Vec<Value>> {
+    let query_url = format!("{ARCGIS_LAYER_URL}/query");
+
+    let response = client
+        .get(query_url)
+        .query(&[
+            ("f", "json"),
+            ("where", "1=1"),
+            ("outFields", "*"),
+            ("returnGeometry", "false"),
+            ("resultOffset", &offset.to_string()),
+            ("resultRecordCount", &page_size.to_string()),
+            ("orderByFields", "FID ASC"),
+        ])
+        .send()
+        .with_context(|| format!("Unable to fetch ArcGIS page at offset {offset}"))?
+        .error_for_status()
+        .with_context(|| format!("ArcGIS page request failed at offset {offset}"))?;
+
+    let json: Value = response
+        .json()
+        .with_context(|| format!("Unable to decode ArcGIS page at offset {offset}"))?;
+
+    if let Some(error) = json.get("error") {
+        anyhow::bail!("ArcGIS returned an error at offset {offset}: {error}");
+    }
+
+    let features = json
+        .get("features")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let attributes = features
+        .into_iter()
+        .filter_map(|feature| feature.get("attributes").cloned())
+        .collect();
+
+    Ok(attributes)
 }
 
 /// Fetch and classify ArcGIS features.


### PR DESCRIPTION

## Overview

This PR introduces the `v0.4.2` maintenance/refactor release for `sw_galaxy_map_sync`.

The release completes another step toward making `sw_galaxy_map_sync` a standalone synchronization engine by moving ArcGIS FeatureServer access directly into the sync crate.

---

# Changed

## Standalone ArcGIS Provider

`sw_galaxy_map_sync` no longer depends on the ArcGIS provisioning APIs from:

```text
sw_galaxy_map_core::provision::arcgis
```

The sync crate now owns its ArcGIS source access layer, including:

* ArcGIS layer metadata fetching,
* ArcGIS FeatureServer query execution,
* paginated feature retrieval,
* raw attributes extraction,
* page-size handling,
* ArcGIS error handling.

---

# Preserved Behavior

The existing synchronization behavior is preserved:

* ArcGIS records are still fetched from the same FeatureServer source,
* raw attributes are still normalized by the sync crate,
* known and unknown records are still classified the same way,
* ArcGIS JSON export keeps the same logical structure,
* SQLite and PostgreSQL import pipelines continue to use the same normalized dataset.

---

# Why

This change continues the architectural decoupling started in `v0.4.0`.

`v0.4.0` moved database schema provisioning into `sw_galaxy_map_sync`.

`v0.4.2` now moves ArcGIS source fetching into `sw_galaxy_map_sync` as well.

This makes the sync crate more self-contained and better suited for:

* standalone ETL workflows,
* remote PostgreSQL synchronization,
* future API/data-service pipelines,
* independent release evolution.

---

# Validation

Validated with:

* cargo build,
* cargo fmt,
* cargo clippy -- -D warnings,
* cargo test,
* ArcGIS fetch,
* SQLite ArcGIS import,
* PostgreSQL ArcGIS import.
