### PR TITLE
sw_galaxy_map_sync - Validate coordinate units before bulk conversion

### DIFF
--- a/crates/sw_galaxy_map_sync/src/pipeline/convert_coordinates.rs
+++ b/crates/sw_galaxy_map_sync/src/pipeline/convert_coordinates.rs
@@ -49,6 +49,52 @@ pub fn round_2(value: f64) -> f64 {
     (value * 100.0).round() / 100.0
 }
 
+fn detect_single_grid_unit_sqlite(conn: &Connection) -> anyhow::Result<String> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT DISTINCT LOWER(TRIM(grid_unit))
+        FROM planets
+        WHERE grid_unit IS NOT NULL
+          AND TRIM(grid_unit) <> ''
+        "#,
+    )?;
+
+    let units = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    match units.as_slice() {
+        [] => anyhow::bail!("No valid grid_unit values found in planets."),
+        [unit] => Ok(unit.clone()),
+        _ => anyhow::bail!(
+            "Mixed grid_unit values found in planets: {:?}. Coordinate conversion aborted.",
+            units
+        ),
+    }
+}
+
+async fn detect_single_grid_unit_postgres(conn: &mut PgConnection) -> anyhow::Result<String> {
+    let units: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT DISTINCT LOWER(TRIM(grid_unit))
+        FROM planets
+        WHERE grid_unit IS NOT NULL
+          AND TRIM(grid_unit) <> ''
+        "#,
+    )
+    .fetch_all(conn)
+    .await?;
+
+    match units.as_slice() {
+        [] => anyhow::bail!("No valid grid_unit values found in planets."),
+        [unit] => Ok(unit.clone()),
+        _ => anyhow::bail!(
+            "Mixed grid_unit values found in planets: {:?}. Coordinate conversion aborted.",
+            units
+        ),
+    }
+}
+
 pub fn convert_coordinates_sqlite(
     options: &ConvertCoordinatesOptions,
 ) -> Result<ConvertCoordinatesStats> {
@@ -65,11 +111,7 @@ pub fn convert_coordinates_sqlite(
         CoordinateUnitArg::Ly => "ly",
     };
 
-    let current_unit: String = conn.query_row(
-        "SELECT grid_unit FROM planets WHERE grid_unit IS NOT NULL LIMIT 1",
-        [],
-        |row| row.get(0),
-    )?;
+    let current_unit = detect_single_grid_unit_sqlite(&conn)?;
 
     if current_unit.eq_ignore_ascii_case(target_unit) {
         bail!("Coordinates are already stored in '{target_unit}'. Nothing to convert.");
@@ -180,16 +222,7 @@ pub async fn convert_coordinates_postgres(
         CoordinateUnitArg::Ly => "ly",
     };
 
-    let current_unit: String = sqlx::query_scalar(
-        r#"
-        SELECT grid_unit
-        FROM planets
-        WHERE grid_unit IS NOT NULL
-        LIMIT 1
-        "#,
-    )
-    .fetch_one(&mut conn)
-    .await?;
+    let current_unit = detect_single_grid_unit_postgres(&mut conn).await?;
 
     if current_unit.eq_ignore_ascii_case(target_unit) {
         bail!("Coordinates are already stored in '{target_unit}'. Nothing to convert.");


### PR DESCRIPTION

## Overview

This PR fixes a coordinate normalization safety issue in the `convert coordinates` workflow.

Previously, both SQLite and PostgreSQL conversion pipelines determined the source coordinate unit using a single sampled row:

```sql
SELECT grid_unit FROM planets LIMIT 1
```

This approach could silently corrupt coordinates when the database contained mixed `grid_unit` values.

---

# Problem

Mixed coordinate-unit states are reachable during normal synchronization workflows.

Example:

1. database initially imported in `pc`,
2. coordinates converted to `ly`,
3. later ArcGIS import reintroduces new rows in `pc`,
4. table now contains both `pc` and `ly` rows.

The previous implementation could then:

* incorrectly skip conversion,
* double-convert part of the dataset,
* partially corrupt coordinates.

---

# Fixed

The conversion pipeline now validates the entire dataset before applying any bulk normalization.

Validation query:

```sql
SELECT DISTINCT LOWER(TRIM(grid_unit))
FROM planets
WHERE grid_unit IS NOT NULL
  AND TRIM(grid_unit) <> ''
```

Behavior:

* no valid units → abort,
* one distinct unit → conversion allowed,
* multiple distinct units → conversion aborted.

---

# Added Safety Guarantees

The coordinate conversion workflow now guarantees:

* no conversion on mixed datasets,
* no accidental double normalization,
* no partial coordinate corruption,
* consistent unit validation across SQLite and PostgreSQL backends.

---

# Changed

* replace single-row unit sampling with full-table validation,
* standardize coordinate unit validation logic across backends,
* improve normalization safety for future synchronization workflows.

---

# Validation

Validated with:

* cargo build,
* cargo fmt,
* cargo clippy -- -D warnings,
* cargo test,
* SQLite coordinate conversion,
* PostgreSQL coordinate conversion,
* mixed-unit validation scenarios,
* dry-run coordinate workflows.
